### PR TITLE
Create BLS_SeriesID.csv

### DIFF
--- a/lookup-tables/BLS_SeriesID.csv
+++ b/lookup-tables/BLS_SeriesID.csv
@@ -1,0 +1,8382 @@
+area_type_code,area_code,area_text,display_level,selectable,sort_sequence
+A,ST0100000000000,Alabama,0,T,1
+A,ST0200000000000,Alaska,0,T,149
+A,ST0400000000000,Arizona,0,T,193
+A,ST0500000000000,Arkansas,0,T,257
+A,ST0600000000000,California,0,T,383
+A,ST0800000000000,Colorado,0,T,772
+A,ST0900000000000,Connecticut,0,T,908
+A,ST1000000000000,Delaware,0,T,1100
+A,ST1100000000000,District of Columbia,0,T,1112
+A,ST1200000000000,Florida,0,T,1119
+A,ST1300000000000,Georgia,0,T,1331
+A,ST1500000000000,Hawaii,0,T,1585
+A,ST1600000000000,Idaho,0,T,1595
+A,ST1700000000000,Illinois,0,T,1676
+A,ST1800000000000,Indiana,0,T,1961
+A,ST1900000000000,Iowa,0,T,2142
+A,ST2000000000000,Kansas,0,T,2304
+A,ST2100000000000,Kentucky,0,T,2454
+A,ST2200000000000,Louisiana,0,T,2626
+A,ST2300000000000,Maine,0,T,2730
+A,ST2400000000000,Maryland,0,T,3302
+A,ST2500000000000,Massachusetts,0,T,3349
+A,ST2600000000000,Michigan,0,T,3747
+A,ST2700000000000,Minnesota,0,T,3972
+A,ST2800000000000,Mississippi,0,T,4144
+A,ST2900000000000,Missouri,0,T,4278
+A,ST3000000000000,Montana,0,T,4469
+A,ST3100000000000,Nebraska,0,T,4542
+A,ST3200000000000,Nevada,0,T,4660
+A,ST3300000000000,New Hampshire,0,T,4695
+A,ST3400000000000,New Jersey,0,T,4983
+A,ST3500000000000,New Mexico,0,T,5121
+A,ST3600000000000,New York,0,T,5186
+A,ST3700000000000,North Carolina,0,T,5393
+A,ST3800000000000,North Dakota,0,T,5615
+A,ST3900000000000,Ohio,0,T,5688
+A,ST4000000000000,Oklahoma,0,T,5924
+A,ST4100000000000,Oregon,0,T,6059
+A,ST4200000000000,Pennsylvania,0,T,6159
+A,ST4400000000000,Rhode Island,0,T,6350
+A,ST4500000000000,South Carolina,0,T,6398
+A,ST4600000000000,South Dakota,0,T,6498
+A,ST4700000000000,Tennessee,0,T,6584
+A,ST4800000000000,Texas,0,T,6756
+A,ST4900000000000,Utah,0,T,7310
+A,ST5000000000000,Vermont,0,T,7393
+A,ST5100000000000,Virginia,0,T,7680
+A,ST5300000000000,Washington,0,T,7879
+A,ST5400000000000,West Virginia,0,T,7998
+A,ST5500000000000,Wisconsin,0,T,8086
+A,ST5600000000000,Wyoming,0,T,8237
+A,ST7200000000000,Puerto Rico,0,T,8275
+B,MT0111500000000,"Anniston-Oxford-Jacksonville, AL Metropolitan Statistical Area",0,T,2
+B,MT0112220000000,"Auburn-Opelika, AL Metropolitan Statistical Area",0,T,3
+B,MT0113820000000,"Birmingham-Hoover, AL Metropolitan Statistical Area",0,T,4
+B,MT0119300000000,"Daphne-Fairhope-Foley, AL Metropolitan Statistical Area",0,T,5
+B,MT0119460000000,"Decatur, AL Metropolitan Statistical Area",0,T,6
+B,MT0120020000000,"Dothan, AL Metropolitan Statistical Area",0,T,7
+B,MT0122520000000,"Florence-Muscle Shoals, AL Metropolitan Statistical Area",0,T,8
+B,MT0123460000000,"Gadsden, AL Metropolitan Statistical Area",0,T,9
+B,MT0126620000000,"Huntsville, AL Metropolitan Statistical Area",0,T,10
+B,MT0133660000000,"Mobile, AL Metropolitan Statistical Area",0,T,11
+B,MT0133860000000,"Montgomery, AL Metropolitan Statistical Area",0,T,12
+B,MT0146220000000,"Tuscaloosa, AL Metropolitan Statistical Area",0,T,13
+B,MT0211260000000,"Anchorage, AK Metropolitan Statistical Area",0,T,150
+B,MT0221820000000,"Fairbanks, AK Metropolitan Statistical Area",0,T,151
+B,MT0422380000000,"Flagstaff, AZ Metropolitan Statistical Area",0,T,194
+B,MT0429420000000,"Lake Havasu City-Kingman, AZ Metropolitan Statistical Area",0,T,195
+B,MT0438060000000,"Phoenix-Mesa-Scottsdale, AZ Metropolitan Statistical Area",0,T,196
+B,MT0439140000000,"Prescott, AZ Metropolitan Statistical Area",0,T,197
+B,MT0443420000000,"Sierra Vista-Douglas, AZ Metropolitan Statistical Area",0,T,198
+B,MT0446060000000,"Tucson, AZ Metropolitan Statistical Area",0,T,199
+B,MT0449740000000,"Yuma, AZ Metropolitan Statistical Area",0,T,200
+B,MT0522220000000,"Fayetteville-Springdale-Rogers, AR-MO Metropolitan Statistical Area",0,T,258
+B,MT0522900000000,"Fort Smith, AR-OK Metropolitan Statistical Area",0,T,259
+B,MT0526300000000,"Hot Springs, AR Metropolitan Statistical Area",0,T,260
+B,MT0527860000000,"Jonesboro, AR Metropolitan Statistical Area",0,T,261
+B,MT0530780000000,"Little Rock-North Little Rock-Conway, AR Metropolitan Statistical Area",0,T,262
+B,MT0538220000000,"Pine Bluff, AR Metropolitan Statistical Area",0,T,263
+B,MT0612540000000,"Bakersfield, CA Metropolitan Statistical Area",0,T,384
+B,MT0617020000000,"Chico, CA Metropolitan Statistical Area",0,T,385
+B,MT0620940000000,"El Centro, CA Metropolitan Statistical Area",0,T,386
+B,MT0623420000000,"Fresno, CA Metropolitan Statistical Area",0,T,387
+B,MT0625260000000,"Hanford-Corcoran, CA Metropolitan Statistical Area",0,T,388
+B,MT0631080000000,"Los Angeles-Long Beach-Anaheim, CA Metropolitan Statistical Area",0,T,389
+B,MT0631460000000,"Madera, CA Metropolitan Statistical Area",0,T,390
+B,MT0632900000000,"Merced, CA Metropolitan Statistical Area",0,T,391
+B,MT0633700000000,"Modesto, CA Metropolitan Statistical Area",0,T,392
+B,MT0634900000000,"Napa, CA Metropolitan Statistical Area",0,T,393
+B,MT0637100000000,"Oxnard-Thousand Oaks-Ventura, CA Metropolitan Statistical Area",0,T,394
+B,MT0639820000000,"Redding, CA Metropolitan Statistical Area",0,T,395
+B,MT0640140000000,"Riverside-San Bernardino-Ontario, CA Metropolitan Statistical Area",0,T,396
+B,MT0640900000000,"Sacramento--Roseville--Arden-Arcade, CA Metropolitan Statistical Area",0,T,397
+B,MT0641500000000,"Salinas, CA Metropolitan Statistical Area",0,T,398
+B,MT0641740000000,"San Diego-Carlsbad, CA Metropolitan Statistical Area",0,T,399
+B,MT0641860000000,"San Francisco-Oakland-Hayward, CA Metropolitan Statistical Area",0,T,400
+B,MT0641940000000,"San Jose-Sunnyvale-Santa Clara, CA Metropolitan Statistical Area",0,T,401
+B,MT0642020000000,"San Luis Obispo-Paso Robles-Arroyo Grande, CA Metropolitan Statistical Area",0,T,402
+B,MT0642100000000,"Santa Cruz-Watsonville, CA Metropolitan Statistical Area",0,T,403
+B,MT0642200000000,"Santa Maria-Santa Barbara, CA Metropolitan Statistical Area",0,T,404
+B,MT0642220000000,"Santa Rosa, CA Metropolitan Statistical Area",0,T,405
+B,MT0644700000000,"Stockton-Lodi, CA Metropolitan Statistical Area",0,T,406
+B,MT0646700000000,"Vallejo-Fairfield, CA Metropolitan Statistical Area",0,T,407
+B,MT0647300000000,"Visalia-Porterville, CA Metropolitan Statistical Area",0,T,408
+B,MT0649700000000,"Yuba City, CA Metropolitan Statistical Area",0,T,409
+B,MT0814500000000,"Boulder, CO Metropolitan Statistical Area",0,T,773
+B,MT0817820000000,"Colorado Springs, CO Metropolitan Statistical Area",0,T,774
+B,MT0819740000000,"Denver-Aurora-Lakewood, CO Metropolitan Statistical Area",0,T,775
+B,MT0822660000000,"Fort Collins, CO Metropolitan Statistical Area",0,T,776
+B,MT0824300000000,"Grand Junction, CO Metropolitan Statistical Area",0,T,777
+B,MT0824540000000,"Greeley, CO Metropolitan Statistical Area",0,T,778
+B,MT0839380000000,"Pueblo, CO Metropolitan Statistical Area",0,T,779
+B,MT0971950000000,"Bridgeport-Stamford-Norwalk, CT Metropolitan NECTA",0,T,909
+B,MT0972850000000,"Danbury, CT Metropolitan NECTA",0,T,910
+B,MT0973450000000,"Hartford-West Hartford-East Hartford, CT Metropolitan NECTA",0,T,911
+B,MT0975700000000,"New Haven, CT Metropolitan NECTA",0,T,912
+B,MT0976450000000,"Norwich-New London-Westerly, CT-RI Metropolitan NECTA",0,T,913
+B,MT0978700000000,"Waterbury, CT Metropolitan NECTA",0,T,914
+B,MT1020100000000,"Dover, DE Metropolitan Statistical Area",0,T,1101
+B,MT1041540000000,"Salisbury, MD-DE Metropolitan Statistical Area",0,T,1102
+B,MT1147900000000,"Washington-Arlington-Alexandria, DC-VA-MD-WV Metropolitan Statistical Area",0,T,1113
+B,MT1215980000000,"Cape Coral-Fort Myers, FL Metropolitan Statistical Area",0,T,1120
+B,MT1218880000000,"Crestview-Fort Walton Beach-Destin, FL Metropolitan Statistical Area",0,T,1121
+B,MT1219660000000,"Deltona-Daytona Beach-Ormond Beach, FL Metropolitan Statistical Area",0,T,1122
+B,MT1223540000000,"Gainesville, FL Metropolitan Statistical Area",0,T,1123
+B,MT1226140000000,"Homosassa Springs, FL Metropolitan Statistical Area",0,T,1124
+B,MT1227260000000,"Jacksonville, FL Metropolitan Statistical Area",0,T,1125
+B,MT1229460000000,"Lakeland-Winter Haven, FL Metropolitan Statistical Area",0,T,1126
+B,MT1233100000000,"Miami-Fort Lauderdale-West Palm Beach, FL Metropolitan Statistical Area",0,T,1127
+B,MT1234940000000,"Naples-Immokalee-Marco Island, FL Metropolitan Statistical Area",0,T,1128
+B,MT1235840000000,"North Port-Sarasota-Bradenton, FL Metropolitan Statistical Area",0,T,1129
+B,MT1236100000000,"Ocala, FL Metropolitan Statistical Area",0,T,1130
+B,MT1236740000000,"Orlando-Kissimmee-Sanford, FL Metropolitan Statistical Area",0,T,1131
+B,MT1237340000000,"Palm Bay-Melbourne-Titusville, FL Metropolitan Statistical Area",0,T,1132
+B,MT1237460000000,"Panama City, FL Metropolitan Statistical Area",0,T,1133
+B,MT1237860000000,"Pensacola-Ferry Pass-Brent, FL Metropolitan Statistical Area",0,T,1134
+B,MT1238940000000,"Port St. Lucie, FL Metropolitan Statistical Area",0,T,1135
+B,MT1239460000000,"Punta Gorda, FL Metropolitan Statistical Area",0,T,1136
+B,MT1242680000000,"Sebastian-Vero Beach, FL Metropolitan Statistical Area",0,T,1137
+B,MT1242700000000,"Sebring, FL Metropolitan Statistical Area",0,T,1138
+B,MT1245220000000,"Tallahassee, FL Metropolitan Statistical Area",0,T,1139
+B,MT1245300000000,"Tampa-St. Petersburg-Clearwater, FL Metropolitan Statistical Area",0,T,1140
+B,MT1245540000000,"The Villages, FL Metropolitan Statistical Area",0,T,1141
+B,MT1310500000000,"Albany, GA Metropolitan Statistical Area",0,T,1332
+B,MT1312020000000,"Athens-Clarke County, GA Metropolitan Statistical Area",0,T,1333
+B,MT1312060000000,"Atlanta-Sandy Springs-Roswell, GA Metropolitan Statistical Area",0,T,1334
+B,MT1312260000000,"Augusta-Richmond County, GA-SC Metropolitan Statistical Area",0,T,1335
+B,MT1315260000000,"Brunswick, GA Metropolitan Statistical Area",0,T,1336
+B,MT1317980000000,"Columbus, GA-AL Metropolitan Statistical Area",0,T,1337
+B,MT1319140000000,"Dalton, GA Metropolitan Statistical Area",0,T,1338
+B,MT1323580000000,"Gainesville, GA Metropolitan Statistical Area",0,T,1339
+B,MT1325980000000,"Hinesville, GA Metropolitan Statistical Area",0,T,1340
+B,MT1331420000000,"Macon-Bibb County, GA Metropolitan Statistical Area",0,T,1341
+B,MT1340660000000,"Rome, GA Metropolitan Statistical Area",0,T,1342
+B,MT1342340000000,"Savannah, GA Metropolitan Statistical Area",0,T,1343
+B,MT1346660000000,"Valdosta, GA Metropolitan Statistical Area",0,T,1344
+B,MT1347580000000,"Warner Robins, GA Metropolitan Statistical Area",0,T,1345
+B,MT1527980000000,"Kahului-Wailuku-Lahaina, HI Metropolitan Statistical Area",0,T,1586
+B,MT1546520000000,"Urban Honolulu, HI Metropolitan Statistical Area",0,T,1587
+B,MT1614260000000,"Boise City, ID Metropolitan Statistical Area",0,T,1596
+B,MT1617660000000,"Coeur d'Alene, ID Metropolitan Statistical Area",0,T,1597
+B,MT1626820000000,"Idaho Falls, ID Metropolitan Statistical Area",0,T,1598
+B,MT1630300000000,"Lewiston, ID-WA Metropolitan Statistical Area",0,T,1599
+B,MT1638540000000,"Pocatello, ID Metropolitan Statistical Area",0,T,1600
+B,MT1646300000000,"Twin Falls, ID Metropolitan Statistical Area",0,T,1601
+B,MT1714010000000,"Bloomington, IL Metropolitan Statistical Area",0,T,1677
+B,MT1716060000000,"Carbondale-Marion, IL Metropolitan Statistical Area",0,T,1678
+B,MT1716580000000,"Champaign-Urbana, IL Metropolitan Statistical Area",0,T,1679
+B,MT1716980000000,"Chicago-Naperville-Elgin, IL-IN-WI Metropolitan Statistical Area",0,T,1680
+B,MT1719180000000,"Danville, IL Metropolitan Statistical Area",0,T,1681
+B,MT1719340000000,"Davenport-Moline-Rock Island, IA-IL Metropolitan Statistical Area",0,T,1682
+B,MT1719500000000,"Decatur, IL Metropolitan Statistical Area",0,T,1683
+B,MT1728100000000,"Kankakee, IL Metropolitan Statistical Area",0,T,1684
+B,MT1737900000000,"Peoria, IL Metropolitan Statistical Area",0,T,1685
+B,MT1740420000000,"Rockford, IL Metropolitan Statistical Area",0,T,1686
+B,MT1744100000000,"Springfield, IL Metropolitan Statistical Area",0,T,1687
+B,MT1814020000000,"Bloomington, IN Metropolitan Statistical Area",0,T,1962
+B,MT1818020000000,"Columbus, IN Metropolitan Statistical Area",0,T,1963
+B,MT1821140000000,"Elkhart-Goshen, IN Metropolitan Statistical Area",0,T,1964
+B,MT1821780000000,"Evansville, IN-KY Metropolitan Statistical Area",0,T,1965
+B,MT1823060000000,"Fort Wayne, IN Metropolitan Statistical Area",0,T,1966
+B,MT1826900000000,"Indianapolis-Carmel-Anderson, IN Metropolitan Statistical Area",0,T,1967
+B,MT1829020000000,"Kokomo, IN Metropolitan Statistical Area",0,T,1968
+B,MT1829200000000,"Lafayette-West Lafayette, IN Metropolitan Statistical Area",0,T,1969
+B,MT1833140000000,"Michigan City-La Porte, IN Metropolitan Statistical Area",0,T,1970
+B,MT1834620000000,"Muncie, IN Metropolitan Statistical Area",0,T,1971
+B,MT1843780000000,"South Bend-Mishawaka, IN-MI Metropolitan Statistical Area",0,T,1972
+B,MT1845460000000,"Terre Haute, IN Metropolitan Statistical Area",0,T,1973
+B,MT1911180000000,"Ames, IA Metropolitan Statistical Area",0,T,2143
+B,MT1916300000000,"Cedar Rapids, IA Metropolitan Statistical Area",0,T,2144
+B,MT1919780000000,"Des Moines-West Des Moines, IA Metropolitan Statistical Area",0,T,2145
+B,MT1920220000000,"Dubuque, IA Metropolitan Statistical Area",0,T,2146
+B,MT1926980000000,"Iowa City, IA Metropolitan Statistical Area",0,T,2147
+B,MT1943580000000,"Sioux City, IA-NE-SD Metropolitan Statistical Area",0,T,2148
+B,MT1947940000000,"Waterloo-Cedar Falls, IA Metropolitan Statistical Area",0,T,2149
+B,MT2029940000000,"Lawrence, KS Metropolitan Statistical Area",0,T,2305
+B,MT2031740000000,"Manhattan, KS Metropolitan Statistical Area",0,T,2306
+B,MT2045820000000,"Topeka, KS Metropolitan Statistical Area",0,T,2307
+B,MT2048620000000,"Wichita, KS Metropolitan Statistical Area",0,T,2308
+B,MT2114540000000,"Bowling Green, KY Metropolitan Statistical Area",0,T,2455
+B,MT2121060000000,"Elizabethtown-Fort Knox, KY Metropolitan Statistical Area",0,T,2456
+B,MT2130460000000,"Lexington-Fayette, KY Metropolitan Statistical Area",0,T,2457
+B,MT2131140000000,"Louisville/Jefferson County, KY-IN Metropolitan Statistical Area",0,T,2458
+B,MT2136980000000,"Owensboro, KY Metropolitan Statistical Area",0,T,2459
+B,MT2210780000000,"Alexandria, LA Metropolitan Statistical Area",0,T,2627
+B,MT2212940000000,"Baton Rouge, LA Metropolitan Statistical Area",0,T,2628
+B,MT2225220000000,"Hammond, LA Metropolitan Statistical Area",0,T,2629
+B,MT2226380000000,"Houma-Thibodaux, LA Metropolitan Statistical Area",0,T,2630
+B,MT2229180000000,"Lafayette, LA Metropolitan Statistical Area",0,T,2631
+B,MT2229340000000,"Lake Charles, LA Metropolitan Statistical Area",0,T,2632
+B,MT2233740000000,"Monroe, LA Metropolitan Statistical Area",0,T,2633
+B,MT2235380000000,"New Orleans-Metairie, LA Metropolitan Statistical Area",0,T,2634
+B,MT2243340000000,"Shreveport-Bossier City, LA Metropolitan Statistical Area",0,T,2635
+B,MT2370750000000,"Bangor, ME Metropolitan NECTA",0,T,2731
+B,MT2374650000000,"Lewiston-Auburn, ME Metropolitan NECTA",0,T,2732
+B,MT2376750000000,"Portland-South Portland, ME Metropolitan NECTA",0,T,2733
+B,MT2412580000000,"Baltimore-Columbia-Towson, MD Metropolitan Statistical Area",0,T,3303
+B,MT2415680000000,"California-Lexington Park, MD Metropolitan Statistical Area",0,T,3304
+B,MT2419060000000,"Cumberland, MD-WV Metropolitan Statistical Area",0,T,3305
+B,MT2425180000000,"Hagerstown-Martinsburg, MD-WV Metropolitan Statistical Area",0,T,3306
+B,MT2570900000000,"Barnstable Town, MA Metropolitan NECTA",0,T,3350
+B,MT2571650000000,"Boston-Cambridge-Nashua, MA-NH Metropolitan NECTA",0,T,3351
+B,MT2574500000000,"Leominster-Gardner, MA Metropolitan NECTA",0,T,3352
+B,MT2575550000000,"New Bedford, MA Metropolitan NECTA",0,T,3353
+B,MT2576600000000,"Pittsfield, MA Metropolitan NECTA",0,T,3354
+B,MT2578100000000,"Springfield, MA-CT Metropolitan NECTA",0,T,3355
+B,MT2579600000000,"Worcester, MA-CT Metropolitan NECTA",0,T,3356
+B,MT2611460000000,"Ann Arbor, MI Metropolitan Statistical Area",0,T,3748
+B,MT2612980000000,"Battle Creek, MI Metropolitan Statistical Area",0,T,3749
+B,MT2613020000000,"Bay City, MI Metropolitan Statistical Area",0,T,3750
+B,MT2619820000000,"Detroit-Warren-Dearborn, MI Metropolitan Statistical Area",0,T,3751
+B,MT2622420000000,"Flint, MI Metropolitan Statistical Area",0,T,3752
+B,MT2624340000000,"Grand Rapids-Wyoming, MI Metropolitan Statistical Area",0,T,3753
+B,MT2627100000000,"Jackson, MI Metropolitan Statistical Area",0,T,3754
+B,MT2628020000000,"Kalamazoo-Portage, MI Metropolitan Statistical Area",0,T,3755
+B,MT2629620000000,"Lansing-East Lansing, MI Metropolitan Statistical Area",0,T,3756
+B,MT2633220000000,"Midland, MI Metropolitan Statistical Area",0,T,3757
+B,MT2633780000000,"Monroe, MI Metropolitan Statistical Area",0,T,3758
+B,MT2634740000000,"Muskegon, MI Metropolitan Statistical Area",0,T,3759
+B,MT2635660000000,"Niles-Benton Harbor, MI Metropolitan Statistical Area",0,T,3760
+B,MT2640980000000,"Saginaw, MI Metropolitan Statistical Area",0,T,3761
+B,MT2720260000000,"Duluth, MN-WI Metropolitan Statistical Area",0,T,3973
+B,MT2731860000000,"Mankato-North Mankato, MN Metropolitan Statistical Area",0,T,3974
+B,MT2733460000000,"Minneapolis-St. Paul-Bloomington, MN-WI Metropolitan Statistical Area",0,T,3975
+B,MT2740340000000,"Rochester, MN Metropolitan Statistical Area",0,T,3976
+B,MT2741060000000,"St. Cloud, MN Metropolitan Statistical Area",0,T,3977
+B,MT2825060000000,"Gulfport-Biloxi-Pascagoula, MS Metropolitan Statistical Area",0,T,4145
+B,MT2825620000000,"Hattiesburg, MS Metropolitan Statistical Area",0,T,4146
+B,MT2827140000000,"Jackson, MS Metropolitan Statistical Area",0,T,4147
+B,MT2916020000000,"Cape Girardeau, MO-IL Metropolitan Statistical Area",0,T,4279
+B,MT2917860000000,"Columbia, MO Metropolitan Statistical Area",0,T,4280
+B,MT2927620000000,"Jefferson City, MO Metropolitan Statistical Area",0,T,4281
+B,MT2927900000000,"Joplin, MO Metropolitan Statistical Area",0,T,4282
+B,MT2928140000000,"Kansas City, MO-KS Metropolitan Statistical Area",0,T,4283
+B,MT2941140000000,"St. Joseph, MO-KS Metropolitan Statistical Area",0,T,4284
+B,MT2941180000000,"St. Louis, MO-IL Metropolitan Statistical Area",0,T,4285
+B,MT2944180000000,"Springfield, MO Metropolitan Statistical Area",0,T,4286
+B,MT3013740000000,"Billings, MT Metropolitan Statistical Area",0,T,4470
+B,MT3024500000000,"Great Falls, MT Metropolitan Statistical Area",0,T,4471
+B,MT3033540000000,"Missoula, MT Metropolitan Statistical Area",0,T,4472
+B,MT3124260000000,"Grand Island, NE Metropolitan Statistical Area",0,T,4543
+B,MT3130700000000,"Lincoln, NE Metropolitan Statistical Area",0,T,4544
+B,MT3136540000000,"Omaha-Council Bluffs, NE-IA Metropolitan Statistical Area",0,T,4545
+B,MT3216180000000,"Carson City, NV Metropolitan Statistical Area",0,T,4661
+B,MT3229820000000,"Las Vegas-Henderson-Paradise, NV Metropolitan Statistical Area",0,T,4662
+B,MT3239900000000,"Reno, NV Metropolitan Statistical Area",0,T,4663
+B,MT3373050000000,"Dover-Durham, NH-ME Metropolitan NECTA",0,T,4696
+B,MT3374950000000,"Manchester, NH Metropolitan NECTA",0,T,4697
+B,MT3376900000000,"Portsmouth, NH-ME Metropolitan NECTA",0,T,4698
+B,MT3412100000000,"Atlantic City-Hammonton, NJ Metropolitan Statistical Area",0,T,4984
+B,MT3436140000000,"Ocean City, NJ Metropolitan Statistical Area",0,T,4985
+B,MT3445940000000,"Trenton, NJ Metropolitan Statistical Area",0,T,4986
+B,MT3447220000000,"Vineland-Bridgeton, NJ Metropolitan Statistical Area",0,T,4987
+B,MT3510740000000,"Albuquerque, NM Metropolitan Statistical Area",0,T,5122
+B,MT3522140000000,"Farmington, NM Metropolitan Statistical Area",0,T,5123
+B,MT3529740000000,"Las Cruces, NM Metropolitan Statistical Area",0,T,5124
+B,MT3542140000000,"Santa Fe, NM Metropolitan Statistical Area",0,T,5125
+B,MT3610580000000,"Albany-Schenectady-Troy, NY Metropolitan Statistical Area",0,T,5187
+B,MT3613780000000,"Binghamton, NY Metropolitan Statistical Area",0,T,5188
+B,MT3615380000000,"Buffalo-Cheektowaga-Niagara Falls, NY Metropolitan Statistical Area",0,T,5189
+B,MT3621300000000,"Elmira, NY Metropolitan Statistical Area",0,T,5190
+B,MT3624020000000,"Glens Falls, NY Metropolitan Statistical Area",0,T,5191
+B,MT3627060000000,"Ithaca, NY Metropolitan Statistical Area",0,T,5192
+B,MT3628740000000,"Kingston, NY Metropolitan Statistical Area",0,T,5193
+B,MT3635620000000,"New York-Newark-Jersey City, NY-NJ-PA Metropolitan Statistical Area",0,T,5194
+B,MT3640380000000,"Rochester, NY Metropolitan Statistical Area",0,T,5195
+B,MT3645060000000,"Syracuse, NY Metropolitan Statistical Area",0,T,5196
+B,MT3646540000000,"Utica-Rome, NY Metropolitan Statistical Area",0,T,5197
+B,MT3648060000000,"Watertown-Fort Drum, NY Metropolitan Statistical Area",0,T,5198
+B,MT3711700000000,"Asheville, NC Metropolitan Statistical Area",0,T,5394
+B,MT3715500000000,"Burlington, NC Metropolitan Statistical Area",0,T,5395
+B,MT3716740000000,"Charlotte-Concord-Gastonia, NC-SC Metropolitan Statistical Area",0,T,5396
+B,MT3720500000000,"Durham-Chapel Hill, NC Metropolitan Statistical Area",0,T,5397
+B,MT3722180000000,"Fayetteville, NC Metropolitan Statistical Area",0,T,5398
+B,MT3724140000000,"Goldsboro, NC Metropolitan Statistical Area",0,T,5399
+B,MT3724660000000,"Greensboro-High Point, NC Metropolitan Statistical Area",0,T,5400
+B,MT3724780000000,"Greenville, NC Metropolitan Statistical Area",0,T,5401
+B,MT3725860000000,"Hickory-Lenoir-Morganton, NC Metropolitan Statistical Area",0,T,5402
+B,MT3727340000000,"Jacksonville, NC Metropolitan Statistical Area",0,T,5403
+B,MT3735100000000,"New Bern, NC Metropolitan Statistical Area",0,T,5404
+B,MT3739580000000,"Raleigh, NC Metropolitan Statistical Area",0,T,5405
+B,MT3740580000000,"Rocky Mount, NC Metropolitan Statistical Area",0,T,5406
+B,MT3748900000000,"Wilmington, NC Metropolitan Statistical Area",0,T,5407
+B,MT3749180000000,"Winston-Salem, NC Metropolitan Statistical Area",0,T,5408
+B,MT3813900000000,"Bismarck, ND Metropolitan Statistical Area",0,T,5616
+B,MT3822020000000,"Fargo, ND-MN Metropolitan Statistical Area",0,T,5617
+B,MT3824220000000,"Grand Forks, ND-MN Metropolitan Statistical Area",0,T,5618
+B,MT3910420000000,"Akron, OH Metropolitan Statistical Area",0,T,5689
+B,MT3915940000000,"Canton-Massillon, OH Metropolitan Statistical Area",0,T,5690
+B,MT3917140000000,"Cincinnati, OH-KY-IN Metropolitan Statistical Area",0,T,5691
+B,MT3917460000000,"Cleveland-Elyria, OH Metropolitan Statistical Area",0,T,5692
+B,MT3918140000000,"Columbus, OH Metropolitan Statistical Area",0,T,5693
+B,MT3919380000000,"Dayton, OH Metropolitan Statistical Area",0,T,5694
+B,MT3930620000000,"Lima, OH Metropolitan Statistical Area",0,T,5695
+B,MT3931900000000,"Mansfield, OH Metropolitan Statistical Area",0,T,5696
+B,MT3944220000000,"Springfield, OH Metropolitan Statistical Area",0,T,5697
+B,MT3945780000000,"Toledo, OH Metropolitan Statistical Area",0,T,5698
+B,MT3948260000000,"Weirton-Steubenville, WV-OH Metropolitan Statistical Area",0,T,5699
+B,MT3949660000000,"Youngstown-Warren-Boardman, OH-PA Metropolitan Statistical Area",0,T,5700
+B,MT4021420000000,"Enid, OK Metropolitan Statistical Area",0,T,5925
+B,MT4030020000000,"Lawton, OK Metropolitan Statistical Area",0,T,5926
+B,MT4036420000000,"Oklahoma City, OK Metropolitan Statistical Area",0,T,5927
+B,MT4046140000000,"Tulsa, OK Metropolitan Statistical Area",0,T,5928
+B,MT4110540000000,"Albany, OR Metropolitan Statistical Area",0,T,6060
+B,MT4113460000000,"Bend-Redmond, OR Metropolitan Statistical Area",0,T,6061
+B,MT4118700000000,"Corvallis, OR Metropolitan Statistical Area",0,T,6062
+B,MT4121660000000,"Eugene, OR Metropolitan Statistical Area",0,T,6063
+B,MT4124420000000,"Grants Pass, OR Metropolitan Statistical Area",0,T,6064
+B,MT4132780000000,"Medford, OR Metropolitan Statistical Area",0,T,6065
+B,MT4138900000000,"Portland-Vancouver-Hillsboro, OR-WA Metropolitan Statistical Area",0,T,6066
+B,MT4141420000000,"Salem, OR Metropolitan Statistical Area",0,T,6067
+B,MT4210900000000,"Allentown-Bethlehem-Easton, PA-NJ Metropolitan Statistical Area",0,T,6160
+B,MT4211020000000,"Altoona, PA Metropolitan Statistical Area",0,T,6161
+B,MT4214100000000,"Bloomsburg-Berwick, PA Metropolitan Statistical Area",0,T,6162
+B,MT4216540000000,"Chambersburg-Waynesboro, PA Metropolitan Statistical Area",0,T,6163
+B,MT4220700000000,"East Stroudsburg, PA Metropolitan Statistical Area",0,T,6164
+B,MT4221500000000,"Erie, PA Metropolitan Statistical Area",0,T,6165
+B,MT4223900000000,"Gettysburg, PA Metropolitan Statistical Area",0,T,6166
+B,MT4225420000000,"Harrisburg-Carlisle, PA Metropolitan Statistical Area",0,T,6167
+B,MT4227780000000,"Johnstown, PA Metropolitan Statistical Area",0,T,6168
+B,MT4229540000000,"Lancaster, PA Metropolitan Statistical Area",0,T,6169
+B,MT4230140000000,"Lebanon, PA Metropolitan Statistical Area",0,T,6170
+B,MT4237980000000,"Philadelphia-Camden-Wilmington, PA-NJ-DE-MD Metropolitan Statistical Area",0,T,6171
+B,MT4238300000000,"Pittsburgh, PA Metropolitan Statistical Area",0,T,6172
+B,MT4239740000000,"Reading, PA Metropolitan Statistical Area",0,T,6173
+B,MT4242540000000,"Scranton--Wilkes-Barre--Hazleton, PA Metropolitan Statistical Area",0,T,6174
+B,MT4244300000000,"State College, PA Metropolitan Statistical Area",0,T,6175
+B,MT4248700000000,"Williamsport, PA Metropolitan Statistical Area",0,T,6176
+B,MT4249620000000,"York-Hanover, PA Metropolitan Statistical Area",0,T,6177
+B,MT4477200000000,"Providence-Warwick, RI-MA Metropolitan NECTA",0,T,6351
+B,MT4516700000000,"Charleston-North Charleston, SC Metropolitan Statistical Area",0,T,6399
+B,MT4517900000000,"Columbia, SC Metropolitan Statistical Area",0,T,6400
+B,MT4522500000000,"Florence, SC Metropolitan Statistical Area",0,T,6401
+B,MT4524860000000,"Greenville-Anderson-Mauldin, SC Metropolitan Statistical Area",0,T,6402
+B,MT4525940000000,"Hilton Head Island-Bluffton-Beaufort, SC Metropolitan Statistical Area",0,T,6403
+B,MT4534820000000,"Myrtle Beach-Conway-North Myrtle Beach, SC-NC Metropolitan Statistical Area",0,T,6404
+B,MT4543900000000,"Spartanburg, SC Metropolitan Statistical Area",0,T,6405
+B,MT4544940000000,"Sumter, SC Metropolitan Statistical Area",0,T,6406
+B,MT4639660000000,"Rapid City, SD Metropolitan Statistical Area",0,T,6499
+B,MT4643620000000,"Sioux Falls, SD Metropolitan Statistical Area",0,T,6500
+B,MT4716860000000,"Chattanooga, TN-GA Metropolitan Statistical Area",0,T,6585
+B,MT4717300000000,"Clarksville, TN-KY Metropolitan Statistical Area",0,T,6586
+B,MT4717420000000,"Cleveland, TN Metropolitan Statistical Area",0,T,6587
+B,MT4727180000000,"Jackson, TN Metropolitan Statistical Area",0,T,6588
+B,MT4727740000000,"Johnson City, TN Metropolitan Statistical Area",0,T,6589
+B,MT4728700000000,"Kingsport-Bristol-Bristol, TN-VA Metropolitan Statistical Area",0,T,6590
+B,MT4728940000000,"Knoxville, TN Metropolitan Statistical Area",0,T,6591
+B,MT4732820000000,"Memphis, TN-MS-AR Metropolitan Statistical Area",0,T,6592
+B,MT4734100000000,"Morristown, TN Metropolitan Statistical Area",0,T,6593
+B,MT4734980000000,"Nashville-Davidson--Murfreesboro--Franklin, TN Metropolitan Statistical Area",0,T,6594
+B,MT4810180000000,"Abilene, TX Metropolitan Statistical Area",0,T,6757
+B,MT4811100000000,"Amarillo, TX Metropolitan Statistical Area",0,T,6758
+B,MT4812420000000,"Austin-Round Rock, TX Metropolitan Statistical Area",0,T,6759
+B,MT4813140000000,"Beaumont-Port Arthur, TX Metropolitan Statistical Area",0,T,6760
+B,MT4815180000000,"Brownsville-Harlingen, TX Metropolitan Statistical Area",0,T,6761
+B,MT4817780000000,"College Station-Bryan, TX Metropolitan Statistical Area",0,T,6762
+B,MT4818580000000,"Corpus Christi, TX Metropolitan Statistical Area",0,T,6763
+B,MT4819100000000,"Dallas-Fort Worth-Arlington, TX Metropolitan Statistical Area",0,T,6764
+B,MT4821340000000,"El Paso, TX Metropolitan Statistical Area",0,T,6765
+B,MT4826420000000,"Houston-The Woodlands-Sugar Land, TX Metropolitan Statistical Area",0,T,6766
+B,MT4828660000000,"Killeen-Temple, TX Metropolitan Statistical Area",0,T,6767
+B,MT4829700000000,"Laredo, TX Metropolitan Statistical Area",0,T,6768
+B,MT4830980000000,"Longview, TX Metropolitan Statistical Area",0,T,6769
+B,MT4831180000000,"Lubbock, TX Metropolitan Statistical Area",0,T,6770
+B,MT4832580000000,"McAllen-Edinburg-Mission, TX Metropolitan Statistical Area",0,T,6771
+B,MT4833260000000,"Midland, TX Metropolitan Statistical Area",0,T,6772
+B,MT4836220000000,"Odessa, TX Metropolitan Statistical Area",0,T,6773
+B,MT4841660000000,"San Angelo, TX Metropolitan Statistical Area",0,T,6774
+B,MT4841700000000,"San Antonio-New Braunfels, TX Metropolitan Statistical Area",0,T,6775
+B,MT4843300000000,"Sherman-Denison, TX Metropolitan Statistical Area",0,T,6776
+B,MT4845500000000,"Texarkana, TX-AR Metropolitan Statistical Area",0,T,6777
+B,MT4846340000000,"Tyler, TX Metropolitan Statistical Area",0,T,6778
+B,MT4847020000000,"Victoria, TX Metropolitan Statistical Area",0,T,6779
+B,MT4847380000000,"Waco, TX Metropolitan Statistical Area",0,T,6780
+B,MT4848660000000,"Wichita Falls, TX Metropolitan Statistical Area",0,T,6781
+B,MT4930860000000,"Logan, UT-ID Metropolitan Statistical Area",0,T,7311
+B,MT4936260000000,"Ogden-Clearfield, UT Metropolitan Statistical Area",0,T,7312
+B,MT4939340000000,"Provo-Orem, UT Metropolitan Statistical Area",0,T,7313
+B,MT4941100000000,"St. George, UT Metropolitan Statistical Area",0,T,7314
+B,MT4941620000000,"Salt Lake City, UT Metropolitan Statistical Area",0,T,7315
+B,MT5072400000000,"Burlington-South Burlington, VT Metropolitan NECTA",0,T,7394
+B,MT5113980000000,"Blacksburg-Christiansburg-Radford, VA Metropolitan Statistical Area",0,T,7681
+B,MT5116820000000,"Charlottesville, VA Metropolitan Statistical Area",0,T,7682
+B,MT5125500000000,"Harrisonburg, VA Metropolitan Statistical Area",0,T,7683
+B,MT5131340000000,"Lynchburg, VA Metropolitan Statistical Area",0,T,7684
+B,MT5140060000000,"Richmond, VA Metropolitan Statistical Area",0,T,7685
+B,MT5140220000000,"Roanoke, VA Metropolitan Statistical Area",0,T,7686
+B,MT5144420000000,"Staunton-Waynesboro, VA Metropolitan Statistical Area",0,T,7687
+B,MT5147260000000,"Virginia Beach-Norfolk-Newport News, VA-NC Metropolitan Statistical Area",0,T,7688
+B,MT5149020000000,"Winchester, VA-WV Metropolitan Statistical Area",0,T,7689
+B,MT5313380000000,"Bellingham, WA Metropolitan Statistical Area",0,T,7880
+B,MT5314740000000,"Bremerton-Silverdale, WA Metropolitan Statistical Area",0,T,7881
+B,MT5328420000000,"Kennewick-Richland, WA Metropolitan Statistical Area",0,T,7882
+B,MT5331020000000,"Longview, WA Metropolitan Statistical Area",0,T,7883
+B,MT5334580000000,"Mount Vernon-Anacortes, WA Metropolitan Statistical Area",0,T,7884
+B,MT5336500000000,"Olympia-Tumwater, WA Metropolitan Statistical Area",0,T,7885
+B,MT5342660000000,"Seattle-Tacoma-Bellevue, WA Metropolitan Statistical Area",0,T,7886
+B,MT5344060000000,"Spokane-Spokane Valley, WA Metropolitan Statistical Area",0,T,7887
+B,MT5347460000000,"Walla Walla, WA Metropolitan Statistical Area",0,T,7888
+B,MT5348300000000,"Wenatchee, WA Metropolitan Statistical Area",0,T,7889
+B,MT5349420000000,"Yakima, WA Metropolitan Statistical Area",0,T,7890
+B,MT5413220000000,"Beckley, WV Metropolitan Statistical Area",0,T,7999
+B,MT5416620000000,"Charleston, WV Metropolitan Statistical Area",0,T,8000
+B,MT5426580000000,"Huntington-Ashland, WV-KY-OH Metropolitan Statistical Area",0,T,8001
+B,MT5434060000000,"Morgantown, WV Metropolitan Statistical Area",0,T,8002
+B,MT5437620000000,"Parkersburg-Vienna, WV Metropolitan Statistical Area",0,T,8003
+B,MT5448540000000,"Wheeling, WV-OH Metropolitan Statistical Area",0,T,8004
+B,MT5511540000000,"Appleton, WI Metropolitan Statistical Area",0,T,8087
+B,MT5520740000000,"Eau Claire, WI Metropolitan Statistical Area",0,T,8088
+B,MT5522540000000,"Fond du Lac, WI Metropolitan Statistical Area",0,T,8089
+B,MT5524580000000,"Green Bay, WI Metropolitan Statistical Area",0,T,8090
+B,MT5527500000000,"Janesville-Beloit, WI Metropolitan Statistical Area",0,T,8091
+B,MT5529100000000,"La Crosse-Onalaska, WI-MN Metropolitan Statistical Area",0,T,8092
+B,MT5531540000000,"Madison, WI Metropolitan Statistical Area",0,T,8093
+B,MT5533340000000,"Milwaukee-Waukesha-West Allis, WI Metropolitan Statistical Area",0,T,8094
+B,MT5536780000000,"Oshkosh-Neenah, WI Metropolitan Statistical Area",0,T,8095
+B,MT5539540000000,"Racine, WI Metropolitan Statistical Area",0,T,8096
+B,MT5543100000000,"Sheboygan, WI Metropolitan Statistical Area",0,T,8097
+B,MT5548140000000,"Wausau, WI Metropolitan Statistical Area",0,T,8098
+B,MT5616220000000,"Casper, WY Metropolitan Statistical Area",0,T,8238
+B,MT5616940000000,"Cheyenne, WY Metropolitan Statistical Area",0,T,8239
+B,MT7210380000000,"Aguadilla-Isabela, PR Metropolitan Statistical Area",0,T,8276
+B,MT7211640000000,"Arecibo, PR Metropolitan Statistical Area",0,T,8277
+B,MT7225020000000,"Guayama, PR Metropolitan Statistical Area",0,T,8278
+B,MT7232420000000,"Mayaguez, PR Metropolitan Statistical Area",0,T,8279
+B,MT7238660000000,"Ponce, PR Metropolitan Statistical Area",0,T,8280
+B,MT7241900000000,"San German, PR Metropolitan Statistical Area",0,T,8281
+B,MT7241980000000,"San Juan-Carolina-Caguas, PR Metropolitan Statistical Area",0,T,8282
+C,DV0611244000000,"Anaheim-Santa Ana-Irvine, CA Metropolitan Division",0,T,410
+C,DV0631084000000,"Los Angeles-Long Beach-Glendale, CA Metropolitan Division",0,T,411
+C,DV0636084000000,"Oakland-Hayward-Berkeley, CA Metropolitan Division",0,T,412
+C,DV0641884000000,"San Francisco-Redwood City-South San Francisco, CA Metropolitan Division",0,T,413
+C,DV0642034000000,"San Rafael, CA Metropolitan Division",0,T,414
+C,DV1048864000000,"Wilmington, DE-MD-NJ Metropolitan Division",0,T,1103
+C,DV1147894000000,"Washington-Arlington-Alexandria, DC-VA-MD-WV Metropolitan Division",0,T,1114
+C,DV1222744000000,"Fort Lauderdale-Pompano Beach-Deerfield Beach, FL Metropolitan Division",0,T,1142
+C,DV1233124000000,"Miami-Miami Beach-Kendall, FL Metropolitan Division",0,T,1143
+C,DV1248424000000,"West Palm Beach-Boca Raton-Delray Beach, FL Metropolitan Division",0,T,1144
+C,DV1716974000000,"Chicago-Naperville-Arlington Heights, IL Metropolitan Division",0,T,1688
+C,DV1720994000000,"Elgin, IL Metropolitan Division",0,T,1689
+C,DV1729404000000,"Lake County-Kenosha County, IL-WI Metropolitan Division",0,T,1690
+C,DV1823844000000,"Gary, IN Metropolitan Division",0,T,1974
+C,DV2443524000000,"Silver Spring-Frederick-Rockville, MD Metropolitan Division",0,T,3307
+C,DV2571654000000,"Boston-Cambridge-Newton, MA NECTA Division",0,T,3357
+C,DV2572104000000,"Brockton-Bridgewater-Easton, MA NECTA Division",0,T,3358
+C,DV2573104000000,"Framingham, MA NECTA Division",0,T,3359
+C,DV2573604000000,"Haverhill-Newburyport-Amesbury Town, MA-NH NECTA Division",0,T,3360
+C,DV2574204000000,"Lawrence-Methuen Town-Salem, MA-NH NECTA Division",0,T,3361
+C,DV2574804000000,"Lowell-Billerica-Chelmsford, MA-NH NECTA Division",0,T,3362
+C,DV2574854000000,"Lynn-Saugus-Marblehead, MA NECTA Division",0,T,3363
+C,DV2576524000000,"Peabody-Salem-Beverly, MA NECTA Division",0,T,3364
+C,DV2578254000000,"Taunton-Middleborough-Norton, MA NECTA Division",0,T,3365
+C,DV2619804000000,"Detroit-Dearborn-Livonia, MI Metropolitan Division",0,T,3762
+C,DV2647664000000,"Warren-Troy-Farmington Hills, MI Metropolitan Division",0,T,3763
+C,DV3375404000000,"Nashua, NH-MA NECTA Division",0,T,4699
+C,DV3415804000000,"Camden, NJ Metropolitan Division",0,T,4988
+C,DV3435084000000,"Newark, NJ-PA Metropolitan Division",0,T,4989
+C,DV3620524000000,"Dutchess County-Putnam County, NY Metropolitan Division",0,T,5199
+C,DV3635004000000,"Nassau County-Suffolk County, NY Metropolitan Division",0,T,5200
+C,DV3635614000000,"New York-Jersey City-White Plains, NY-NJ Metropolitan Division",0,T,5201
+C,DV4233874000000,"Montgomery County-Bucks County-Chester County, PA Metropolitan Division",0,T,6178
+C,DV4237964000000,"Philadelphia, PA Metropolitan Division",0,T,6179
+C,DV4819124000000,"Dallas-Plano-Irving, TX Metropolitan Division",0,T,6782
+C,DV4823104000000,"Fort Worth-Arlington, TX Metropolitan Division",0,T,6783
+C,DV5342644000000,"Seattle-Bellevue-Everett, WA Metropolitan Division",0,T,7891
+C,DV5345104000000,"Tacoma-Lakewood, WA Metropolitan Division",0,T,7892
+D,MC0110700000000,"Albertville, AL Micropolitan Statistical Area",0,T,14
+D,MC0110760000000,"Alexander City, AL Micropolitan Statistical Area",0,T,15
+D,MC0112120000000,"Atmore, AL Micropolitan Statistical Area",0,T,16
+D,MC0118980000000,"Cullman, AL Micropolitan Statistical Area",0,T,17
+D,MC0121460000000,"Enterprise, AL Micropolitan Statistical Area",0,T,18
+D,MC0121640000000,"Eufaula, AL-GA Micropolitan Statistical Area",0,T,19
+D,MC0122840000000,"Fort Payne, AL Micropolitan Statistical Area",0,T,20
+D,MC0137120000000,"Ozark, AL Micropolitan Statistical Area",0,T,21
+D,MC0142460000000,"Scottsboro, AL Micropolitan Statistical Area",0,T,22
+D,MC0142820000000,"Selma, AL Micropolitan Statistical Area",0,T,23
+D,MC0145180000000,"Talladega-Sylacauga, AL Micropolitan Statistical Area",0,T,24
+D,MC0145980000000,"Troy, AL Micropolitan Statistical Area",0,T,25
+D,MC0146740000000,"Valley, AL Micropolitan Statistical Area",0,T,26
+D,MC0227940000000,"Juneau, AK Micropolitan Statistical Area",0,T,152
+D,MC0228540000000,"Ketchikan, AK Micropolitan Statistical Area",0,T,153
+D,MC0435700000000,"Nogales, AZ Micropolitan Statistical Area",0,T,201
+D,MC0437740000000,"Payson, AZ Micropolitan Statistical Area",0,T,202
+D,MC0440940000000,"Safford, AZ Micropolitan Statistical Area",0,T,203
+D,MC0443320000000,"Show Low, AZ Micropolitan Statistical Area",0,T,204
+D,MC0511660000000,"Arkadelphia, AR Micropolitan Statistical Area",0,T,264
+D,MC0512900000000,"Batesville, AR Micropolitan Statistical Area",0,T,265
+D,MC0514180000000,"Blytheville, AR Micropolitan Statistical Area",0,T,266
+D,MC0515780000000,"Camden, AR Micropolitan Statistical Area",0,T,267
+D,MC0520980000000,"El Dorado, AR Micropolitan Statistical Area",0,T,268
+D,MC0522620000000,"Forrest City, AR Micropolitan Statistical Area",0,T,269
+D,MC0525460000000,"Harrison, AR Micropolitan Statistical Area",0,T,270
+D,MC0525760000000,"Helena-West Helena, AR Micropolitan Statistical Area",0,T,271
+D,MC0526260000000,"Hope, AR Micropolitan Statistical Area",0,T,272
+D,MC0531620000000,"Magnolia, AR Micropolitan Statistical Area",0,T,273
+D,MC0531680000000,"Malvern, AR Micropolitan Statistical Area",0,T,274
+D,MC0534260000000,"Mountain Home, AR Micropolitan Statistical Area",0,T,275
+D,MC0537500000000,"Paragould, AR Micropolitan Statistical Area",0,T,276
+D,MC0540780000000,"Russellville, AR Micropolitan Statistical Area",0,T,277
+D,MC0542620000000,"Searcy, AR Micropolitan Statistical Area",0,T,278
+D,MC0617340000000,"Clearlake, CA Micropolitan Statistical Area",0,T,415
+D,MC0618860000000,"Crescent City, CA Micropolitan Statistical Area",0,T,416
+D,MC0621700000000,"Eureka-Arcata-Fortuna, CA Micropolitan Statistical Area",0,T,417
+D,MC0639780000000,"Red Bluff, CA Micropolitan Statistical Area",0,T,418
+D,MC0643760000000,"Sonora, CA Micropolitan Statistical Area",0,T,419
+D,MC0645000000000,"Susanville, CA Micropolitan Statistical Area",0,T,420
+D,MC0646020000000,"Truckee-Grass Valley, CA Micropolitan Statistical Area",0,T,421
+D,MC0646380000000,"Ukiah, CA Micropolitan Statistical Area",0,T,422
+D,MC0814720000000,"Breckenridge, CO Micropolitan Statistical Area",0,T,780
+D,MC0815860000000,"Canon City, CO Micropolitan Statistical Area",0,T,781
+D,MC0818780000000,"Craig, CO Micropolitan Statistical Area",0,T,782
+D,MC0820420000000,"Durango, CO Micropolitan Statistical Area",0,T,783
+D,MC0820780000000,"Edwards, CO Micropolitan Statistical Area",0,T,784
+D,MC0822820000000,"Fort Morgan, CO Micropolitan Statistical Area",0,T,785
+D,MC0824060000000,"Glenwood Springs, CO Micropolitan Statistical Area",0,T,786
+D,MC0833940000000,"Montrose, CO Micropolitan Statistical Area",0,T,787
+D,MC0844460000000,"Steamboat Springs, CO Micropolitan Statistical Area",0,T,788
+D,MC0844540000000,"Sterling, CO Micropolitan Statistical Area",0,T,789
+D,MC0978400000000,"Torrington, CT Micropolitan NECTA",0,T,915
+D,MC1211580000000,"Arcadia, FL Micropolitan Statistical Area",0,T,1145
+D,MC1217500000000,"Clewiston, FL Micropolitan Statistical Area",0,T,1146
+D,MC1228580000000,"Key West, FL Micropolitan Statistical Area",0,T,1147
+D,MC1229380000000,"Lake City, FL Micropolitan Statistical Area",0,T,1148
+D,MC1236380000000,"Okeechobee, FL Micropolitan Statistical Area",0,T,1149
+D,MC1237260000000,"Palatka, FL Micropolitan Statistical Area",0,T,1150
+D,MC1248100000000,"Wauchula, FL Micropolitan Statistical Area",0,T,1151
+D,MC1311140000000,"Americus, GA Micropolitan Statistical Area",0,T,1346
+D,MC1312460000000,"Bainbridge, GA Micropolitan Statistical Area",0,T,1347
+D,MC1315660000000,"Calhoun, GA Micropolitan Statistical Area",0,T,1348
+D,MC1316340000000,"Cedartown, GA Micropolitan Statistical Area",0,T,1349
+D,MC1318380000000,"Cordele, GA Micropolitan Statistical Area",0,T,1350
+D,MC1318460000000,"Cornelia, GA Micropolitan Statistical Area",0,T,1351
+D,MC1320060000000,"Douglas, GA Micropolitan Statistical Area",0,T,1352
+D,MC1320140000000,"Dublin, GA Micropolitan Statistical Area",0,T,1353
+D,MC1322340000000,"Fitzgerald, GA Micropolitan Statistical Area",0,T,1354
+D,MC1327600000000,"Jefferson, GA Micropolitan Statistical Area",0,T,1355
+D,MC1327700000000,"Jesup, GA Micropolitan Statistical Area",0,T,1356
+D,MC1329300000000,"LaGrange, GA Micropolitan Statistical Area",0,T,1357
+D,MC1333300000000,"Milledgeville, GA Micropolitan Statistical Area",0,T,1358
+D,MC1334220000000,"Moultrie, GA Micropolitan Statistical Area",0,T,1359
+D,MC1341220000000,"St. Marys, GA Micropolitan Statistical Area",0,T,1360
+D,MC1344340000000,"Statesboro, GA Micropolitan Statistical Area",0,T,1361
+D,MC1344900000000,"Summerville, GA Micropolitan Statistical Area",0,T,1362
+D,MC1345580000000,"Thomaston, GA Micropolitan Statistical Area",0,T,1363
+D,MC1345620000000,"Thomasville, GA Micropolitan Statistical Area",0,T,1364
+D,MC1345700000000,"Tifton, GA Micropolitan Statistical Area",0,T,1365
+D,MC1345740000000,"Toccoa, GA Micropolitan Statistical Area",0,T,1366
+D,MC1347080000000,"Vidalia, GA Micropolitan Statistical Area",0,T,1367
+D,MC1348180000000,"Waycross, GA Micropolitan Statistical Area",0,T,1368
+D,MC1525900000000,"Hilo, HI Micropolitan Statistical Area",0,T,1588
+D,MC1528180000000,"Kapaa, HI Micropolitan Statistical Area",0,T,1589
+D,MC1613940000000,"Blackfoot, ID Micropolitan Statistical Area",0,T,1602
+D,MC1615420000000,"Burley, ID Micropolitan Statistical Area",0,T,1603
+D,MC1625200000000,"Hailey, ID Micropolitan Statistical Area",0,T,1604
+D,MC1634140000000,"Moscow, ID Micropolitan Statistical Area",0,T,1605
+D,MC1634300000000,"Mountain Home, ID Micropolitan Statistical Area",0,T,1606
+D,MC1639940000000,"Rexburg, ID Micropolitan Statistical Area",0,T,1607
+D,MC1641760000000,"Sandpoint, ID Micropolitan Statistical Area",0,T,1608
+D,MC1715900000000,"Canton, IL Micropolitan Statistical Area",0,T,1691
+D,MC1716460000000,"Centralia, IL Micropolitan Statistical Area",0,T,1692
+D,MC1716660000000,"Charleston-Mattoon, IL Micropolitan Statistical Area",0,T,1693
+D,MC1719940000000,"Dixon, IL Micropolitan Statistical Area",0,T,1694
+D,MC1720820000000,"Effingham, IL Micropolitan Statistical Area",0,T,1695
+D,MC1723300000000,"Freeport, IL Micropolitan Statistical Area",0,T,1696
+D,MC1723660000000,"Galesburg, IL Micropolitan Statistical Area",0,T,1697
+D,MC1727300000000,"Jacksonville, IL Micropolitan Statistical Area",0,T,1698
+D,MC1730660000000,"Lincoln, IL Micropolitan Statistical Area",0,T,1699
+D,MC1731380000000,"Macomb, IL Micropolitan Statistical Area",0,T,1700
+D,MC1734500000000,"Mount Vernon, IL Micropolitan Statistical Area",0,T,1701
+D,MC1736860000000,"Ottawa-Peru, IL Micropolitan Statistical Area",0,T,1702
+D,MC1738700000000,"Pontiac, IL Micropolitan Statistical Area",0,T,1703
+D,MC1739500000000,"Quincy, IL-MO Micropolitan Statistical Area",0,T,1704
+D,MC1740300000000,"Rochelle, IL Micropolitan Statistical Area",0,T,1705
+D,MC1744580000000,"Sterling, IL Micropolitan Statistical Area",0,T,1706
+D,MC1745380000000,"Taylorville, IL Micropolitan Statistical Area",0,T,1707
+D,MC1811420000000,"Angola, IN Micropolitan Statistical Area",0,T,1975
+D,MC1812140000000,"Auburn, IN Micropolitan Statistical Area",0,T,1976
+D,MC1813260000000,"Bedford, IN Micropolitan Statistical Area",0,T,1977
+D,MC1818220000000,"Connersville, IN Micropolitan Statistical Area",0,T,1978
+D,MC1818820000000,"Crawfordsville, IN Micropolitan Statistical Area",0,T,1979
+D,MC1819540000000,"Decatur, IN Micropolitan Statistical Area",0,T,1980
+D,MC1823140000000,"Frankfort, IN Micropolitan Statistical Area",0,T,1981
+D,MC1824700000000,"Greensburg, IN Micropolitan Statistical Area",0,T,1982
+D,MC1826540000000,"Huntington, IN Micropolitan Statistical Area",0,T,1983
+D,MC1827540000000,"Jasper, IN Micropolitan Statistical Area",0,T,1984
+D,MC1828340000000,"Kendallville, IN Micropolitan Statistical Area",0,T,1985
+D,MC1830900000000,"Logansport, IN Micropolitan Statistical Area",0,T,1986
+D,MC1831500000000,"Madison, IN Micropolitan Statistical Area",0,T,1987
+D,MC1831980000000,"Marion, IN Micropolitan Statistical Area",0,T,1988
+D,MC1835220000000,"New Castle, IN Micropolitan Statistical Area",0,T,1989
+D,MC1835860000000,"North Vernon, IN Micropolitan Statistical Area",0,T,1990
+D,MC1837940000000,"Peru, IN Micropolitan Statistical Area",0,T,1991
+D,MC1838500000000,"Plymouth, IN Micropolitan Statistical Area",0,T,1992
+D,MC1839980000000,"Richmond, IN Micropolitan Statistical Area",0,T,1993
+D,MC1842980000000,"Seymour, IN Micropolitan Statistical Area",0,T,1994
+D,MC1847180000000,"Vincennes, IN Micropolitan Statistical Area",0,T,1995
+D,MC1847340000000,"Wabash, IN Micropolitan Statistical Area",0,T,1996
+D,MC1847700000000,"Warsaw, IN Micropolitan Statistical Area",0,T,1997
+D,MC1847780000000,"Washington, IN Micropolitan Statistical Area",0,T,1998
+D,MC1914340000000,"Boone, IA Micropolitan Statistical Area",0,T,2150
+D,MC1915460000000,"Burlington, IA-IL Micropolitan Statistical Area",0,T,2151
+D,MC1916140000000,"Carroll, IA Micropolitan Statistical Area",0,T,2152
+D,MC1917540000000,"Clinton, IA Micropolitan Statistical Area",0,T,2153
+D,MC1921840000000,"Fairfield, IA Micropolitan Statistical Area",0,T,2154
+D,MC1922700000000,"Fort Dodge, IA Micropolitan Statistical Area",0,T,2155
+D,MC1922800000000,"Fort Madison-Keokuk, IA-IL-MO Micropolitan Statistical Area",0,T,2156
+D,MC1932260000000,"Marshalltown, IA Micropolitan Statistical Area",0,T,2157
+D,MC1932380000000,"Mason City, IA Micropolitan Statistical Area",0,T,2158
+D,MC1934700000000,"Muscatine, IA Micropolitan Statistical Area",0,T,2159
+D,MC1935500000000,"Newton, IA Micropolitan Statistical Area",0,T,2160
+D,MC1936820000000,"Oskaloosa, IA Micropolitan Statistical Area",0,T,2161
+D,MC1936900000000,"Ottumwa, IA Micropolitan Statistical Area",0,T,2162
+D,MC1937800000000,"Pella, IA Micropolitan Statistical Area",0,T,2163
+D,MC1943980000000,"Spencer, IA Micropolitan Statistical Area",0,T,2164
+D,MC1944020000000,"Spirit Lake, IA Micropolitan Statistical Area",0,T,2165
+D,MC1944740000000,"Storm Lake, IA Micropolitan Statistical Area",0,T,2166
+D,MC2011680000000,"Arkansas City-Winfield, KS Micropolitan Statistical Area",0,T,2309
+D,MC2011860000000,"Atchison, KS Micropolitan Statistical Area",0,T,2310
+D,MC2017700000000,"Coffeyville, KS Micropolitan Statistical Area",0,T,2311
+D,MC2019980000000,"Dodge City, KS Micropolitan Statistical Area",0,T,2312
+D,MC2021380000000,"Emporia, KS Micropolitan Statistical Area",0,T,2313
+D,MC2023780000000,"Garden City, KS Micropolitan Statistical Area",0,T,2314
+D,MC2024460000000,"Great Bend, KS Micropolitan Statistical Area",0,T,2315
+D,MC2025700000000,"Hays, KS Micropolitan Statistical Area",0,T,2316
+D,MC2026740000000,"Hutchinson, KS Micropolitan Statistical Area",0,T,2317
+D,MC2027920000000,"Junction City, KS Micropolitan Statistical Area",0,T,2318
+D,MC2030580000000,"Liberal, KS Micropolitan Statistical Area",0,T,2319
+D,MC2032700000000,"McPherson, KS Micropolitan Statistical Area",0,T,2320
+D,MC2036840000000,"Ottawa, KS Micropolitan Statistical Area",0,T,2321
+D,MC2037660000000,"Parsons, KS Micropolitan Statistical Area",0,T,2322
+D,MC2038260000000,"Pittsburg, KS Micropolitan Statistical Area",0,T,2323
+D,MC2041460000000,"Salina, KS Micropolitan Statistical Area",0,T,2324
+D,MC2112680000000,"Bardstown, KY Micropolitan Statistical Area",0,T,2460
+D,MC2115820000000,"Campbellsville, KY Micropolitan Statistical Area",0,T,2461
+D,MC2116420000000,"Central City, KY Micropolitan Statistical Area",0,T,2462
+D,MC2119220000000,"Danville, KY Micropolitan Statistical Area",0,T,2463
+D,MC2123180000000,"Frankfort, KY Micropolitan Statistical Area",0,T,2464
+D,MC2123980000000,"Glasgow, KY Micropolitan Statistical Area",0,T,2465
+D,MC2130940000000,"London, KY Micropolitan Statistical Area",0,T,2466
+D,MC2131580000000,"Madisonville, KY Micropolitan Statistical Area",0,T,2467
+D,MC2132460000000,"Mayfield, KY Micropolitan Statistical Area",0,T,2468
+D,MC2132500000000,"Maysville, KY Micropolitan Statistical Area",0,T,2469
+D,MC2133180000000,"Middlesborough, KY Micropolitan Statistical Area",0,T,2470
+D,MC2134460000000,"Mount Sterling, KY Micropolitan Statistical Area",0,T,2471
+D,MC2134660000000,"Murray, KY Micropolitan Statistical Area",0,T,2472
+D,MC2137140000000,"Paducah, KY-IL Micropolitan Statistical Area",0,T,2473
+D,MC2140080000000,"Richmond-Berea, KY Micropolitan Statistical Area",0,T,2474
+D,MC2143700000000,"Somerset, KY Micropolitan Statistical Area",0,T,2475
+D,MC2212820000000,"Bastrop, LA Micropolitan Statistical Area",0,T,2636
+D,MC2214220000000,"Bogalusa, LA Micropolitan Statistical Area",0,T,2637
+D,MC2219760000000,"DeRidder, LA Micropolitan Statistical Area",0,T,2638
+D,MC2222860000000,"Fort Polk South, LA Micropolitan Statistical Area",0,T,2639
+D,MC2227660000000,"Jennings, LA Micropolitan Statistical Area",0,T,2640
+D,MC2234020000000,"Morgan City, LA Micropolitan Statistical Area",0,T,2641
+D,MC2235060000000,"Natchitoches, LA Micropolitan Statistical Area",0,T,2642
+D,MC2236660000000,"Opelousas, LA Micropolitan Statistical Area",0,T,2643
+D,MC2240820000000,"Ruston, LA Micropolitan Statistical Area",0,T,2644
+D,MC2370600000000,"Augusta, ME Micropolitan NECTA",0,T,2734
+D,MC2372250000000,"Brunswick, ME Micropolitan NECTA",0,T,2735
+D,MC2377950000000,"Sanford, ME Micropolitan NECTA",0,T,2736
+D,MC2378850000000,"Waterville, ME Micropolitan NECTA",0,T,2737
+D,MC2415700000000,"Cambridge, MD Micropolitan Statistical Area",0,T,3308
+D,MC2420660000000,"Easton, MD Micropolitan Statistical Area",0,T,3309
+D,MC2570450000000,"Athol, MA Micropolitan NECTA",0,T,3366
+D,MC2573300000000,"Greenfield Town, MA Micropolitan NECTA",0,T,3367
+D,MC2576150000000,"North Adams, MA-VT Micropolitan NECTA",0,T,3368
+D,MC2578500000000,"Vineyard Haven, MA Micropolitan NECTA",0,T,3369
+D,MC2610300000000,"Adrian, MI Micropolitan Statistical Area",0,T,3764
+D,MC2610940000000,"Alma, MI Micropolitan Statistical Area",0,T,3765
+D,MC2610980000000,"Alpena, MI Micropolitan Statistical Area",0,T,3766
+D,MC2613660000000,"Big Rapids, MI Micropolitan Statistical Area",0,T,3767
+D,MC2615620000000,"Cadillac, MI Micropolitan Statistical Area",0,T,3768
+D,MC2617740000000,"Coldwater, MI Micropolitan Statistical Area",0,T,3769
+D,MC2621540000000,"Escanaba, MI Micropolitan Statistical Area",0,T,3770
+D,MC2625880000000,"Hillsdale, MI Micropolitan Statistical Area",0,T,3771
+D,MC2626090000000,"Holland, MI Micropolitan Statistical Area",0,T,3772
+D,MC2626340000000,"Houghton, MI Micropolitan Statistical Area",0,T,3773
+D,MC2626960000000,"Ionia, MI Micropolitan Statistical Area",0,T,3774
+D,MC2627020000000,"Iron Mountain, MI-WI Micropolitan Statistical Area",0,T,3775
+D,MC2631220000000,"Ludington, MI Micropolitan Statistical Area",0,T,3776
+D,MC2632100000000,"Marquette, MI Micropolitan Statistical Area",0,T,3777
+D,MC2634380000000,"Mount Pleasant, MI Micropolitan Statistical Area",0,T,3778
+D,MC2637020000000,"Owosso, MI Micropolitan Statistical Area",0,T,3779
+D,MC2642300000000,"Sault Ste. Marie, MI Micropolitan Statistical Area",0,T,3780
+D,MC2644780000000,"Sturgis, MI Micropolitan Statistical Area",0,T,3781
+D,MC2645900000000,"Traverse City, MI Micropolitan Statistical Area",0,T,3782
+D,MC2710660000000,"Albert Lea, MN Micropolitan Statistical Area",0,T,3978
+D,MC2710820000000,"Alexandria, MN Micropolitan Statistical Area",0,T,3979
+D,MC2712380000000,"Austin, MN Micropolitan Statistical Area",0,T,3980
+D,MC2713420000000,"Bemidji, MN Micropolitan Statistical Area",0,T,3981
+D,MC2714660000000,"Brainerd, MN Micropolitan Statistical Area",0,T,3982
+D,MC2721860000000,"Fairmont, MN Micropolitan Statistical Area",0,T,3983
+D,MC2722060000000,"Faribault-Northfield, MN Micropolitan Statistical Area",0,T,3984
+D,MC2722260000000,"Fergus Falls, MN Micropolitan Statistical Area",0,T,3985
+D,MC2724330000000,"Grand Rapids, MN Micropolitan Statistical Area",0,T,3986
+D,MC2726780000000,"Hutchinson, MN Micropolitan Statistical Area",0,T,3987
+D,MC2732140000000,"Marshall, MN Micropolitan Statistical Area",0,T,3988
+D,MC2735580000000,"New Ulm, MN Micropolitan Statistical Area",0,T,3989
+D,MC2736940000000,"Owatonna, MN Micropolitan Statistical Area",0,T,3990
+D,MC2739860000000,"Red Wing, MN Micropolitan Statistical Area",0,T,3991
+D,MC2748820000000,"Willmar, MN Micropolitan Statistical Area",0,T,3992
+D,MC2749100000000,"Winona, MN Micropolitan Statistical Area",0,T,3993
+D,MC2749380000000,"Worthington, MN Micropolitan Statistical Area",0,T,3994
+D,MC2815020000000,"Brookhaven, MS Micropolitan Statistical Area",0,T,4148
+D,MC2817260000000,"Clarksdale, MS Micropolitan Statistical Area",0,T,4149
+D,MC2817380000000,"Cleveland, MS Micropolitan Statistical Area",0,T,4150
+D,MC2818060000000,"Columbus, MS Micropolitan Statistical Area",0,T,4151
+D,MC2818420000000,"Corinth, MS Micropolitan Statistical Area",0,T,4152
+D,MC2824740000000,"Greenville, MS Micropolitan Statistical Area",0,T,4153
+D,MC2824900000000,"Greenwood, MS Micropolitan Statistical Area",0,T,4154
+D,MC2824980000000,"Grenada, MS Micropolitan Statistical Area",0,T,4155
+D,MC2826940000000,"Indianola, MS Micropolitan Statistical Area",0,T,4156
+D,MC2829860000000,"Laurel, MS Micropolitan Statistical Area",0,T,4157
+D,MC2832620000000,"McComb, MS Micropolitan Statistical Area",0,T,4158
+D,MC2832940000000,"Meridian, MS Micropolitan Statistical Area",0,T,4159
+D,MC2835020000000,"Natchez, MS-LA Micropolitan Statistical Area",0,T,4160
+D,MC2837060000000,"Oxford, MS Micropolitan Statistical Area",0,T,4161
+D,MC2838100000000,"Picayune, MS Micropolitan Statistical Area",0,T,4162
+D,MC2844260000000,"Starkville, MS Micropolitan Statistical Area",0,T,4163
+D,MC2846180000000,"Tupelo, MS Micropolitan Statistical Area",0,T,4164
+D,MC2846980000000,"Vicksburg, MS Micropolitan Statistical Area",0,T,4165
+D,MC2848500000000,"West Point, MS Micropolitan Statistical Area",0,T,4166
+D,MC2914700000000,"Branson, MO Micropolitan Statistical Area",0,T,4287
+D,MC2922100000000,"Farmington, MO Micropolitan Statistical Area",0,T,4288
+D,MC2922780000000,"Fort Leonard Wood, MO Micropolitan Statistical Area",0,T,4289
+D,MC2925300000000,"Hannibal, MO Micropolitan Statistical Area",0,T,4290
+D,MC2928380000000,"Kennett, MO Micropolitan Statistical Area",0,T,4291
+D,MC2928860000000,"Kirksville, MO Micropolitan Statistical Area",0,T,4292
+D,MC2930060000000,"Lebanon, MO Micropolitan Statistical Area",0,T,4293
+D,MC2932180000000,"Marshall, MO Micropolitan Statistical Area",0,T,4294
+D,MC2932340000000,"Maryville, MO Micropolitan Statistical Area",0,T,4295
+D,MC2933020000000,"Mexico, MO Micropolitan Statistical Area",0,T,4296
+D,MC2933620000000,"Moberly, MO Micropolitan Statistical Area",0,T,4297
+D,MC2938740000000,"Poplar Bluff, MO Micropolitan Statistical Area",0,T,4298
+D,MC2940620000000,"Rolla, MO Micropolitan Statistical Area",0,T,4299
+D,MC2942740000000,"Sedalia, MO Micropolitan Statistical Area",0,T,4300
+D,MC2943460000000,"Sikeston, MO Micropolitan Statistical Area",0,T,4301
+D,MC2947660000000,"Warrensburg, MO Micropolitan Statistical Area",0,T,4302
+D,MC2948460000000,"West Plains, MO Micropolitan Statistical Area",0,T,4303
+D,MC3014580000000,"Bozeman, MT Micropolitan Statistical Area",0,T,4473
+D,MC3015580000000,"Butte-Silver Bow, MT Micropolitan Statistical Area",0,T,4474
+D,MC3025740000000,"Helena, MT Micropolitan Statistical Area",0,T,4475
+D,MC3028060000000,"Kalispell, MT Micropolitan Statistical Area",0,T,4476
+D,MC3113100000000,"Beatrice, NE Micropolitan Statistical Area",0,T,4546
+D,MC3118100000000,"Columbus, NE Micropolitan Statistical Area",0,T,4547
+D,MC3123340000000,"Fremont, NE Micropolitan Statistical Area",0,T,4548
+D,MC3125580000000,"Hastings, NE Micropolitan Statistical Area",0,T,4549
+D,MC3128260000000,"Kearney, NE Micropolitan Statistical Area",0,T,4550
+D,MC3130420000000,"Lexington, NE Micropolitan Statistical Area",0,T,4551
+D,MC3135740000000,"Norfolk, NE Micropolitan Statistical Area",0,T,4552
+D,MC3135820000000,"North Platte, NE Micropolitan Statistical Area",0,T,4553
+D,MC3142420000000,"Scottsbluff, NE Micropolitan Statistical Area",0,T,4554
+D,MC3221220000000,"Elko, NV Micropolitan Statistical Area",0,T,4664
+D,MC3221980000000,"Fallon, NV Micropolitan Statistical Area",0,T,4665
+D,MC3222280000000,"Fernley, NV Micropolitan Statistical Area",0,T,4666
+D,MC3223820000000,"Gardnerville Ranchos, NV Micropolitan Statistical Area",0,T,4667
+D,MC3237220000000,"Pahrump, NV Micropolitan Statistical Area",0,T,4668
+D,MC3249080000000,"Winnemucca, NV Micropolitan Statistical Area",0,T,4669
+D,MC3371500000000,"Berlin, NH Micropolitan NECTA",0,T,4700
+D,MC3372500000000,"Claremont, NH Micropolitan NECTA",0,T,4701
+D,MC3372700000000,"Concord, NH Micropolitan NECTA",0,T,4702
+D,MC3373750000000,"Keene, NH Micropolitan NECTA",0,T,4703
+D,MC3373900000000,"Laconia, NH Micropolitan NECTA",0,T,4704
+D,MC3374350000000,"Lebanon, NH-VT Micropolitan NECTA",0,T,4705
+D,MC3510460000000,"Alamogordo, NM Micropolitan Statistical Area",0,T,5126
+D,MC3516100000000,"Carlsbad-Artesia, NM Micropolitan Statistical Area",0,T,5127
+D,MC3517580000000,"Clovis, NM Micropolitan Statistical Area",0,T,5128
+D,MC3519700000000,"Deming, NM Micropolitan Statistical Area",0,T,5129
+D,MC3521580000000,"Espanola, NM Micropolitan Statistical Area",0,T,5130
+D,MC3523700000000,"Gallup, NM Micropolitan Statistical Area",0,T,5131
+D,MC3524380000000,"Grants, NM Micropolitan Statistical Area",0,T,5132
+D,MC3526020000000,"Hobbs, NM Micropolitan Statistical Area",0,T,5133
+D,MC3529780000000,"Las Vegas, NM Micropolitan Statistical Area",0,T,5134
+D,MC3531060000000,"Los Alamos, NM Micropolitan Statistical Area",0,T,5135
+D,MC3538780000000,"Portales, NM Micropolitan Statistical Area",0,T,5136
+D,MC3540740000000,"Roswell, NM Micropolitan Statistical Area",0,T,5137
+D,MC3540760000000,"Ruidoso, NM Micropolitan Statistical Area",0,T,5138
+D,MC3543500000000,"Silver City, NM Micropolitan Statistical Area",0,T,5139
+D,MC3545340000000,"Taos, NM Micropolitan Statistical Area",0,T,5140
+D,MC3611220000000,"Amsterdam, NY Micropolitan Statistical Area",0,T,5202
+D,MC3612180000000,"Auburn, NY Micropolitan Statistical Area",0,T,5203
+D,MC3612860000000,"Batavia, NY Micropolitan Statistical Area",0,T,5204
+D,MC3618500000000,"Corning, NY Micropolitan Statistical Area",0,T,5205
+D,MC3618660000000,"Cortland, NY Micropolitan Statistical Area",0,T,5206
+D,MC3624100000000,"Gloversville, NY Micropolitan Statistical Area",0,T,5207
+D,MC3626460000000,"Hudson, NY Micropolitan Statistical Area",0,T,5208
+D,MC3627460000000,"Jamestown-Dunkirk-Fredonia, NY Micropolitan Statistical Area",0,T,5209
+D,MC3631660000000,"Malone, NY Micropolitan Statistical Area",0,T,5210
+D,MC3636300000000,"Ogdensburg-Massena, NY Micropolitan Statistical Area",0,T,5211
+D,MC3636460000000,"Olean, NY Micropolitan Statistical Area",0,T,5212
+D,MC3636580000000,"Oneonta, NY Micropolitan Statistical Area",0,T,5213
+D,MC3638460000000,"Plattsburgh, NY Micropolitan Statistical Area",0,T,5214
+D,MC3642900000000,"Seneca Falls, NY Micropolitan Statistical Area",0,T,5215
+D,MC3710620000000,"Albemarle, NC Micropolitan Statistical Area",0,T,5409
+D,MC3714380000000,"Boone, NC Micropolitan Statistical Area",0,T,5410
+D,MC3714820000000,"Brevard, NC Micropolitan Statistical Area",0,T,5411
+D,MC3719000000000,"Cullowhee, NC Micropolitan Statistical Area",0,T,5412
+D,MC3720380000000,"Dunn, NC Micropolitan Statistical Area",0,T,5413
+D,MC3721020000000,"Elizabeth City, NC Micropolitan Statistical Area",0,T,5414
+D,MC3722580000000,"Forest City, NC Micropolitan Statistical Area",0,T,5415
+D,MC3725780000000,"Henderson, NC Micropolitan Statistical Area",0,T,5416
+D,MC3728620000000,"Kill Devil Hills, NC Micropolitan Statistical Area",0,T,5417
+D,MC3728820000000,"Kinston, NC Micropolitan Statistical Area",0,T,5418
+D,MC3729900000000,"Laurinburg, NC Micropolitan Statistical Area",0,T,5419
+D,MC3731300000000,"Lumberton, NC Micropolitan Statistical Area",0,T,5420
+D,MC3732000000000,"Marion, NC Micropolitan Statistical Area",0,T,5421
+D,MC3733980000000,"Morehead City, NC Micropolitan Statistical Area",0,T,5422
+D,MC3734340000000,"Mount Airy, NC Micropolitan Statistical Area",0,T,5423
+D,MC3735900000000,"North Wilkesboro, NC Micropolitan Statistical Area",0,T,5424
+D,MC3737080000000,"Oxford, NC Micropolitan Statistical Area",0,T,5425
+D,MC3738240000000,"Pinehurst-Southern Pines, NC Micropolitan Statistical Area",0,T,5426
+D,MC3740260000000,"Roanoke Rapids, NC Micropolitan Statistical Area",0,T,5427
+D,MC3740460000000,"Rockingham, NC Micropolitan Statistical Area",0,T,5428
+D,MC3741820000000,"Sanford, NC Micropolitan Statistical Area",0,T,5429
+D,MC3743140000000,"Shelby, NC Micropolitan Statistical Area",0,T,5430
+D,MC3747820000000,"Washington, NC Micropolitan Statistical Area",0,T,5431
+D,MC3748980000000,"Wilson, NC Micropolitan Statistical Area",0,T,5432
+D,MC3819860000000,"Dickinson, ND Micropolitan Statistical Area",0,T,5619
+D,MC3827420000000,"Jamestown, ND Micropolitan Statistical Area",0,T,5620
+D,MC3833500000000,"Minot, ND Micropolitan Statistical Area",0,T,5621
+D,MC3847420000000,"Wahpeton, ND-MN Micropolitan Statistical Area",0,T,5622
+D,MC3848780000000,"Williston, ND Micropolitan Statistical Area",0,T,5623
+D,MC3911740000000,"Ashland, OH Micropolitan Statistical Area",0,T,5701
+D,MC3911780000000,"Ashtabula, OH Micropolitan Statistical Area",0,T,5702
+D,MC3911900000000,"Athens, OH Micropolitan Statistical Area",0,T,5703
+D,MC3913340000000,"Bellefontaine, OH Micropolitan Statistical Area",0,T,5704
+D,MC3915340000000,"Bucyrus, OH Micropolitan Statistical Area",0,T,5705
+D,MC3915740000000,"Cambridge, OH Micropolitan Statistical Area",0,T,5706
+D,MC3916380000000,"Celina, OH Micropolitan Statistical Area",0,T,5707
+D,MC3917060000000,"Chillicothe, OH Micropolitan Statistical Area",0,T,5708
+D,MC3918740000000,"Coshocton, OH Micropolitan Statistical Area",0,T,5709
+D,MC3919580000000,"Defiance, OH Micropolitan Statistical Area",0,T,5710
+D,MC3922300000000,"Findlay, OH Micropolitan Statistical Area",0,T,5711
+D,MC3923380000000,"Fremont, OH Micropolitan Statistical Area",0,T,5712
+D,MC3924820000000,"Greenville, OH Micropolitan Statistical Area",0,T,5713
+D,MC3927160000000,"Jackson, OH Micropolitan Statistical Area",0,T,5714
+D,MC3931930000000,"Marietta, OH Micropolitan Statistical Area",0,T,5715
+D,MC3932020000000,"Marion, OH Micropolitan Statistical Area",0,T,5716
+D,MC3934540000000,"Mount Vernon, OH Micropolitan Statistical Area",0,T,5717
+D,MC3935420000000,"New Philadelphia-Dover, OH Micropolitan Statistical Area",0,T,5718
+D,MC3935940000000,"Norwalk, OH Micropolitan Statistical Area",0,T,5719
+D,MC3938580000000,"Point Pleasant, WV-OH Micropolitan Statistical Area",0,T,5720
+D,MC3938840000000,"Port Clinton, OH Micropolitan Statistical Area",0,T,5721
+D,MC3939020000000,"Portsmouth, OH Micropolitan Statistical Area",0,T,5722
+D,MC3941400000000,"Salem, OH Micropolitan Statistical Area",0,T,5723
+D,MC3941780000000,"Sandusky, OH Micropolitan Statistical Area",0,T,5724
+D,MC3943380000000,"Sidney, OH Micropolitan Statistical Area",0,T,5725
+D,MC3945660000000,"Tiffin, OH Micropolitan Statistical Area",0,T,5726
+D,MC3946500000000,"Urbana, OH Micropolitan Statistical Area",0,T,5727
+D,MC3946780000000,"Van Wert, OH Micropolitan Statistical Area",0,T,5728
+D,MC3947540000000,"Wapakoneta, OH Micropolitan Statistical Area",0,T,5729
+D,MC3947920000000,"Washington Court House, OH Micropolitan Statistical Area",0,T,5730
+D,MC3948940000000,"Wilmington, OH Micropolitan Statistical Area",0,T,5731
+D,MC3949300000000,"Wooster, OH Micropolitan Statistical Area",0,T,5732
+D,MC3949780000000,"Zanesville, OH Micropolitan Statistical Area",0,T,5733
+D,MC4010220000000,"Ada, OK Micropolitan Statistical Area",0,T,5929
+D,MC4011060000000,"Altus, OK Micropolitan Statistical Area",0,T,5930
+D,MC4011620000000,"Ardmore, OK Micropolitan Statistical Area",0,T,5931
+D,MC4012780000000,"Bartlesville, OK Micropolitan Statistical Area",0,T,5932
+D,MC4020340000000,"Duncan, OK Micropolitan Statistical Area",0,T,5933
+D,MC4020460000000,"Durant, OK Micropolitan Statistical Area",0,T,5934
+D,MC4021120000000,"Elk City, OK Micropolitan Statistical Area",0,T,5935
+D,MC4025100000000,"Guymon, OK Micropolitan Statistical Area",0,T,5936
+D,MC4032540000000,"McAlester, OK Micropolitan Statistical Area",0,T,5937
+D,MC4033060000000,"Miami, OK Micropolitan Statistical Area",0,T,5938
+D,MC4034780000000,"Muskogee, OK Micropolitan Statistical Area",0,T,5939
+D,MC4038620000000,"Ponca City, OK Micropolitan Statistical Area",0,T,5940
+D,MC4043060000000,"Shawnee, OK Micropolitan Statistical Area",0,T,5941
+D,MC4044660000000,"Stillwater, OK Micropolitan Statistical Area",0,T,5942
+D,MC4045140000000,"Tahlequah, OK Micropolitan Statistical Area",0,T,5943
+D,MC4048220000000,"Weatherford, OK Micropolitan Statistical Area",0,T,5944
+D,MC4049260000000,"Woodward, OK Micropolitan Statistical Area",0,T,5945
+D,MC4111820000000,"Astoria, OR Micropolitan Statistical Area",0,T,6068
+D,MC4115060000000,"Brookings, OR Micropolitan Statistical Area",0,T,6069
+D,MC4118300000000,"Coos Bay, OR Micropolitan Statistical Area",0,T,6070
+D,MC4125840000000,"Hermiston-Pendleton, OR Micropolitan Statistical Area",0,T,6071
+D,MC4126220000000,"Hood River, OR Micropolitan Statistical Area",0,T,6072
+D,MC4128900000000,"Klamath Falls, OR Micropolitan Statistical Area",0,T,6073
+D,MC4129260000000,"La Grande, OR Micropolitan Statistical Area",0,T,6074
+D,MC4135440000000,"Newport, OR Micropolitan Statistical Area",0,T,6075
+D,MC4136620000000,"Ontario, OR-ID Micropolitan Statistical Area",0,T,6076
+D,MC4139260000000,"Prineville, OR Micropolitan Statistical Area",0,T,6077
+D,MC4140700000000,"Roseburg, OR Micropolitan Statistical Area",0,T,6078
+D,MC4145520000000,"The Dalles, OR Micropolitan Statistical Area",0,T,6079
+D,MC4214620000000,"Bradford, PA Micropolitan Statistical Area",0,T,6180
+D,MC4220180000000,"DuBois, PA Micropolitan Statistical Area",0,T,6181
+D,MC4226500000000,"Huntingdon, PA Micropolitan Statistical Area",0,T,6182
+D,MC4226860000000,"Indiana, PA Micropolitan Statistical Area",0,T,6183
+D,MC4230260000000,"Lewisburg, PA Micropolitan Statistical Area",0,T,6184
+D,MC4230380000000,"Lewistown, PA Micropolitan Statistical Area",0,T,6185
+D,MC4230820000000,"Lock Haven, PA Micropolitan Statistical Area",0,T,6186
+D,MC4232740000000,"Meadville, PA Micropolitan Statistical Area",0,T,6187
+D,MC4235260000000,"New Castle, PA Micropolitan Statistical Area",0,T,6188
+D,MC4236340000000,"Oil City, PA Micropolitan Statistical Area",0,T,6189
+D,MC4239060000000,"Pottsville, PA Micropolitan Statistical Area",0,T,6190
+D,MC4241260000000,"St. Marys, PA Micropolitan Statistical Area",0,T,6191
+D,MC4242380000000,"Sayre, PA Micropolitan Statistical Area",0,T,6192
+D,MC4242780000000,"Selinsgrove, PA Micropolitan Statistical Area",0,T,6193
+D,MC4243740000000,"Somerset, PA Micropolitan Statistical Area",0,T,6194
+D,MC4244980000000,"Sunbury, PA Micropolitan Statistical Area",0,T,6195
+D,MC4247620000000,"Warren, PA Micropolitan Statistical Area",0,T,6196
+D,MC4513500000000,"Bennettsville, SC Micropolitan Statistical Area",0,T,6407
+D,MC4523500000000,"Gaffney, SC Micropolitan Statistical Area",0,T,6408
+D,MC4523860000000,"Georgetown, SC Micropolitan Statistical Area",0,T,6409
+D,MC4524940000000,"Greenwood, SC Micropolitan Statistical Area",0,T,6410
+D,MC4535140000000,"Newberry, SC Micropolitan Statistical Area",0,T,6411
+D,MC4536700000000,"Orangeburg, SC Micropolitan Statistical Area",0,T,6412
+D,MC4542860000000,"Seneca, SC Micropolitan Statistical Area",0,T,6413
+D,MC4610100000000,"Aberdeen, SD Micropolitan Statistical Area",0,T,6501
+D,MC4615100000000,"Brookings, SD Micropolitan Statistical Area",0,T,6502
+D,MC4626700000000,"Huron, SD Micropolitan Statistical Area",0,T,6503
+D,MC4633580000000,"Mitchell, SD Micropolitan Statistical Area",0,T,6504
+D,MC4638180000000,"Pierre, SD Micropolitan Statistical Area",0,T,6505
+D,MC4643940000000,"Spearfish, SD Micropolitan Statistical Area",0,T,6506
+D,MC4646820000000,"Vermillion, SD Micropolitan Statistical Area",0,T,6507
+D,MC4647980000000,"Watertown, SD Micropolitan Statistical Area",0,T,6508
+D,MC4649460000000,"Yankton, SD Micropolitan Statistical Area",0,T,6509
+D,MC4711940000000,"Athens, TN Micropolitan Statistical Area",0,T,6595
+D,MC4715140000000,"Brownsville, TN Micropolitan Statistical Area",0,T,6596
+D,MC4718260000000,"Cookeville, TN Micropolitan Statistical Area",0,T,6597
+D,MC4718900000000,"Crossville, TN Micropolitan Statistical Area",0,T,6598
+D,MC4719420000000,"Dayton, TN Micropolitan Statistical Area",0,T,6599
+D,MC4720540000000,"Dyersburg, TN Micropolitan Statistical Area",0,T,6600
+D,MC4724620000000,"Greeneville, TN Micropolitan Statistical Area",0,T,6601
+D,MC4729980000000,"Lawrenceburg, TN Micropolitan Statistical Area",0,T,6602
+D,MC4730280000000,"Lewisburg, TN Micropolitan Statistical Area",0,T,6603
+D,MC4732280000000,"Martin, TN Micropolitan Statistical Area",0,T,6604
+D,MC4732660000000,"McMinnville, TN Micropolitan Statistical Area",0,T,6605
+D,MC4735460000000,"Newport, TN Micropolitan Statistical Area",0,T,6606
+D,MC4737540000000,"Paris, TN Micropolitan Statistical Area",0,T,6607
+D,MC4742940000000,"Sevierville, TN Micropolitan Statistical Area",0,T,6608
+D,MC4743180000000,"Shelbyville, TN Micropolitan Statistical Area",0,T,6609
+D,MC4746100000000,"Tullahoma-Manchester, TN Micropolitan Statistical Area",0,T,6610
+D,MC4746460000000,"Union City, TN-KY Micropolitan Statistical Area",0,T,6611
+D,MC4810860000000,"Alice, TX Micropolitan Statistical Area",0,T,6784
+D,MC4811380000000,"Andrews, TX Micropolitan Statistical Area",0,T,6785
+D,MC4811980000000,"Athens, TX Micropolitan Statistical Area",0,T,6786
+D,MC4813060000000,"Bay City, TX Micropolitan Statistical Area",0,T,6787
+D,MC4813300000000,"Beeville, TX Micropolitan Statistical Area",0,T,6788
+D,MC4813700000000,"Big Spring, TX Micropolitan Statistical Area",0,T,6789
+D,MC4814300000000,"Bonham, TX Micropolitan Statistical Area",0,T,6790
+D,MC4814420000000,"Borger, TX Micropolitan Statistical Area",0,T,6791
+D,MC4814780000000,"Brenham, TX Micropolitan Statistical Area",0,T,6792
+D,MC4815220000000,"Brownwood, TX Micropolitan Statistical Area",0,T,6793
+D,MC4818620000000,"Corsicana, TX Micropolitan Statistical Area",0,T,6794
+D,MC4819620000000,"Del Rio, TX Micropolitan Statistical Area",0,T,6795
+D,MC4820300000000,"Dumas, TX Micropolitan Statistical Area",0,T,6796
+D,MC4820580000000,"Eagle Pass, TX Micropolitan Statistical Area",0,T,6797
+D,MC4820900000000,"El Campo, TX Micropolitan Statistical Area",0,T,6798
+D,MC4823240000000,"Fredericksburg, TX Micropolitan Statistical Area",0,T,6799
+D,MC4823620000000,"Gainesville, TX Micropolitan Statistical Area",0,T,6800
+D,MC4825820000000,"Hereford, TX Micropolitan Statistical Area",0,T,6801
+D,MC4826660000000,"Huntsville, TX Micropolitan Statistical Area",0,T,6802
+D,MC4827380000000,"Jacksonville, TX Micropolitan Statistical Area",0,T,6803
+D,MC4828500000000,"Kerrville, TX Micropolitan Statistical Area",0,T,6804
+D,MC4828780000000,"Kingsville, TX Micropolitan Statistical Area",0,T,6805
+D,MC4829500000000,"Lamesa, TX Micropolitan Statistical Area",0,T,6806
+D,MC4830220000000,"Levelland, TX Micropolitan Statistical Area",0,T,6807
+D,MC4831260000000,"Lufkin, TX Micropolitan Statistical Area",0,T,6808
+D,MC4832220000000,"Marshall, TX Micropolitan Statistical Area",0,T,6809
+D,MC4833420000000,"Mineral Wells, TX Micropolitan Statistical Area",0,T,6810
+D,MC4834420000000,"Mount Pleasant, TX Micropolitan Statistical Area",0,T,6811
+D,MC4834860000000,"Nacogdoches, TX Micropolitan Statistical Area",0,T,6812
+D,MC4837300000000,"Palestine, TX Micropolitan Statistical Area",0,T,6813
+D,MC4837420000000,"Pampa, TX Micropolitan Statistical Area",0,T,6814
+D,MC4837580000000,"Paris, TX Micropolitan Statistical Area",0,T,6815
+D,MC4837770000000,"Pearsall, TX Micropolitan Statistical Area",0,T,6816
+D,MC4837780000000,"Pecos, TX Micropolitan Statistical Area",0,T,6817
+D,MC4838380000000,"Plainview, TX Micropolitan Statistical Area",0,T,6818
+D,MC4838920000000,"Port Lavaca, TX Micropolitan Statistical Area",0,T,6819
+D,MC4839700000000,"Raymondville, TX Micropolitan Statistical Area",0,T,6820
+D,MC4840100000000,"Rio Grande City, TX Micropolitan Statistical Area",0,T,6821
+D,MC4843660000000,"Snyder, TX Micropolitan Statistical Area",0,T,6822
+D,MC4844500000000,"Stephenville, TX Micropolitan Statistical Area",0,T,6823
+D,MC4844860000000,"Sulphur Springs, TX Micropolitan Statistical Area",0,T,6824
+D,MC4845020000000,"Sweetwater, TX Micropolitan Statistical Area",0,T,6825
+D,MC4846620000000,"Uvalde, TX Micropolitan Statistical Area",0,T,6826
+D,MC4846900000000,"Vernon, TX Micropolitan Statistical Area",0,T,6827
+D,MC4849820000000,"Zapata, TX Micropolitan Statistical Area",0,T,6828
+D,MC4916260000000,"Cedar City, UT Micropolitan Statistical Area",0,T,7316
+D,MC4925720000000,"Heber, UT Micropolitan Statistical Area",0,T,7317
+D,MC4939220000000,"Price, UT Micropolitan Statistical Area",0,T,7318
+D,MC4944920000000,"Summit Park, UT Micropolitan Statistical Area",0,T,7319
+D,MC4946860000000,"Vernal, UT Micropolitan Statistical Area",0,T,7320
+D,MC5071050000000,"Barre, VT Micropolitan NECTA",0,T,7395
+D,MC5071350000000,"Bennington, VT Micropolitan NECTA",0,T,7396
+D,MC5077650000000,"Rutland, VT Micropolitan NECTA",0,T,7397
+D,MC5113720000000,"Big Stone Gap, VA Micropolitan Statistical Area",0,T,7690
+D,MC5119260000000,"Danville, VA Micropolitan Statistical Area",0,T,7691
+D,MC5132300000000,"Martinsville, VA Micropolitan Statistical Area",0,T,7692
+D,MC5310140000000,"Aberdeen, WA Micropolitan Statistical Area",0,T,7893
+D,MC5316500000000,"Centralia, WA Micropolitan Statistical Area",0,T,7894
+D,MC5321260000000,"Ellensburg, WA Micropolitan Statistical Area",0,T,7895
+D,MC5334180000000,"Moses Lake, WA Micropolitan Statistical Area",0,T,7896
+D,MC5336020000000,"Oak Harbor, WA Micropolitan Statistical Area",0,T,7897
+D,MC5336830000000,"Othello, WA Micropolitan Statistical Area",0,T,7898
+D,MC5338820000000,"Port Angeles, WA Micropolitan Statistical Area",0,T,7899
+D,MC5339420000000,"Pullman, WA Micropolitan Statistical Area",0,T,7900
+D,MC5343220000000,"Shelton, WA Micropolitan Statistical Area",0,T,7901
+D,MC5414140000000,"Bluefield, WV-VA Micropolitan Statistical Area",0,T,8005
+D,MC5417220000000,"Clarksburg, WV Micropolitan Statistical Area",0,T,8006
+D,MC5421180000000,"Elkins, WV Micropolitan Statistical Area",0,T,8007
+D,MC5421900000000,"Fairmont, WV Micropolitan Statistical Area",0,T,8008
+D,MC5430880000000,"Logan, WV Micropolitan Statistical Area",0,T,8009
+D,MC5512660000000,"Baraboo, WI Micropolitan Statistical Area",0,T,8099
+D,MC5513180000000,"Beaver Dam, WI Micropolitan Statistical Area",0,T,8100
+D,MC5531820000000,"Manitowoc, WI Micropolitan Statistical Area",0,T,8101
+D,MC5531940000000,"Marinette, WI-MI Micropolitan Statistical Area",0,T,8102
+D,MC5532860000000,"Menomonie, WI Micropolitan Statistical Area",0,T,8103
+D,MC5532980000000,"Merrill, WI Micropolitan Statistical Area",0,T,8104
+D,MC5538420000000,"Platteville, WI Micropolitan Statistical Area",0,T,8105
+D,MC5543020000000,"Shawano, WI Micropolitan Statistical Area",0,T,8106
+D,MC5544620000000,"Stevens Point, WI Micropolitan Statistical Area",0,T,8107
+D,MC5548020000000,"Watertown-Fort Atkinson, WI Micropolitan Statistical Area",0,T,8108
+D,MC5548580000000,"Whitewater-Elkhorn, WI Micropolitan Statistical Area",0,T,8109
+D,MC5549220000000,"Wisconsin Rapids-Marshfield, WI Micropolitan Statistical Area",0,T,8110
+D,MC5621740000000,"Evanston, WY Micropolitan Statistical Area",0,T,8240
+D,MC5623940000000,"Gillette, WY Micropolitan Statistical Area",0,T,8241
+D,MC5627220000000,"Jackson, WY-ID Micropolitan Statistical Area",0,T,8242
+D,MC5629660000000,"Laramie, WY Micropolitan Statistical Area",0,T,8243
+D,MC5640180000000,"Riverton, WY Micropolitan Statistical Area",0,T,8244
+D,MC5640540000000,"Rock Springs, WY Micropolitan Statistical Area",0,T,8245
+D,MC5643260000000,"Sheridan, WY Micropolitan Statistical Area",0,T,8246
+D,MC7210260000000,"Adjuntas, PR Micropolitan Statistical Area",0,T,8283
+D,MC7217620000000,"Coamo, PR Micropolitan Statistical Area",0,T,8284
+D,MC7217640000000,"Coco, PR Micropolitan Statistical Area",0,T,8285
+D,MC7227580000000,"Jayuya, PR Micropolitan Statistical Area",0,T,8286
+D,MC7242180000000,"Santa Isabel, PR Micropolitan Statistical Area",0,T,8287
+E,CA0114200000000,"Birmingham-Hoover-Talladega, AL Combined Statistical Area",0,T,27
+E,CA0122200000000,"Dothan-Enterprise-Ozark, AL Combined Statistical Area",0,T,28
+E,CA0129000000000,"Huntsville-Decatur-Albertville, AL Combined Statistical Area",0,T,29
+E,CA0138000000000,"Mobile-Daphne-Fairhope, AL Combined Statistical Area",0,T,30
+E,CA0453600000000,"Tucson-Nogales, AZ Combined Statistical Area",0,T,205
+E,CA0528400000000,"Hot Springs-Malvern, AR Combined Statistical Area",0,T,279
+E,CA0530800000000,"Jonesboro-Paragould, AR Combined Statistical Area",0,T,280
+E,CA0534000000000,"Little Rock-North Little Rock, AR Combined Statistical Area",0,T,281
+E,CA0626000000000,"Fresno-Madera, CA Combined Statistical Area",0,T,423
+E,CA0634800000000,"Los Angeles-Long Beach, CA Combined Statistical Area",0,T,424
+E,CA0638200000000,"Modesto-Merced, CA Combined Statistical Area",0,T,425
+E,CA0645400000000,"Redding-Red Bluff, CA Combined Statistical Area",0,T,426
+E,CA0647200000000,"Sacramento-Roseville, CA Combined Statistical Area",0,T,427
+E,CA0648800000000,"San Jose-San Francisco-Oakland, CA Combined Statistical Area",0,T,428
+E,CA0654600000000,"Visalia-Porterville-Hanford, CA Combined Statistical Area",0,T,429
+E,CA0821600000000,"Denver-Aurora, CO Combined Statistical Area",0,T,790
+E,CA0823300000000,"Edwards-Glenwood Springs, CO Combined Statistical Area",0,T,791
+E,CA0844400000000,"Pueblo-Canon City, CO Combined Statistical Area",0,T,792
+E,CA0852500000000,"Steamboat Springs-Craig, CO Combined Statistical Area",0,T,793
+E,CA0972000000000,"Bridgeport-New Haven-Stamford, CT Combined NECTA",0,T,916
+E,CA0979000000000,"Springfield-Hartford-West Hartford, MA-CT Combined NECTA",0,T,917
+E,CA1154800000000,"Washington-Baltimore-Arlington, DC-MD-VA-WV-PA Combined Statistical Area",0,T,1115
+E,CA1216200000000,"Cape Coral-Fort Myers-Naples, FL Combined Statistical Area",0,T,1152
+E,CA1226400000000,"Gainesville-Lake City, FL Combined Statistical Area",0,T,1153
+E,CA1230000000000,"Jacksonville-St. Marys-Palatka, FL-GA Combined Statistical Area",0,T,1154
+E,CA1237000000000,"Miami-Fort Lauderdale-Port St. Lucie, FL Combined Statistical Area",0,T,1155
+E,CA1241200000000,"North Port-Sarasota, FL Combined Statistical Area",0,T,1156
+E,CA1242200000000,"Orlando-Deltona-Daytona Beach, FL Combined Statistical Area",0,T,1157
+E,CA1242600000000,"Pensacola-Ferry Pass, FL-AL Combined Statistical Area",0,T,1158
+E,CA1253300000000,"Tallahassee-Bainbridge, FL-GA Combined Statistical Area",0,T,1159
+E,CA1312200000000,"Atlanta--Athens-Clarke County--Sandy Springs, GA Combined Statistical Area",0,T,1369
+E,CA1319400000000,"Columbus-Auburn-Opelika, GA-AL Combined Statistical Area",0,T,1370
+E,CA1335600000000,"Macon-Bibb County--Warner Robins, GA Combined Statistical Area",0,T,1371
+E,CA1347000000000,"Rome-Summerville, GA Combined Statistical Area",0,T,1372
+E,CA1349600000000,"Savannah-Hinesville-Statesboro, GA Combined Statistical Area",0,T,1373
+E,CA1614700000000,"Boise City-Mountain Home-Ontario, ID-OR Combined Statistical Area",0,T,1609
+E,CA1629200000000,"Idaho Falls-Rexburg-Blackfoot, ID Combined Statistical Area",0,T,1610
+E,CA1714500000000,"Bloomington-Pontiac, IL Combined Statistical Area",0,T,1708
+E,CA1717600000000,"Chicago-Naperville, IL-IN-WI Combined Statistical Area",0,T,1709
+E,CA1722100000000,"Dixon-Sterling, IL Combined Statistical Area",0,T,1710
+E,CA1742700000000,"Peoria-Canton, IL Combined Statistical Area",0,T,1711
+E,CA1744800000000,"Quincy-Hannibal, IL-MO Combined Statistical Area",0,T,1712
+E,CA1746600000000,"Rockford-Freeport-Rochelle, IL Combined Statistical Area",0,T,1713
+E,CA1752200000000,"Springfield-Jacksonville-Lincoln, IL Combined Statistical Area",0,T,1714
+E,CA1814400000000,"Bloomington-Bedford, IN Combined Statistical Area",0,T,1999
+E,CA1825800000000,"Fort Wayne-Huntington-Auburn, IN Combined Statistical Area",0,T,2000
+E,CA1829400000000,"Indianapolis-Carmel-Muncie, IN Combined Statistical Area",0,T,2001
+E,CA1831600000000,"Kokomo-Peru, IN Combined Statistical Area",0,T,2002
+E,CA1832000000000,"Lafayette-West Lafayette-Frankfort, IN Combined Statistical Area",0,T,2003
+E,CA1845800000000,"Richmond-Connersville, IN Combined Statistical Area",0,T,2004
+E,CA1851500000000,"South Bend-Elkhart-Mishawaka, IN-MI Combined Statistical Area",0,T,2005
+E,CA1916800000000,"Cedar Rapids-Iowa City, IA Combined Statistical Area",0,T,2167
+E,CA1920900000000,"Davenport-Moline, IA-IL Combined Statistical Area",0,T,2168
+E,CA1921800000000,"Des Moines-Ames-West Des Moines, IA Combined Statistical Area",0,T,2169
+E,CA1942300000000,"Oskaloosa-Pella, IA Combined Statistical Area",0,T,2170
+E,CA1951200000000,"Sioux City-Vermillion, IA-SD-NE Combined Statistical Area",0,T,2171
+E,CA2035800000000,"Manhattan-Junction City, KS Combined Statistical Area",0,T,2325
+E,CA2055600000000,"Wichita-Arkansas City-Winfield, KS Combined Statistical Area",0,T,2326
+E,CA2115000000000,"Bowling Green-Glasgow, KY Combined Statistical Area",0,T,2476
+E,CA2133600000000,"Lexington-Fayette--Richmond--Frankfort, KY Combined Statistical Area",0,T,2477
+E,CA2135000000000,"Louisville/Jefferson County--Elizabethtown--Madison, KY-IN Combined Statistical Area",0,T,2478
+E,CA2142400000000,"Paducah-Mayfield, KY-IL Combined Statistical Area",0,T,2479
+E,CA2221700000000,"DeRidder-Fort Polk South, LA Combined Statistical Area",0,T,2645
+E,CA2231800000000,"Lafayette-Opelousas-Morgan City, LA Combined Statistical Area",0,T,2646
+E,CA2232400000000,"Lake Charles-Jennings, LA Combined Statistical Area",0,T,2647
+E,CA2238400000000,"Monroe-Ruston-Bastrop, LA Combined Statistical Area",0,T,2648
+E,CA2240600000000,"New Orleans-Metairie-Hammond, LA-MS Combined Statistical Area",0,T,2649
+E,CA2371000000000,"Augusta-Waterville, ME Combined NECTA",0,T,2738
+E,CA2377500000000,"Portland-Lewiston-South Portland, ME Combined NECTA",0,T,2739
+E,CA2571500000000,"Boston-Worcester-Providence, MA-RI-NH-CT-ME Combined NECTA",0,T,3370
+E,CA2577000000000,"Pittsfield-North Adams, MA-VT Combined NECTA",0,T,3371
+E,CA2622000000000,"Detroit-Warren-Ann Arbor, MI Combined Statistical Area",0,T,3783
+E,CA2626600000000,"Grand Rapids-Wyoming-Muskegon, MI Combined Statistical Area",0,T,3784
+E,CA2631000000000,"Kalamazoo-Battle Creek-Portage, MI Combined Statistical Area",0,T,3785
+E,CA2633000000000,"Lansing-East Lansing-Owosso, MI Combined Statistical Area",0,T,3786
+E,CA2639400000000,"Mount Pleasant-Alma, MI Combined Statistical Area",0,T,3787
+E,CA2647400000000,"Saginaw-Midland-Bay City, MI Combined Statistical Area",0,T,3788
+E,CA2735900000000,"Mankato-New Ulm-North Mankato, MN Combined Statistical Area",0,T,3995
+E,CA2737800000000,"Minneapolis-St. Paul, MN-WI Combined Statistical Area",0,T,3996
+E,CA2746200000000,"Rochester-Austin, MN Combined Statistical Area",0,T,3997
+E,CA2818500000000,"Cleveland-Indianola, MS Combined Statistical Area",0,T,4167
+E,CA2820000000000,"Columbus-West Point, MS Combined Statistical Area",0,T,4168
+E,CA2829800000000,"Jackson-Vicksburg-Brookhaven, MS Combined Statistical Area",0,T,4169
+E,CA2916400000000,"Cape Girardeau-Sikeston, MO-IL Combined Statistical Area",0,T,4304
+E,CA2919000000000,"Columbia-Moberly-Mexico, MO Combined Statistical Area",0,T,4305
+E,CA2930900000000,"Joplin-Miami, MO-OK Combined Statistical Area",0,T,4306
+E,CA2931200000000,"Kansas City-Overland Park-Kansas City, MO-KS Combined Statistical Area",0,T,4307
+E,CA2947600000000,"St. Louis-St. Charles-Farmington, MO-IL Combined Statistical Area",0,T,4308
+E,CA2952000000000,"Springfield-Branson, MO Combined Statistical Area",0,T,4309
+E,CA3133900000000,"Lincoln-Beatrice, NE Combined Statistical Area",0,T,4555
+E,CA3142000000000,"Omaha-Council Bluffs-Fremont, NE-IA Combined Statistical Area",0,T,4556
+E,CA3233200000000,"Las Vegas-Henderson, NV-AZ Combined Statistical Area",0,T,4670
+E,CA3245600000000,"Reno-Carson City-Fernley, NV Combined Statistical Area",0,T,4671
+E,CA3372500000000,"Claremont-Lebanon, NH-VT Combined NECTA",0,T,4706
+E,CA3510600000000,"Albuquerque-Santa Fe-Las Vegas, NM Combined Statistical Area",0,T,5141
+E,CA3518800000000,"Clovis-Portales, NM Combined Statistical Area",0,T,5142
+E,CA3610400000000,"Albany-Schenectady, NY Combined Statistical Area",0,T,5216
+E,CA3616000000000,"Buffalo-Cheektowaga, NY Combined Statistical Area",0,T,5217
+E,CA3623600000000,"Elmira-Corning, NY Combined Statistical Area",0,T,5218
+E,CA3629600000000,"Ithaca-Cortland, NY Combined Statistical Area",0,T,5219
+E,CA3640800000000,"New York-Newark, NY-NJ-CT-PA Combined Statistical Area",0,T,5220
+E,CA3646400000000,"Rochester-Batavia-Seneca Falls, NY Combined Statistical Area",0,T,5221
+E,CA3653200000000,"Syracuse-Auburn, NY Combined Statistical Area",0,T,5222
+E,CA3712000000000,"Asheville-Brevard, NC Combined Statistical Area",0,T,5433
+E,CA3717200000000,"Charlotte-Concord, NC-SC Combined Statistical Area",0,T,5434
+E,CA3724600000000,"Fayetteville-Lumberton-Laurinburg, NC Combined Statistical Area",0,T,5435
+E,CA3726800000000,"Greensboro--Winston-Salem--High Point, NC Combined Statistical Area",0,T,5436
+E,CA3727400000000,"Greenville-Washington, NC Combined Statistical Area",0,T,5437
+E,CA3728000000000,"Hickory-Lenoir, NC Combined Statistical Area",0,T,5438
+E,CA3740400000000,"New Bern-Morehead City, NC Combined Statistical Area",0,T,5439
+E,CA3745000000000,"Raleigh-Durham-Chapel Hill, NC Combined Statistical Area",0,T,5440
+E,CA3746800000000,"Rocky Mount-Wilson-Roanoke Rapids, NC Combined Statistical Area",0,T,5441
+E,CA3824400000000,"Fargo-Wahpeton, ND-MN Combined Statistical Area",0,T,5624
+E,CA3917800000000,"Cincinnati-Wilmington-Maysville, OH-KY-IN Combined Statistical Area",0,T,5734
+E,CA3918400000000,"Cleveland-Akron-Canton, OH Combined Statistical Area",0,T,5735
+E,CA3919800000000,"Columbus-Marion-Zanesville, OH Combined Statistical Area",0,T,5736
+E,CA3921200000000,"Dayton-Springfield-Sidney, OH Combined Statistical Area",0,T,5737
+E,CA3924800000000,"Findlay-Tiffin, OH Combined Statistical Area",0,T,5738
+E,CA3933800000000,"Lima-Van Wert-Celina, OH Combined Statistical Area",0,T,5739
+E,CA3936000000000,"Mansfield-Ashland-Bucyrus, OH Combined Statistical Area",0,T,5740
+E,CA3953400000000,"Toledo-Port Clinton, OH Combined Statistical Area",0,T,5741
+E,CA3956600000000,"Youngstown-Warren, OH-PA Combined Statistical Area",0,T,5742
+E,CA4041600000000,"Oklahoma City-Shawnee, OK Combined Statistical Area",0,T,5946
+E,CA4053800000000,"Tulsa-Muskogee-Bartlesville, OK Combined Statistical Area",0,T,5947
+E,CA4114000000000,"Bend-Redmond-Prineville, OR Combined Statistical Area",0,T,6080
+E,CA4136600000000,"Medford-Grants Pass, OR Combined Statistical Area",0,T,6081
+E,CA4144000000000,"Portland-Vancouver-Salem, OR-WA Combined Statistical Area",0,T,6082
+E,CA4214600000000,"Bloomsburg-Berwick-Sunbury, PA Combined Statistical Area",0,T,6197
+E,CA4224000000000,"Erie-Meadville, PA Combined Statistical Area",0,T,6198
+E,CA4227600000000,"Harrisburg-York-Lebanon, PA Combined Statistical Area",0,T,6199
+E,CA4230600000000,"Johnstown-Somerset, PA Combined Statistical Area",0,T,6200
+E,CA4242800000000,"Philadelphia-Reading-Camden, PA-NJ-DE-MD Combined Statistical Area",0,T,6201
+E,CA4243000000000,"Pittsburgh-New Castle-Weirton, PA-OH-WV Combined Statistical Area",0,T,6202
+E,CA4252400000000,"State College-DuBois, PA Combined Statistical Area",0,T,6203
+E,CA4255800000000,"Williamsport-Lock Haven, PA Combined Statistical Area",0,T,6204
+E,CA4519200000000,"Columbia-Orangeburg-Newberry, SC Combined Statistical Area",0,T,6414
+E,CA4527300000000,"Greenville-Spartanburg-Anderson, SC Combined Statistical Area",0,T,6415
+E,CA4539600000000,"Myrtle Beach-Conway, SC-NC Combined Statistical Area",0,T,6416
+E,CA4645200000000,"Rapid City-Spearfish, SD Combined Statistical Area",0,T,6510
+E,CA4717400000000,"Chattanooga-Cleveland-Dalton, TN-GA-AL Combined Statistical Area",0,T,6612
+E,CA4729700000000,"Jackson-Brownsville, TN Combined Statistical Area",0,T,6613
+E,CA4730400000000,"Johnson City-Kingsport-Bristol, TN-VA Combined Statistical Area",0,T,6614
+E,CA4731400000000,"Knoxville-Morristown-Sevierville, TN Combined Statistical Area",0,T,6615
+E,CA4736200000000,"Martin-Union City, TN-KY Combined Statistical Area",0,T,6616
+E,CA4736800000000,"Memphis-Forrest City, TN-MS-AR Combined Statistical Area",0,T,6617
+E,CA4740000000000,"Nashville-Davidson--Murfreesboro, TN Combined Statistical Area",0,T,6618
+E,CA4810800000000,"Amarillo-Borger, TX Combined Statistical Area",0,T,6829
+E,CA4815400000000,"Brownsville-Harlingen-Raymondville, TX Combined Statistical Area",0,T,6830
+E,CA4820400000000,"Corpus Christi-Kingsville-Alice, TX Combined Statistical Area",0,T,6831
+E,CA4820600000000,"Dallas-Fort Worth, TX-OK Combined Statistical Area",0,T,6832
+E,CA4823800000000,"El Paso-Las Cruces, TX-NM Combined Statistical Area",0,T,6833
+E,CA4828800000000,"Houston-The Woodlands, TX Combined Statistical Area",0,T,6834
+E,CA4834600000000,"Longview-Marshall, TX Combined Statistical Area",0,T,6835
+E,CA4835200000000,"Lubbock-Levelland, TX Combined Statistical Area",0,T,6836
+E,CA4836500000000,"McAllen-Edinburg, TX Combined Statistical Area",0,T,6837
+E,CA4837200000000,"Midland-Odessa, TX Combined Statistical Area",0,T,6838
+E,CA4848400000000,"San Antonio-New Braunfels-Pearsall, TX Combined Statistical Area",0,T,6839
+E,CA4854000000000,"Tyler-Jacksonville, TX Combined Statistical Area",0,T,6840
+E,CA4854400000000,"Victoria-Port Lavaca, TX Combined Statistical Area",0,T,6841
+E,CA4948200000000,"Salt Lake City-Provo-Orem, UT Combined Statistical Area",0,T,7321
+E,CA5127700000000,"Harrisonburg-Staunton-Waynesboro, VA Combined Statistical Area",0,T,7693
+E,CA5154500000000,"Virginia Beach-Norfolk, VA-NC Combined Statistical Area",0,T,7694
+E,CA5339300000000,"Moses Lake-Othello, WA Combined Statistical Area",0,T,7902
+E,CA5344600000000,"Pullman-Moscow, WA-ID Combined Statistical Area",0,T,7903
+E,CA5350000000000,"Seattle-Tacoma, WA Combined Statistical Area",0,T,7904
+E,CA5351800000000,"Spokane-Spokane Valley-Coeur d'Alene, WA-ID Combined Statistical Area",0,T,7905
+E,CA5417000000000,"Charleston-Huntington-Ashland, WV-OH-KY Combined Statistical Area",0,T,8010
+E,CA5439000000000,"Morgantown-Fairmont, WV Combined Statistical Area",0,T,8011
+E,CA5442500000000,"Parkersburg-Marietta-Vienna, WV-OH Combined Statistical Area",0,T,8012
+E,CA5511800000000,"Appleton-Oshkosh-Neenah, WI Combined Statistical Area",0,T,8111
+E,CA5523200000000,"Eau Claire-Menomonie, WI Combined Statistical Area",0,T,8112
+E,CA5526700000000,"Green Bay-Shawano, WI Combined Statistical Area",0,T,8113
+E,CA5535700000000,"Madison-Janesville-Beloit, WI Combined Statistical Area",0,T,8114
+E,CA5537600000000,"Milwaukee-Racine-Waukesha, WI Combined Statistical Area",0,T,8115
+E,CA5555400000000,"Wausau-Stevens Point-Wisconsin Rapids, WI Combined Statistical Area",0,T,8116
+E,CA7236400000000,"Mayaguez-San German, PR Combined Statistical Area",0,T,8288
+E,CA7243400000000,"Ponce-Coamo-Santa Isabel, PR Combined Statistical Area",0,T,8289
+E,CA7249000000000,"San Juan-Carolina, PR Combined Statistical Area",0,T,8290
+F,CN0100100000000,"Autauga County, AL",0,T,31
+F,CN0100300000000,"Baldwin County, AL",0,T,32
+F,CN0100500000000,"Barbour County, AL",0,T,33
+F,CN0100700000000,"Bibb County, AL",0,T,34
+F,CN0100900000000,"Blount County, AL",0,T,35
+F,CN0101100000000,"Bullock County, AL",0,T,36
+F,CN0101300000000,"Butler County, AL",0,T,37
+F,CN0101500000000,"Calhoun County, AL",0,T,38
+F,CN0101700000000,"Chambers County, AL",0,T,39
+F,CN0101900000000,"Cherokee County, AL",0,T,40
+F,CN0102100000000,"Chilton County, AL",0,T,41
+F,CN0102300000000,"Choctaw County, AL",0,T,42
+F,CN0102500000000,"Clarke County, AL",0,T,43
+F,CN0102700000000,"Clay County, AL",0,T,44
+F,CN0102900000000,"Cleburne County, AL",0,T,45
+F,CN0103100000000,"Coffee County, AL",0,T,46
+F,CN0103300000000,"Colbert County, AL",0,T,47
+F,CN0103500000000,"Conecuh County, AL",0,T,48
+F,CN0103700000000,"Coosa County, AL",0,T,49
+F,CN0103900000000,"Covington County, AL",0,T,50
+F,CN0104100000000,"Crenshaw County, AL",0,T,51
+F,CN0104300000000,"Cullman County, AL",0,T,52
+F,CN0104500000000,"Dale County, AL",0,T,53
+F,CN0104700000000,"Dallas County, AL",0,T,54
+F,CN0104900000000,"DeKalb County, AL",0,T,55
+F,CN0105100000000,"Elmore County, AL",0,T,56
+F,CN0105300000000,"Escambia County, AL",0,T,57
+F,CN0105500000000,"Etowah County, AL",0,T,58
+F,CN0105700000000,"Fayette County, AL",0,T,59
+F,CN0105900000000,"Franklin County, AL",0,T,60
+F,CN0106100000000,"Geneva County, AL",0,T,61
+F,CN0106300000000,"Greene County, AL",0,T,62
+F,CN0106500000000,"Hale County, AL",0,T,63
+F,CN0106700000000,"Henry County, AL",0,T,64
+F,CN0106900000000,"Houston County, AL",0,T,65
+F,CN0107100000000,"Jackson County, AL",0,T,66
+F,CN0107300000000,"Jefferson County, AL",0,T,67
+F,CN0107500000000,"Lamar County, AL",0,T,68
+F,CN0107700000000,"Lauderdale County, AL",0,T,69
+F,CN0107900000000,"Lawrence County, AL",0,T,70
+F,CN0108100000000,"Lee County, AL",0,T,71
+F,CN0108300000000,"Limestone County, AL",0,T,72
+F,CN0108500000000,"Lowndes County, AL",0,T,73
+F,CN0108700000000,"Macon County, AL",0,T,74
+F,CN0108900000000,"Madison County, AL",0,T,75
+F,CN0109100000000,"Marengo County, AL",0,T,76
+F,CN0109300000000,"Marion County, AL",0,T,77
+F,CN0109500000000,"Marshall County, AL",0,T,78
+F,CN0109700000000,"Mobile County, AL",0,T,79
+F,CN0109900000000,"Monroe County, AL",0,T,80
+F,CN0110100000000,"Montgomery County, AL",0,T,81
+F,CN0110300000000,"Morgan County, AL",0,T,82
+F,CN0110500000000,"Perry County, AL",0,T,83
+F,CN0110700000000,"Pickens County, AL",0,T,84
+F,CN0110900000000,"Pike County, AL",0,T,85
+F,CN0111100000000,"Randolph County, AL",0,T,86
+F,CN0111300000000,"Russell County, AL",0,T,87
+F,CN0111500000000,"St. Clair County, AL",0,T,88
+F,CN0111700000000,"Shelby County, AL",0,T,89
+F,CN0111900000000,"Sumter County, AL",0,T,90
+F,CN0112100000000,"Talladega County, AL",0,T,91
+F,CN0112300000000,"Tallapoosa County, AL",0,T,92
+F,CN0112500000000,"Tuscaloosa County, AL",0,T,93
+F,CN0112700000000,"Walker County, AL",0,T,94
+F,CN0112900000000,"Washington County, AL",0,T,95
+F,CN0113100000000,"Wilcox County, AL",0,T,96
+F,CN0113300000000,"Winston County, AL",0,T,97
+F,CN0201300000000,"Aleutians East Borough, AK",0,T,154
+F,CN0201600000000,"Aleutians West Census Area, AK",0,T,155
+F,CN0202000000000,"Anchorage Borough/municipality, AK",0,T,156
+F,CN0205000000000,"Bethel Census Area, AK",0,T,157
+F,CN0206000000000,"Bristol Bay Borough, AK",0,T,158
+F,CN0206300000000,"Chugach Census Area, AK",0,T,159
+F,CN0206600000000,"Copper River Census Area, AK",0,T,160
+F,CN0206800000000,"Denali Borough, AK",0,T,161
+F,CN0207000000000,"Dillingham Census Area, AK",0,T,162
+F,CN0209000000000,"Fairbanks North Star Borough, AK",0,T,163
+F,CN0210000000000,"Haines Borough, AK",0,T,164
+F,CN0210500000000,"Hoonah-Angoon Census Area, AK",0,T,165
+F,CN0211000000000,"Juneau Borough/city, AK",0,T,166
+F,CN0212200000000,"Kenai Peninsula Borough, AK",0,T,167
+F,CN0213000000000,"Ketchikan Gateway Borough, AK",0,T,168
+F,CN0215000000000,"Kodiak Island Borough, AK",0,T,169
+F,CN0215800000000,"Kusilvak Census Area, AK",0,T,170
+F,CN0216400000000,"Lake and Peninsula Borough, AK",0,T,171
+F,CN0217000000000,"Matanuska-Susitna Borough, AK",0,T,172
+F,CN0218000000000,"Nome Census Area, AK",0,T,173
+F,CN0218500000000,"North Slope Borough, AK",0,T,174
+F,CN0218800000000,"Northwest Arctic Borough, AK",0,T,175
+F,CN0219500000000,"Petersburg Borough, AK",0,T,176
+F,CN0219800000000,"Prince of Wales-Hyder Census Area, AK",0,T,177
+F,CN0220100000000,"Prince of Wales-Outer Ketchikan Census Area, AK",0,T,178
+F,CN0222000000000,"Sitka Borough/city, AK",0,T,179
+F,CN0223000000000,"Skagway Municipality, AK",0,T,180
+F,CN0223200000000,"Skagway-Hoonah-Angoon Census Area, AK",0,T,181
+F,CN0224000000000,"Southeast Fairbanks Census Area, AK",0,T,182
+F,CN0226100000000,"Valdez-Cordova Census Area, AK",0,T,183
+F,CN0227500000000,"Wrangell Borough/city, AK",0,T,184
+F,CN0228000000000,"Wrangell-Petersburg Census Area, AK",0,T,185
+F,CN0228200000000,"Yakutat Borough/city, AK",0,T,186
+F,CN0229000000000,"Yukon-Koyukuk Census Area, AK",0,T,187
+F,CN0400100000000,"Apache County, AZ",0,T,206
+F,CN0400300000000,"Cochise County, AZ",0,T,207
+F,CN0400500000000,"Coconino County, AZ",0,T,208
+F,CN0400700000000,"Gila County, AZ",0,T,209
+F,CN0400900000000,"Graham County, AZ",0,T,210
+F,CN0401100000000,"Greenlee County, AZ",0,T,211
+F,CN0401200000000,"La Paz County, AZ",0,T,212
+F,CN0401300000000,"Maricopa County, AZ",0,T,213
+F,CN0401500000000,"Mohave County, AZ",0,T,214
+F,CN0401700000000,"Navajo County, AZ",0,T,215
+F,CN0401900000000,"Pima County, AZ",0,T,216
+F,CN0402100000000,"Pinal County, AZ",0,T,217
+F,CN0402300000000,"Santa Cruz County, AZ",0,T,218
+F,CN0402500000000,"Yavapai County, AZ",0,T,219
+F,CN0402700000000,"Yuma County, AZ",0,T,220
+F,CN0500100000000,"Arkansas County, AR",0,T,282
+F,CN0500300000000,"Ashley County, AR",0,T,283
+F,CN0500500000000,"Baxter County, AR",0,T,284
+F,CN0500700000000,"Benton County, AR",0,T,285
+F,CN0500900000000,"Boone County, AR",0,T,286
+F,CN0501100000000,"Bradley County, AR",0,T,287
+F,CN0501300000000,"Calhoun County, AR",0,T,288
+F,CN0501500000000,"Carroll County, AR",0,T,289
+F,CN0501700000000,"Chicot County, AR",0,T,290
+F,CN0501900000000,"Clark County, AR",0,T,291
+F,CN0502100000000,"Clay County, AR",0,T,292
+F,CN0502300000000,"Cleburne County, AR",0,T,293
+F,CN0502500000000,"Cleveland County, AR",0,T,294
+F,CN0502700000000,"Columbia County, AR",0,T,295
+F,CN0502900000000,"Conway County, AR",0,T,296
+F,CN0503100000000,"Craighead County, AR",0,T,297
+F,CN0503300000000,"Crawford County, AR",0,T,298
+F,CN0503500000000,"Crittenden County, AR",0,T,299
+F,CN0503700000000,"Cross County, AR",0,T,300
+F,CN0503900000000,"Dallas County, AR",0,T,301
+F,CN0504100000000,"Desha County, AR",0,T,302
+F,CN0504300000000,"Drew County, AR",0,T,303
+F,CN0504500000000,"Faulkner County, AR",0,T,304
+F,CN0504700000000,"Franklin County, AR",0,T,305
+F,CN0504900000000,"Fulton County, AR",0,T,306
+F,CN0505100000000,"Garland County, AR",0,T,307
+F,CN0505300000000,"Grant County, AR",0,T,308
+F,CN0505500000000,"Greene County, AR",0,T,309
+F,CN0505700000000,"Hempstead County, AR",0,T,310
+F,CN0505900000000,"Hot Spring County, AR",0,T,311
+F,CN0506100000000,"Howard County, AR",0,T,312
+F,CN0506300000000,"Independence County, AR",0,T,313
+F,CN0506500000000,"Izard County, AR",0,T,314
+F,CN0506700000000,"Jackson County, AR",0,T,315
+F,CN0506900000000,"Jefferson County, AR",0,T,316
+F,CN0507100000000,"Johnson County, AR",0,T,317
+F,CN0507300000000,"Lafayette County, AR",0,T,318
+F,CN0507500000000,"Lawrence County, AR",0,T,319
+F,CN0507700000000,"Lee County, AR",0,T,320
+F,CN0507900000000,"Lincoln County, AR",0,T,321
+F,CN0508100000000,"Little River County, AR",0,T,322
+F,CN0508300000000,"Logan County, AR",0,T,323
+F,CN0508500000000,"Lonoke County, AR",0,T,324
+F,CN0508700000000,"Madison County, AR",0,T,325
+F,CN0508900000000,"Marion County, AR",0,T,326
+F,CN0509100000000,"Miller County, AR",0,T,327
+F,CN0509300000000,"Mississippi County, AR",0,T,328
+F,CN0509500000000,"Monroe County, AR",0,T,329
+F,CN0509700000000,"Montgomery County, AR",0,T,330
+F,CN0509900000000,"Nevada County, AR",0,T,331
+F,CN0510100000000,"Newton County, AR",0,T,332
+F,CN0510300000000,"Ouachita County, AR",0,T,333
+F,CN0510500000000,"Perry County, AR",0,T,334
+F,CN0510700000000,"Phillips County, AR",0,T,335
+F,CN0510900000000,"Pike County, AR",0,T,336
+F,CN0511100000000,"Poinsett County, AR",0,T,337
+F,CN0511300000000,"Polk County, AR",0,T,338
+F,CN0511500000000,"Pope County, AR",0,T,339
+F,CN0511700000000,"Prairie County, AR",0,T,340
+F,CN0511900000000,"Pulaski County, AR",0,T,341
+F,CN0512100000000,"Randolph County, AR",0,T,342
+F,CN0512300000000,"St. Francis County, AR",0,T,343
+F,CN0512500000000,"Saline County, AR",0,T,344
+F,CN0512700000000,"Scott County, AR",0,T,345
+F,CN0512900000000,"Searcy County, AR",0,T,346
+F,CN0513100000000,"Sebastian County, AR",0,T,347
+F,CN0513300000000,"Sevier County, AR",0,T,348
+F,CN0513500000000,"Sharp County, AR",0,T,349
+F,CN0513700000000,"Stone County, AR",0,T,350
+F,CN0513900000000,"Union County, AR",0,T,351
+F,CN0514100000000,"Van Buren County, AR",0,T,352
+F,CN0514300000000,"Washington County, AR",0,T,353
+F,CN0514500000000,"White County, AR",0,T,354
+F,CN0514700000000,"Woodruff County, AR",0,T,355
+F,CN0514900000000,"Yell County, AR",0,T,356
+F,CN0600100000000,"Alameda County, CA",0,T,430
+F,CN0600300000000,"Alpine County, CA",0,T,431
+F,CN0600500000000,"Amador County, CA",0,T,432
+F,CN0600700000000,"Butte County, CA",0,T,433
+F,CN0600900000000,"Calaveras County, CA",0,T,434
+F,CN0601100000000,"Colusa County, CA",0,T,435
+F,CN0601300000000,"Contra Costa County, CA",0,T,436
+F,CN0601500000000,"Del Norte County, CA",0,T,437
+F,CN0601700000000,"El Dorado County, CA",0,T,438
+F,CN0601900000000,"Fresno County, CA",0,T,439
+F,CN0602100000000,"Glenn County, CA",0,T,440
+F,CN0602300000000,"Humboldt County, CA",0,T,441
+F,CN0602500000000,"Imperial County, CA",0,T,442
+F,CN0602700000000,"Inyo County, CA",0,T,443
+F,CN0602900000000,"Kern County, CA",0,T,444
+F,CN0603100000000,"Kings County, CA",0,T,445
+F,CN0603300000000,"Lake County, CA",0,T,446
+F,CN0603500000000,"Lassen County, CA",0,T,447
+F,CN0603700000000,"Los Angeles County, CA",0,T,448
+F,CN0603900000000,"Madera County, CA",0,T,449
+F,CN0604100000000,"Marin County, CA",0,T,450
+F,CN0604300000000,"Mariposa County, CA",0,T,451
+F,CN0604500000000,"Mendocino County, CA",0,T,452
+F,CN0604700000000,"Merced County, CA",0,T,453
+F,CN0604900000000,"Modoc County, CA",0,T,454
+F,CN0605100000000,"Mono County, CA",0,T,455
+F,CN0605300000000,"Monterey County, CA",0,T,456
+F,CN0605500000000,"Napa County, CA",0,T,457
+F,CN0605700000000,"Nevada County, CA",0,T,458
+F,CN0605900000000,"Orange County, CA",0,T,459
+F,CN0606100000000,"Placer County, CA",0,T,460
+F,CN0606300000000,"Plumas County, CA",0,T,461
+F,CN0606500000000,"Riverside County, CA",0,T,462
+F,CN0606700000000,"Sacramento County, CA",0,T,463
+F,CN0606900000000,"San Benito County, CA",0,T,464
+F,CN0607100000000,"San Bernardino County, CA",0,T,465
+F,CN0607300000000,"San Diego County, CA",0,T,466
+F,CN0607500000000,"San Francisco County/city, CA",0,T,467
+F,CN0607700000000,"San Joaquin County, CA",0,T,468
+F,CN0607900000000,"San Luis Obispo County, CA",0,T,469
+F,CN0608100000000,"San Mateo County, CA",0,T,470
+F,CN0608300000000,"Santa Barbara County, CA",0,T,471
+F,CN0608500000000,"Santa Clara County, CA",0,T,472
+F,CN0608700000000,"Santa Cruz County, CA",0,T,473
+F,CN0608900000000,"Shasta County, CA",0,T,474
+F,CN0609100000000,"Sierra County, CA",0,T,475
+F,CN0609300000000,"Siskiyou County, CA",0,T,476
+F,CN0609500000000,"Solano County, CA",0,T,477
+F,CN0609700000000,"Sonoma County, CA",0,T,478
+F,CN0609900000000,"Stanislaus County, CA",0,T,479
+F,CN0610100000000,"Sutter County, CA",0,T,480
+F,CN0610300000000,"Tehama County, CA",0,T,481
+F,CN0610500000000,"Trinity County, CA",0,T,482
+F,CN0610700000000,"Tulare County, CA",0,T,483
+F,CN0610900000000,"Tuolumne County, CA",0,T,484
+F,CN0611100000000,"Ventura County, CA",0,T,485
+F,CN0611300000000,"Yolo County, CA",0,T,486
+F,CN0611500000000,"Yuba County, CA",0,T,487
+F,CN0800100000000,"Adams County, CO",0,T,794
+F,CN0800300000000,"Alamosa County, CO",0,T,795
+F,CN0800500000000,"Arapahoe County, CO",0,T,796
+F,CN0800700000000,"Archuleta County, CO",0,T,797
+F,CN0800900000000,"Baca County, CO",0,T,798
+F,CN0801100000000,"Bent County, CO",0,T,799
+F,CN0801300000000,"Boulder County, CO",0,T,800
+F,CN0801400000000,"Broomfield County/city, CO",0,T,801
+F,CN0801500000000,"Chaffee County, CO",0,T,802
+F,CN0801700000000,"Cheyenne County, CO",0,T,803
+F,CN0801900000000,"Clear Creek County, CO",0,T,804
+F,CN0802100000000,"Conejos County, CO",0,T,805
+F,CN0802300000000,"Costilla County, CO",0,T,806
+F,CN0802500000000,"Crowley County, CO",0,T,807
+F,CN0802700000000,"Custer County, CO",0,T,808
+F,CN0802900000000,"Delta County, CO",0,T,809
+F,CN0803100000000,"Denver County/city, CO",0,T,810
+F,CN0803300000000,"Dolores County, CO",0,T,811
+F,CN0803500000000,"Douglas County, CO",0,T,812
+F,CN0803700000000,"Eagle County, CO",0,T,813
+F,CN0803900000000,"Elbert County, CO",0,T,814
+F,CN0804100000000,"El Paso County, CO",0,T,815
+F,CN0804300000000,"Fremont County, CO",0,T,816
+F,CN0804500000000,"Garfield County, CO",0,T,817
+F,CN0804700000000,"Gilpin County, CO",0,T,818
+F,CN0804900000000,"Grand County, CO",0,T,819
+F,CN0805100000000,"Gunnison County, CO",0,T,820
+F,CN0805300000000,"Hinsdale County, CO",0,T,821
+F,CN0805500000000,"Huerfano County, CO",0,T,822
+F,CN0805700000000,"Jackson County, CO",0,T,823
+F,CN0805900000000,"Jefferson County, CO",0,T,824
+F,CN0806100000000,"Kiowa County, CO",0,T,825
+F,CN0806300000000,"Kit Carson County, CO",0,T,826
+F,CN0806500000000,"Lake County, CO",0,T,827
+F,CN0806700000000,"La Plata County, CO",0,T,828
+F,CN0806900000000,"Larimer County, CO",0,T,829
+F,CN0807100000000,"Las Animas County, CO",0,T,830
+F,CN0807300000000,"Lincoln County, CO",0,T,831
+F,CN0807500000000,"Logan County, CO",0,T,832
+F,CN0807700000000,"Mesa County, CO",0,T,833
+F,CN0807900000000,"Mineral County, CO",0,T,834
+F,CN0808100000000,"Moffat County, CO",0,T,835
+F,CN0808300000000,"Montezuma County, CO",0,T,836
+F,CN0808500000000,"Montrose County, CO",0,T,837
+F,CN0808700000000,"Morgan County, CO",0,T,838
+F,CN0808900000000,"Otero County, CO",0,T,839
+F,CN0809100000000,"Ouray County, CO",0,T,840
+F,CN0809300000000,"Park County, CO",0,T,841
+F,CN0809500000000,"Phillips County, CO",0,T,842
+F,CN0809700000000,"Pitkin County, CO",0,T,843
+F,CN0809900000000,"Prowers County, CO",0,T,844
+F,CN0810100000000,"Pueblo County, CO",0,T,845
+F,CN0810300000000,"Rio Blanco County, CO",0,T,846
+F,CN0810500000000,"Rio Grande County, CO",0,T,847
+F,CN0810700000000,"Routt County, CO",0,T,848
+F,CN0810900000000,"Saguache County, CO",0,T,849
+F,CN0811100000000,"San Juan County, CO",0,T,850
+F,CN0811300000000,"San Miguel County, CO",0,T,851
+F,CN0811500000000,"Sedgwick County, CO",0,T,852
+F,CN0811700000000,"Summit County, CO",0,T,853
+F,CN0811900000000,"Teller County, CO",0,T,854
+F,CN0812100000000,"Washington County, CO",0,T,855
+F,CN0812300000000,"Weld County, CO",0,T,856
+F,CN0812500000000,"Yuma County, CO",0,T,857
+F,CN0900100000000,"Fairfield County, CT",0,T,918
+F,CN0900300000000,"Hartford County, CT",0,T,919
+F,CN0900500000000,"Litchfield County, CT",0,T,920
+F,CN0900700000000,"Middlesex County, CT",0,T,921
+F,CN0900900000000,"New Haven County, CT",0,T,922
+F,CN0901100000000,"New London County, CT",0,T,923
+F,CN0901300000000,"Tolland County, CT",0,T,924
+F,CN0901500000000,"Windham County, CT",0,T,925
+F,CN1000100000000,"Kent County, DE",0,T,1104
+F,CN1000300000000,"New Castle County, DE",0,T,1105
+F,CN1000500000000,"Sussex County, DE",0,T,1106
+F,CN1100100000000,District of Columbia,0,T,1116
+F,CN1200100000000,"Alachua County, FL",0,T,1160
+F,CN1200300000000,"Baker County, FL",0,T,1161
+F,CN1200500000000,"Bay County, FL",0,T,1162
+F,CN1200700000000,"Bradford County, FL",0,T,1163
+F,CN1200900000000,"Brevard County, FL",0,T,1164
+F,CN1201100000000,"Broward County, FL",0,T,1165
+F,CN1201300000000,"Calhoun County, FL",0,T,1166
+F,CN1201500000000,"Charlotte County, FL",0,T,1167
+F,CN1201700000000,"Citrus County, FL",0,T,1168
+F,CN1201900000000,"Clay County, FL",0,T,1169
+F,CN1202100000000,"Collier County, FL",0,T,1170
+F,CN1202300000000,"Columbia County, FL",0,T,1171
+F,CN1202700000000,"DeSoto County, FL",0,T,1172
+F,CN1202900000000,"Dixie County, FL",0,T,1173
+F,CN1203100000000,"Duval County, FL",0,T,1174
+F,CN1203300000000,"Escambia County, FL",0,T,1175
+F,CN1203500000000,"Flagler County, FL",0,T,1176
+F,CN1203700000000,"Franklin County, FL",0,T,1177
+F,CN1203900000000,"Gadsden County, FL",0,T,1178
+F,CN1204100000000,"Gilchrist County, FL",0,T,1179
+F,CN1204300000000,"Glades County, FL",0,T,1180
+F,CN1204500000000,"Gulf County, FL",0,T,1181
+F,CN1204700000000,"Hamilton County, FL",0,T,1182
+F,CN1204900000000,"Hardee County, FL",0,T,1183
+F,CN1205100000000,"Hendry County, FL",0,T,1184
+F,CN1205300000000,"Hernando County, FL",0,T,1185
+F,CN1205500000000,"Highlands County, FL",0,T,1186
+F,CN1205700000000,"Hillsborough County, FL",0,T,1187
+F,CN1205900000000,"Holmes County, FL",0,T,1188
+F,CN1206100000000,"Indian River County, FL",0,T,1189
+F,CN1206300000000,"Jackson County, FL",0,T,1190
+F,CN1206500000000,"Jefferson County, FL",0,T,1191
+F,CN1206700000000,"Lafayette County, FL",0,T,1192
+F,CN1206900000000,"Lake County, FL",0,T,1193
+F,CN1207100000000,"Lee County, FL",0,T,1194
+F,CN1207300000000,"Leon County, FL",0,T,1195
+F,CN1207500000000,"Levy County, FL",0,T,1196
+F,CN1207700000000,"Liberty County, FL",0,T,1197
+F,CN1207900000000,"Madison County, FL",0,T,1198
+F,CN1208100000000,"Manatee County, FL",0,T,1199
+F,CN1208300000000,"Marion County, FL",0,T,1200
+F,CN1208500000000,"Martin County, FL",0,T,1201
+F,CN1208600000000,"Miami-Dade County, FL",0,T,1202
+F,CN1208700000000,"Monroe County, FL",0,T,1203
+F,CN1208900000000,"Nassau County, FL",0,T,1204
+F,CN1209100000000,"Okaloosa County, FL",0,T,1205
+F,CN1209300000000,"Okeechobee County, FL",0,T,1206
+F,CN1209500000000,"Orange County, FL",0,T,1207
+F,CN1209700000000,"Osceola County, FL",0,T,1208
+F,CN1209900000000,"Palm Beach County, FL",0,T,1209
+F,CN1210100000000,"Pasco County, FL",0,T,1210
+F,CN1210300000000,"Pinellas County, FL",0,T,1211
+F,CN1210500000000,"Polk County, FL",0,T,1212
+F,CN1210700000000,"Putnam County, FL",0,T,1213
+F,CN1210900000000,"St. Johns County, FL",0,T,1214
+F,CN1211100000000,"St. Lucie County, FL",0,T,1215
+F,CN1211300000000,"Santa Rosa County, FL",0,T,1216
+F,CN1211500000000,"Sarasota County, FL",0,T,1217
+F,CN1211700000000,"Seminole County, FL",0,T,1218
+F,CN1211900000000,"Sumter County, FL",0,T,1219
+F,CN1212100000000,"Suwannee County, FL",0,T,1220
+F,CN1212300000000,"Taylor County, FL",0,T,1221
+F,CN1212500000000,"Union County, FL",0,T,1222
+F,CN1212700000000,"Volusia County, FL",0,T,1223
+F,CN1212900000000,"Wakulla County, FL",0,T,1224
+F,CN1213100000000,"Walton County, FL",0,T,1225
+F,CN1213300000000,"Washington County, FL",0,T,1226
+F,CN1300100000000,"Appling County, GA",0,T,1374
+F,CN1300300000000,"Atkinson County, GA",0,T,1375
+F,CN1300500000000,"Bacon County, GA",0,T,1376
+F,CN1300700000000,"Baker County, GA",0,T,1377
+F,CN1300900000000,"Baldwin County, GA",0,T,1378
+F,CN1301100000000,"Banks County, GA",0,T,1379
+F,CN1301300000000,"Barrow County, GA",0,T,1380
+F,CN1301500000000,"Bartow County, GA",0,T,1381
+F,CN1301700000000,"Ben Hill County, GA",0,T,1382
+F,CN1301900000000,"Berrien County, GA",0,T,1383
+F,CN1302100000000,"Bibb County, GA",0,T,1384
+F,CN1302300000000,"Bleckley County, GA",0,T,1385
+F,CN1302500000000,"Brantley County, GA",0,T,1386
+F,CN1302700000000,"Brooks County, GA",0,T,1387
+F,CN1302900000000,"Bryan County, GA",0,T,1388
+F,CN1303100000000,"Bulloch County, GA",0,T,1389
+F,CN1303300000000,"Burke County, GA",0,T,1390
+F,CN1303500000000,"Butts County, GA",0,T,1391
+F,CN1303700000000,"Calhoun County, GA",0,T,1392
+F,CN1303900000000,"Camden County, GA",0,T,1393
+F,CN1304300000000,"Candler County, GA",0,T,1394
+F,CN1304500000000,"Carroll County, GA",0,T,1395
+F,CN1304700000000,"Catoosa County, GA",0,T,1396
+F,CN1304900000000,"Charlton County, GA",0,T,1397
+F,CN1305100000000,"Chatham County, GA",0,T,1398
+F,CN1305300000000,"Chattahoochee County, GA",0,T,1399
+F,CN1305500000000,"Chattooga County, GA",0,T,1400
+F,CN1305700000000,"Cherokee County, GA",0,T,1401
+F,CN1305900000000,"Clarke County, GA",0,T,1402
+F,CN1306100000000,"Clay County, GA",0,T,1403
+F,CN1306300000000,"Clayton County, GA",0,T,1404
+F,CN1306500000000,"Clinch County, GA",0,T,1405
+F,CN1306700000000,"Cobb County, GA",0,T,1406
+F,CN1306900000000,"Coffee County, GA",0,T,1407
+F,CN1307100000000,"Colquitt County, GA",0,T,1408
+F,CN1307300000000,"Columbia County, GA",0,T,1409
+F,CN1307500000000,"Cook County, GA",0,T,1410
+F,CN1307700000000,"Coweta County, GA",0,T,1411
+F,CN1307900000000,"Crawford County, GA",0,T,1412
+F,CN1308100000000,"Crisp County, GA",0,T,1413
+F,CN1308300000000,"Dade County, GA",0,T,1414
+F,CN1308500000000,"Dawson County, GA",0,T,1415
+F,CN1308700000000,"Decatur County, GA",0,T,1416
+F,CN1308900000000,"DeKalb County, GA",0,T,1417
+F,CN1309100000000,"Dodge County, GA",0,T,1418
+F,CN1309300000000,"Dooly County, GA",0,T,1419
+F,CN1309500000000,"Dougherty County, GA",0,T,1420
+F,CN1309700000000,"Douglas County, GA",0,T,1421
+F,CN1309900000000,"Early County, GA",0,T,1422
+F,CN1310100000000,"Echols County, GA",0,T,1423
+F,CN1310300000000,"Effingham County, GA",0,T,1424
+F,CN1310500000000,"Elbert County, GA",0,T,1425
+F,CN1310700000000,"Emanuel County, GA",0,T,1426
+F,CN1310900000000,"Evans County, GA",0,T,1427
+F,CN1311100000000,"Fannin County, GA",0,T,1428
+F,CN1311300000000,"Fayette County, GA",0,T,1429
+F,CN1311500000000,"Floyd County, GA",0,T,1430
+F,CN1311700000000,"Forsyth County, GA",0,T,1431
+F,CN1311900000000,"Franklin County, GA",0,T,1432
+F,CN1312100000000,"Fulton County, GA",0,T,1433
+F,CN1312300000000,"Gilmer County, GA",0,T,1434
+F,CN1312500000000,"Glascock County, GA",0,T,1435
+F,CN1312700000000,"Glynn County, GA",0,T,1436
+F,CN1312900000000,"Gordon County, GA",0,T,1437
+F,CN1313100000000,"Grady County, GA",0,T,1438
+F,CN1313300000000,"Greene County, GA",0,T,1439
+F,CN1313500000000,"Gwinnett County, GA",0,T,1440
+F,CN1313700000000,"Habersham County, GA",0,T,1441
+F,CN1313900000000,"Hall County, GA",0,T,1442
+F,CN1314100000000,"Hancock County, GA",0,T,1443
+F,CN1314300000000,"Haralson County, GA",0,T,1444
+F,CN1314500000000,"Harris County, GA",0,T,1445
+F,CN1314700000000,"Hart County, GA",0,T,1446
+F,CN1314900000000,"Heard County, GA",0,T,1447
+F,CN1315100000000,"Henry County, GA",0,T,1448
+F,CN1315300000000,"Houston County, GA",0,T,1449
+F,CN1315500000000,"Irwin County, GA",0,T,1450
+F,CN1315700000000,"Jackson County, GA",0,T,1451
+F,CN1315900000000,"Jasper County, GA",0,T,1452
+F,CN1316100000000,"Jeff Davis County, GA",0,T,1453
+F,CN1316300000000,"Jefferson County, GA",0,T,1454
+F,CN1316500000000,"Jenkins County, GA",0,T,1455
+F,CN1316700000000,"Johnson County, GA",0,T,1456
+F,CN1316900000000,"Jones County, GA",0,T,1457
+F,CN1317100000000,"Lamar County, GA",0,T,1458
+F,CN1317300000000,"Lanier County, GA",0,T,1459
+F,CN1317500000000,"Laurens County, GA",0,T,1460
+F,CN1317700000000,"Lee County, GA",0,T,1461
+F,CN1317900000000,"Liberty County, GA",0,T,1462
+F,CN1318100000000,"Lincoln County, GA",0,T,1463
+F,CN1318300000000,"Long County, GA",0,T,1464
+F,CN1318500000000,"Lowndes County, GA",0,T,1465
+F,CN1318700000000,"Lumpkin County, GA",0,T,1466
+F,CN1318900000000,"McDuffie County, GA",0,T,1467
+F,CN1319100000000,"McIntosh County, GA",0,T,1468
+F,CN1319300000000,"Macon County, GA",0,T,1469
+F,CN1319500000000,"Madison County, GA",0,T,1470
+F,CN1319700000000,"Marion County, GA",0,T,1471
+F,CN1319900000000,"Meriwether County, GA",0,T,1472
+F,CN1320100000000,"Miller County, GA",0,T,1473
+F,CN1320500000000,"Mitchell County, GA",0,T,1474
+F,CN1320700000000,"Monroe County, GA",0,T,1475
+F,CN1320900000000,"Montgomery County, GA",0,T,1476
+F,CN1321100000000,"Morgan County, GA",0,T,1477
+F,CN1321300000000,"Murray County, GA",0,T,1478
+F,CN1321500000000,"Muscogee County, GA",0,T,1479
+F,CN1321700000000,"Newton County, GA",0,T,1480
+F,CN1321900000000,"Oconee County, GA",0,T,1481
+F,CN1322100000000,"Oglethorpe County, GA",0,T,1482
+F,CN1322300000000,"Paulding County, GA",0,T,1483
+F,CN1322500000000,"Peach County, GA",0,T,1484
+F,CN1322700000000,"Pickens County, GA",0,T,1485
+F,CN1322900000000,"Pierce County, GA",0,T,1486
+F,CN1323100000000,"Pike County, GA",0,T,1487
+F,CN1323300000000,"Polk County, GA",0,T,1488
+F,CN1323500000000,"Pulaski County, GA",0,T,1489
+F,CN1323700000000,"Putnam County, GA",0,T,1490
+F,CN1323900000000,"Quitman County, GA",0,T,1491
+F,CN1324100000000,"Rabun County, GA",0,T,1492
+F,CN1324300000000,"Randolph County, GA",0,T,1493
+F,CN1324500000000,"Richmond County, GA",0,T,1494
+F,CN1324700000000,"Rockdale County, GA",0,T,1495
+F,CN1324900000000,"Schley County, GA",0,T,1496
+F,CN1325100000000,"Screven County, GA",0,T,1497
+F,CN1325300000000,"Seminole County, GA",0,T,1498
+F,CN1325500000000,"Spalding County, GA",0,T,1499
+F,CN1325700000000,"Stephens County, GA",0,T,1500
+F,CN1325900000000,"Stewart County, GA",0,T,1501
+F,CN1326100000000,"Sumter County, GA",0,T,1502
+F,CN1326300000000,"Talbot County, GA",0,T,1503
+F,CN1326500000000,"Taliaferro County, GA",0,T,1504
+F,CN1326700000000,"Tattnall County, GA",0,T,1505
+F,CN1326900000000,"Taylor County, GA",0,T,1506
+F,CN1327100000000,"Telfair County, GA",0,T,1507
+F,CN1327300000000,"Terrell County, GA",0,T,1508
+F,CN1327500000000,"Thomas County, GA",0,T,1509
+F,CN1327700000000,"Tift County, GA",0,T,1510
+F,CN1327900000000,"Toombs County, GA",0,T,1511
+F,CN1328100000000,"Towns County, GA",0,T,1512
+F,CN1328300000000,"Treutlen County, GA",0,T,1513
+F,CN1328500000000,"Troup County, GA",0,T,1514
+F,CN1328700000000,"Turner County, GA",0,T,1515
+F,CN1328900000000,"Twiggs County, GA",0,T,1516
+F,CN1329100000000,"Union County, GA",0,T,1517
+F,CN1329300000000,"Upson County, GA",0,T,1518
+F,CN1329500000000,"Walker County, GA",0,T,1519
+F,CN1329700000000,"Walton County, GA",0,T,1520
+F,CN1329900000000,"Ware County, GA",0,T,1521
+F,CN1330100000000,"Warren County, GA",0,T,1522
+F,CN1330300000000,"Washington County, GA",0,T,1523
+F,CN1330500000000,"Wayne County, GA",0,T,1524
+F,CN1330700000000,"Webster County, GA",0,T,1525
+F,CN1330900000000,"Wheeler County, GA",0,T,1526
+F,CN1331100000000,"White County, GA",0,T,1527
+F,CN1331300000000,"Whitfield County, GA",0,T,1528
+F,CN1331500000000,"Wilcox County, GA",0,T,1529
+F,CN1331700000000,"Wilkes County, GA",0,T,1530
+F,CN1331900000000,"Wilkinson County, GA",0,T,1531
+F,CN1332100000000,"Worth County, GA",0,T,1532
+F,CN1500100000000,"Hawaii County, HI",0,T,1590
+F,CN1500300000000,"Honolulu County/city, HI",0,T,1591
+F,CN1500700000000,"Kauai County, HI",0,T,1592
+F,CN1500900000000,"Maui County, HI",0,T,1593
+F,CN1600100000000,"Ada County, ID",0,T,1611
+F,CN1600300000000,"Adams County, ID",0,T,1612
+F,CN1600500000000,"Bannock County, ID",0,T,1613
+F,CN1600700000000,"Bear Lake County, ID",0,T,1614
+F,CN1600900000000,"Benewah County, ID",0,T,1615
+F,CN1601100000000,"Bingham County, ID",0,T,1616
+F,CN1601300000000,"Blaine County, ID",0,T,1617
+F,CN1601500000000,"Boise County, ID",0,T,1618
+F,CN1601700000000,"Bonner County, ID",0,T,1619
+F,CN1601900000000,"Bonneville County, ID",0,T,1620
+F,CN1602100000000,"Boundary County, ID",0,T,1621
+F,CN1602300000000,"Butte County, ID",0,T,1622
+F,CN1602500000000,"Camas County, ID",0,T,1623
+F,CN1602700000000,"Canyon County, ID",0,T,1624
+F,CN1602900000000,"Caribou County, ID",0,T,1625
+F,CN1603100000000,"Cassia County, ID",0,T,1626
+F,CN1603300000000,"Clark County, ID",0,T,1627
+F,CN1603500000000,"Clearwater County, ID",0,T,1628
+F,CN1603700000000,"Custer County, ID",0,T,1629
+F,CN1603900000000,"Elmore County, ID",0,T,1630
+F,CN1604100000000,"Franklin County, ID",0,T,1631
+F,CN1604300000000,"Fremont County, ID",0,T,1632
+F,CN1604500000000,"Gem County, ID",0,T,1633
+F,CN1604700000000,"Gooding County, ID",0,T,1634
+F,CN1604900000000,"Idaho County, ID",0,T,1635
+F,CN1605100000000,"Jefferson County, ID",0,T,1636
+F,CN1605300000000,"Jerome County, ID",0,T,1637
+F,CN1605500000000,"Kootenai County, ID",0,T,1638
+F,CN1605700000000,"Latah County, ID",0,T,1639
+F,CN1605900000000,"Lemhi County, ID",0,T,1640
+F,CN1606100000000,"Lewis County, ID",0,T,1641
+F,CN1606300000000,"Lincoln County, ID",0,T,1642
+F,CN1606500000000,"Madison County, ID",0,T,1643
+F,CN1606700000000,"Minidoka County, ID",0,T,1644
+F,CN1606900000000,"Nez Perce County, ID",0,T,1645
+F,CN1607100000000,"Oneida County, ID",0,T,1646
+F,CN1607300000000,"Owyhee County, ID",0,T,1647
+F,CN1607500000000,"Payette County, ID",0,T,1648
+F,CN1607700000000,"Power County, ID",0,T,1649
+F,CN1607900000000,"Shoshone County, ID",0,T,1650
+F,CN1608100000000,"Teton County, ID",0,T,1651
+F,CN1608300000000,"Twin Falls County, ID",0,T,1652
+F,CN1608500000000,"Valley County, ID",0,T,1653
+F,CN1608700000000,"Washington County, ID",0,T,1654
+F,CN1700100000000,"Adams County, IL",0,T,1715
+F,CN1700300000000,"Alexander County, IL",0,T,1716
+F,CN1700500000000,"Bond County, IL",0,T,1717
+F,CN1700700000000,"Boone County, IL",0,T,1718
+F,CN1700900000000,"Brown County, IL",0,T,1719
+F,CN1701100000000,"Bureau County, IL",0,T,1720
+F,CN1701300000000,"Calhoun County, IL",0,T,1721
+F,CN1701500000000,"Carroll County, IL",0,T,1722
+F,CN1701700000000,"Cass County, IL",0,T,1723
+F,CN1701900000000,"Champaign County, IL",0,T,1724
+F,CN1702100000000,"Christian County, IL",0,T,1725
+F,CN1702300000000,"Clark County, IL",0,T,1726
+F,CN1702500000000,"Clay County, IL",0,T,1727
+F,CN1702700000000,"Clinton County, IL",0,T,1728
+F,CN1702900000000,"Coles County, IL",0,T,1729
+F,CN1703100000000,"Cook County, IL",0,T,1730
+F,CN1703300000000,"Crawford County, IL",0,T,1731
+F,CN1703500000000,"Cumberland County, IL",0,T,1732
+F,CN1703700000000,"DeKalb County, IL",0,T,1733
+F,CN1703900000000,"De Witt County, IL",0,T,1734
+F,CN1704100000000,"Douglas County, IL",0,T,1735
+F,CN1704300000000,"DuPage County, IL",0,T,1736
+F,CN1704500000000,"Edgar County, IL",0,T,1737
+F,CN1704700000000,"Edwards County, IL",0,T,1738
+F,CN1704900000000,"Effingham County, IL",0,T,1739
+F,CN1705100000000,"Fayette County, IL",0,T,1740
+F,CN1705300000000,"Ford County, IL",0,T,1741
+F,CN1705500000000,"Franklin County, IL",0,T,1742
+F,CN1705700000000,"Fulton County, IL",0,T,1743
+F,CN1705900000000,"Gallatin County, IL",0,T,1744
+F,CN1706100000000,"Greene County, IL",0,T,1745
+F,CN1706300000000,"Grundy County, IL",0,T,1746
+F,CN1706500000000,"Hamilton County, IL",0,T,1747
+F,CN1706700000000,"Hancock County, IL",0,T,1748
+F,CN1706900000000,"Hardin County, IL",0,T,1749
+F,CN1707100000000,"Henderson County, IL",0,T,1750
+F,CN1707300000000,"Henry County, IL",0,T,1751
+F,CN1707500000000,"Iroquois County, IL",0,T,1752
+F,CN1707700000000,"Jackson County, IL",0,T,1753
+F,CN1707900000000,"Jasper County, IL",0,T,1754
+F,CN1708100000000,"Jefferson County, IL",0,T,1755
+F,CN1708300000000,"Jersey County, IL",0,T,1756
+F,CN1708500000000,"Jo Daviess County, IL",0,T,1757
+F,CN1708700000000,"Johnson County, IL",0,T,1758
+F,CN1708900000000,"Kane County, IL",0,T,1759
+F,CN1709100000000,"Kankakee County, IL",0,T,1760
+F,CN1709300000000,"Kendall County, IL",0,T,1761
+F,CN1709500000000,"Knox County, IL",0,T,1762
+F,CN1709700000000,"Lake County, IL",0,T,1763
+F,CN1709900000000,"LaSalle County, IL",0,T,1764
+F,CN1710100000000,"Lawrence County, IL",0,T,1765
+F,CN1710300000000,"Lee County, IL",0,T,1766
+F,CN1710500000000,"Livingston County, IL",0,T,1767
+F,CN1710700000000,"Logan County, IL",0,T,1768
+F,CN1710900000000,"McDonough County, IL",0,T,1769
+F,CN1711100000000,"McHenry County, IL",0,T,1770
+F,CN1711300000000,"McLean County, IL",0,T,1771
+F,CN1711500000000,"Macon County, IL",0,T,1772
+F,CN1711700000000,"Macoupin County, IL",0,T,1773
+F,CN1711900000000,"Madison County, IL",0,T,1774
+F,CN1712100000000,"Marion County, IL",0,T,1775
+F,CN1712300000000,"Marshall County, IL",0,T,1776
+F,CN1712500000000,"Mason County, IL",0,T,1777
+F,CN1712700000000,"Massac County, IL",0,T,1778
+F,CN1712900000000,"Menard County, IL",0,T,1779
+F,CN1713100000000,"Mercer County, IL",0,T,1780
+F,CN1713300000000,"Monroe County, IL",0,T,1781
+F,CN1713500000000,"Montgomery County, IL",0,T,1782
+F,CN1713700000000,"Morgan County, IL",0,T,1783
+F,CN1713900000000,"Moultrie County, IL",0,T,1784
+F,CN1714100000000,"Ogle County, IL",0,T,1785
+F,CN1714300000000,"Peoria County, IL",0,T,1786
+F,CN1714500000000,"Perry County, IL",0,T,1787
+F,CN1714700000000,"Piatt County, IL",0,T,1788
+F,CN1714900000000,"Pike County, IL",0,T,1789
+F,CN1715100000000,"Pope County, IL",0,T,1790
+F,CN1715300000000,"Pulaski County, IL",0,T,1791
+F,CN1715500000000,"Putnam County, IL",0,T,1792
+F,CN1715700000000,"Randolph County, IL",0,T,1793
+F,CN1715900000000,"Richland County, IL",0,T,1794
+F,CN1716100000000,"Rock Island County, IL",0,T,1795
+F,CN1716300000000,"St. Clair County, IL",0,T,1796
+F,CN1716500000000,"Saline County, IL",0,T,1797
+F,CN1716700000000,"Sangamon County, IL",0,T,1798
+F,CN1716900000000,"Schuyler County, IL",0,T,1799
+F,CN1717100000000,"Scott County, IL",0,T,1800
+F,CN1717300000000,"Shelby County, IL",0,T,1801
+F,CN1717500000000,"Stark County, IL",0,T,1802
+F,CN1717700000000,"Stephenson County, IL",0,T,1803
+F,CN1717900000000,"Tazewell County, IL",0,T,1804
+F,CN1718100000000,"Union County, IL",0,T,1805
+F,CN1718300000000,"Vermilion County, IL",0,T,1806
+F,CN1718500000000,"Wabash County, IL",0,T,1807
+F,CN1718700000000,"Warren County, IL",0,T,1808
+F,CN1718900000000,"Washington County, IL",0,T,1809
+F,CN1719100000000,"Wayne County, IL",0,T,1810
+F,CN1719300000000,"White County, IL",0,T,1811
+F,CN1719500000000,"Whiteside County, IL",0,T,1812
+F,CN1719700000000,"Will County, IL",0,T,1813
+F,CN1719900000000,"Williamson County, IL",0,T,1814
+F,CN1720100000000,"Winnebago County, IL",0,T,1815
+F,CN1720300000000,"Woodford County, IL",0,T,1816
+F,CN1800100000000,"Adams County, IN",0,T,2006
+F,CN1800300000000,"Allen County, IN",0,T,2007
+F,CN1800500000000,"Bartholomew County, IN",0,T,2008
+F,CN1800700000000,"Benton County, IN",0,T,2009
+F,CN1800900000000,"Blackford County, IN",0,T,2010
+F,CN1801100000000,"Boone County, IN",0,T,2011
+F,CN1801300000000,"Brown County, IN",0,T,2012
+F,CN1801500000000,"Carroll County, IN",0,T,2013
+F,CN1801700000000,"Cass County, IN",0,T,2014
+F,CN1801900000000,"Clark County, IN",0,T,2015
+F,CN1802100000000,"Clay County, IN",0,T,2016
+F,CN1802300000000,"Clinton County, IN",0,T,2017
+F,CN1802500000000,"Crawford County, IN",0,T,2018
+F,CN1802700000000,"Daviess County, IN",0,T,2019
+F,CN1802900000000,"Dearborn County, IN",0,T,2020
+F,CN1803100000000,"Decatur County, IN",0,T,2021
+F,CN1803300000000,"DeKalb County, IN",0,T,2022
+F,CN1803500000000,"Delaware County, IN",0,T,2023
+F,CN1803700000000,"Dubois County, IN",0,T,2024
+F,CN1803900000000,"Elkhart County, IN",0,T,2025
+F,CN1804100000000,"Fayette County, IN",0,T,2026
+F,CN1804300000000,"Floyd County, IN",0,T,2027
+F,CN1804500000000,"Fountain County, IN",0,T,2028
+F,CN1804700000000,"Franklin County, IN",0,T,2029
+F,CN1804900000000,"Fulton County, IN",0,T,2030
+F,CN1805100000000,"Gibson County, IN",0,T,2031
+F,CN1805300000000,"Grant County, IN",0,T,2032
+F,CN1805500000000,"Greene County, IN",0,T,2033
+F,CN1805700000000,"Hamilton County, IN",0,T,2034
+F,CN1805900000000,"Hancock County, IN",0,T,2035
+F,CN1806100000000,"Harrison County, IN",0,T,2036
+F,CN1806300000000,"Hendricks County, IN",0,T,2037
+F,CN1806500000000,"Henry County, IN",0,T,2038
+F,CN1806700000000,"Howard County, IN",0,T,2039
+F,CN1806900000000,"Huntington County, IN",0,T,2040
+F,CN1807100000000,"Jackson County, IN",0,T,2041
+F,CN1807300000000,"Jasper County, IN",0,T,2042
+F,CN1807500000000,"Jay County, IN",0,T,2043
+F,CN1807700000000,"Jefferson County, IN",0,T,2044
+F,CN1807900000000,"Jennings County, IN",0,T,2045
+F,CN1808100000000,"Johnson County, IN",0,T,2046
+F,CN1808300000000,"Knox County, IN",0,T,2047
+F,CN1808500000000,"Kosciusko County, IN",0,T,2048
+F,CN1808700000000,"LaGrange County, IN",0,T,2049
+F,CN1808900000000,"Lake County, IN",0,T,2050
+F,CN1809100000000,"LaPorte County, IN",0,T,2051
+F,CN1809300000000,"Lawrence County, IN",0,T,2052
+F,CN1809500000000,"Madison County, IN",0,T,2053
+F,CN1809700000000,"Marion County, IN",0,T,2054
+F,CN1809900000000,"Marshall County, IN",0,T,2055
+F,CN1810100000000,"Martin County, IN",0,T,2056
+F,CN1810300000000,"Miami County, IN",0,T,2057
+F,CN1810500000000,"Monroe County, IN",0,T,2058
+F,CN1810700000000,"Montgomery County, IN",0,T,2059
+F,CN1810900000000,"Morgan County, IN",0,T,2060
+F,CN1811100000000,"Newton County, IN",0,T,2061
+F,CN1811300000000,"Noble County, IN",0,T,2062
+F,CN1811500000000,"Ohio County, IN",0,T,2063
+F,CN1811700000000,"Orange County, IN",0,T,2064
+F,CN1811900000000,"Owen County, IN",0,T,2065
+F,CN1812100000000,"Parke County, IN",0,T,2066
+F,CN1812300000000,"Perry County, IN",0,T,2067
+F,CN1812500000000,"Pike County, IN",0,T,2068
+F,CN1812700000000,"Porter County, IN",0,T,2069
+F,CN1812900000000,"Posey County, IN",0,T,2070
+F,CN1813100000000,"Pulaski County, IN",0,T,2071
+F,CN1813300000000,"Putnam County, IN",0,T,2072
+F,CN1813500000000,"Randolph County, IN",0,T,2073
+F,CN1813700000000,"Ripley County, IN",0,T,2074
+F,CN1813900000000,"Rush County, IN",0,T,2075
+F,CN1814100000000,"St. Joseph County, IN",0,T,2076
+F,CN1814300000000,"Scott County, IN",0,T,2077
+F,CN1814500000000,"Shelby County, IN",0,T,2078
+F,CN1814700000000,"Spencer County, IN",0,T,2079
+F,CN1814900000000,"Starke County, IN",0,T,2080
+F,CN1815100000000,"Steuben County, IN",0,T,2081
+F,CN1815300000000,"Sullivan County, IN",0,T,2082
+F,CN1815500000000,"Switzerland County, IN",0,T,2083
+F,CN1815700000000,"Tippecanoe County, IN",0,T,2084
+F,CN1815900000000,"Tipton County, IN",0,T,2085
+F,CN1816100000000,"Union County, IN",0,T,2086
+F,CN1816300000000,"Vanderburgh County, IN",0,T,2087
+F,CN1816500000000,"Vermillion County, IN",0,T,2088
+F,CN1816700000000,"Vigo County, IN",0,T,2089
+F,CN1816900000000,"Wabash County, IN",0,T,2090
+F,CN1817100000000,"Warren County, IN",0,T,2091
+F,CN1817300000000,"Warrick County, IN",0,T,2092
+F,CN1817500000000,"Washington County, IN",0,T,2093
+F,CN1817700000000,"Wayne County, IN",0,T,2094
+F,CN1817900000000,"Wells County, IN",0,T,2095
+F,CN1818100000000,"White County, IN",0,T,2096
+F,CN1818300000000,"Whitley County, IN",0,T,2097
+F,CN1900100000000,"Adair County, IA",0,T,2172
+F,CN1900300000000,"Adams County, IA",0,T,2173
+F,CN1900500000000,"Allamakee County, IA",0,T,2174
+F,CN1900700000000,"Appanoose County, IA",0,T,2175
+F,CN1900900000000,"Audubon County, IA",0,T,2176
+F,CN1901100000000,"Benton County, IA",0,T,2177
+F,CN1901300000000,"Black Hawk County, IA",0,T,2178
+F,CN1901500000000,"Boone County, IA",0,T,2179
+F,CN1901700000000,"Bremer County, IA",0,T,2180
+F,CN1901900000000,"Buchanan County, IA",0,T,2181
+F,CN1902100000000,"Buena Vista County, IA",0,T,2182
+F,CN1902300000000,"Butler County, IA",0,T,2183
+F,CN1902500000000,"Calhoun County, IA",0,T,2184
+F,CN1902700000000,"Carroll County, IA",0,T,2185
+F,CN1902900000000,"Cass County, IA",0,T,2186
+F,CN1903100000000,"Cedar County, IA",0,T,2187
+F,CN1903300000000,"Cerro Gordo County, IA",0,T,2188
+F,CN1903500000000,"Cherokee County, IA",0,T,2189
+F,CN1903700000000,"Chickasaw County, IA",0,T,2190
+F,CN1903900000000,"Clarke County, IA",0,T,2191
+F,CN1904100000000,"Clay County, IA",0,T,2192
+F,CN1904300000000,"Clayton County, IA",0,T,2193
+F,CN1904500000000,"Clinton County, IA",0,T,2194
+F,CN1904700000000,"Crawford County, IA",0,T,2195
+F,CN1904900000000,"Dallas County, IA",0,T,2196
+F,CN1905100000000,"Davis County, IA",0,T,2197
+F,CN1905300000000,"Decatur County, IA",0,T,2198
+F,CN1905500000000,"Delaware County, IA",0,T,2199
+F,CN1905700000000,"Des Moines County, IA",0,T,2200
+F,CN1905900000000,"Dickinson County, IA",0,T,2201
+F,CN1906100000000,"Dubuque County, IA",0,T,2202
+F,CN1906300000000,"Emmet County, IA",0,T,2203
+F,CN1906500000000,"Fayette County, IA",0,T,2204
+F,CN1906700000000,"Floyd County, IA",0,T,2205
+F,CN1906900000000,"Franklin County, IA",0,T,2206
+F,CN1907100000000,"Fremont County, IA",0,T,2207
+F,CN1907300000000,"Greene County, IA",0,T,2208
+F,CN1907500000000,"Grundy County, IA",0,T,2209
+F,CN1907700000000,"Guthrie County, IA",0,T,2210
+F,CN1907900000000,"Hamilton County, IA",0,T,2211
+F,CN1908100000000,"Hancock County, IA",0,T,2212
+F,CN1908300000000,"Hardin County, IA",0,T,2213
+F,CN1908500000000,"Harrison County, IA",0,T,2214
+F,CN1908700000000,"Henry County, IA",0,T,2215
+F,CN1908900000000,"Howard County, IA",0,T,2216
+F,CN1909100000000,"Humboldt County, IA",0,T,2217
+F,CN1909300000000,"Ida County, IA",0,T,2218
+F,CN1909500000000,"Iowa County, IA",0,T,2219
+F,CN1909700000000,"Jackson County, IA",0,T,2220
+F,CN1909900000000,"Jasper County, IA",0,T,2221
+F,CN1910100000000,"Jefferson County, IA",0,T,2222
+F,CN1910300000000,"Johnson County, IA",0,T,2223
+F,CN1910500000000,"Jones County, IA",0,T,2224
+F,CN1910700000000,"Keokuk County, IA",0,T,2225
+F,CN1910900000000,"Kossuth County, IA",0,T,2226
+F,CN1911100000000,"Lee County, IA",0,T,2227
+F,CN1911300000000,"Linn County, IA",0,T,2228
+F,CN1911500000000,"Louisa County, IA",0,T,2229
+F,CN1911700000000,"Lucas County, IA",0,T,2230
+F,CN1911900000000,"Lyon County, IA",0,T,2231
+F,CN1912100000000,"Madison County, IA",0,T,2232
+F,CN1912300000000,"Mahaska County, IA",0,T,2233
+F,CN1912500000000,"Marion County, IA",0,T,2234
+F,CN1912700000000,"Marshall County, IA",0,T,2235
+F,CN1912900000000,"Mills County, IA",0,T,2236
+F,CN1913100000000,"Mitchell County, IA",0,T,2237
+F,CN1913300000000,"Monona County, IA",0,T,2238
+F,CN1913500000000,"Monroe County, IA",0,T,2239
+F,CN1913700000000,"Montgomery County, IA",0,T,2240
+F,CN1913900000000,"Muscatine County, IA",0,T,2241
+F,CN1914100000000,"O'Brien County, IA",0,T,2242
+F,CN1914300000000,"Osceola County, IA",0,T,2243
+F,CN1914500000000,"Page County, IA",0,T,2244
+F,CN1914700000000,"Palo Alto County, IA",0,T,2245
+F,CN1914900000000,"Plymouth County, IA",0,T,2246
+F,CN1915100000000,"Pocahontas County, IA",0,T,2247
+F,CN1915300000000,"Polk County, IA",0,T,2248
+F,CN1915500000000,"Pottawattamie County, IA",0,T,2249
+F,CN1915700000000,"Poweshiek County, IA",0,T,2250
+F,CN1915900000000,"Ringgold County, IA",0,T,2251
+F,CN1916100000000,"Sac County, IA",0,T,2252
+F,CN1916300000000,"Scott County, IA",0,T,2253
+F,CN1916500000000,"Shelby County, IA",0,T,2254
+F,CN1916700000000,"Sioux County, IA",0,T,2255
+F,CN1916900000000,"Story County, IA",0,T,2256
+F,CN1917100000000,"Tama County, IA",0,T,2257
+F,CN1917300000000,"Taylor County, IA",0,T,2258
+F,CN1917500000000,"Union County, IA",0,T,2259
+F,CN1917700000000,"Van Buren County, IA",0,T,2260
+F,CN1917900000000,"Wapello County, IA",0,T,2261
+F,CN1918100000000,"Warren County, IA",0,T,2262
+F,CN1918300000000,"Washington County, IA",0,T,2263
+F,CN1918500000000,"Wayne County, IA",0,T,2264
+F,CN1918700000000,"Webster County, IA",0,T,2265
+F,CN1918900000000,"Winnebago County, IA",0,T,2266
+F,CN1919100000000,"Winneshiek County, IA",0,T,2267
+F,CN1919300000000,"Woodbury County, IA",0,T,2268
+F,CN1919500000000,"Worth County, IA",0,T,2269
+F,CN1919700000000,"Wright County, IA",0,T,2270
+F,CN2000100000000,"Allen County, KS",0,T,2327
+F,CN2000300000000,"Anderson County, KS",0,T,2328
+F,CN2000500000000,"Atchison County, KS",0,T,2329
+F,CN2000700000000,"Barber County, KS",0,T,2330
+F,CN2000900000000,"Barton County, KS",0,T,2331
+F,CN2001100000000,"Bourbon County, KS",0,T,2332
+F,CN2001300000000,"Brown County, KS",0,T,2333
+F,CN2001500000000,"Butler County, KS",0,T,2334
+F,CN2001700000000,"Chase County, KS",0,T,2335
+F,CN2001900000000,"Chautauqua County, KS",0,T,2336
+F,CN2002100000000,"Cherokee County, KS",0,T,2337
+F,CN2002300000000,"Cheyenne County, KS",0,T,2338
+F,CN2002500000000,"Clark County, KS",0,T,2339
+F,CN2002700000000,"Clay County, KS",0,T,2340
+F,CN2002900000000,"Cloud County, KS",0,T,2341
+F,CN2003100000000,"Coffey County, KS",0,T,2342
+F,CN2003300000000,"Comanche County, KS",0,T,2343
+F,CN2003500000000,"Cowley County, KS",0,T,2344
+F,CN2003700000000,"Crawford County, KS",0,T,2345
+F,CN2003900000000,"Decatur County, KS",0,T,2346
+F,CN2004100000000,"Dickinson County, KS",0,T,2347
+F,CN2004300000000,"Doniphan County, KS",0,T,2348
+F,CN2004500000000,"Douglas County, KS",0,T,2349
+F,CN2004700000000,"Edwards County, KS",0,T,2350
+F,CN2004900000000,"Elk County, KS",0,T,2351
+F,CN2005100000000,"Ellis County, KS",0,T,2352
+F,CN2005300000000,"Ellsworth County, KS",0,T,2353
+F,CN2005500000000,"Finney County, KS",0,T,2354
+F,CN2005700000000,"Ford County, KS",0,T,2355
+F,CN2005900000000,"Franklin County, KS",0,T,2356
+F,CN2006100000000,"Geary County, KS",0,T,2357
+F,CN2006300000000,"Gove County, KS",0,T,2358
+F,CN2006500000000,"Graham County, KS",0,T,2359
+F,CN2006700000000,"Grant County, KS",0,T,2360
+F,CN2006900000000,"Gray County, KS",0,T,2361
+F,CN2007100000000,"Greeley County, KS",0,T,2362
+F,CN2007300000000,"Greenwood County, KS",0,T,2363
+F,CN2007500000000,"Hamilton County, KS",0,T,2364
+F,CN2007700000000,"Harper County, KS",0,T,2365
+F,CN2007900000000,"Harvey County, KS",0,T,2366
+F,CN2008100000000,"Haskell County, KS",0,T,2367
+F,CN2008300000000,"Hodgeman County, KS",0,T,2368
+F,CN2008500000000,"Jackson County, KS",0,T,2369
+F,CN2008700000000,"Jefferson County, KS",0,T,2370
+F,CN2008900000000,"Jewell County, KS",0,T,2371
+F,CN2009100000000,"Johnson County, KS",0,T,2372
+F,CN2009300000000,"Kearny County, KS",0,T,2373
+F,CN2009500000000,"Kingman County, KS",0,T,2374
+F,CN2009700000000,"Kiowa County, KS",0,T,2375
+F,CN2009900000000,"Labette County, KS",0,T,2376
+F,CN2010100000000,"Lane County, KS",0,T,2377
+F,CN2010300000000,"Leavenworth County, KS",0,T,2378
+F,CN2010500000000,"Lincoln County, KS",0,T,2379
+F,CN2010700000000,"Linn County, KS",0,T,2380
+F,CN2010900000000,"Logan County, KS",0,T,2381
+F,CN2011100000000,"Lyon County, KS",0,T,2382
+F,CN2011300000000,"McPherson County, KS",0,T,2383
+F,CN2011500000000,"Marion County, KS",0,T,2384
+F,CN2011700000000,"Marshall County, KS",0,T,2385
+F,CN2011900000000,"Meade County, KS",0,T,2386
+F,CN2012100000000,"Miami County, KS",0,T,2387
+F,CN2012300000000,"Mitchell County, KS",0,T,2388
+F,CN2012500000000,"Montgomery County, KS",0,T,2389
+F,CN2012700000000,"Morris County, KS",0,T,2390
+F,CN2012900000000,"Morton County, KS",0,T,2391
+F,CN2013100000000,"Nemaha County, KS",0,T,2392
+F,CN2013300000000,"Neosho County, KS",0,T,2393
+F,CN2013500000000,"Ness County, KS",0,T,2394
+F,CN2013700000000,"Norton County, KS",0,T,2395
+F,CN2013900000000,"Osage County, KS",0,T,2396
+F,CN2014100000000,"Osborne County, KS",0,T,2397
+F,CN2014300000000,"Ottawa County, KS",0,T,2398
+F,CN2014500000000,"Pawnee County, KS",0,T,2399
+F,CN2014700000000,"Phillips County, KS",0,T,2400
+F,CN2014900000000,"Pottawatomie County, KS",0,T,2401
+F,CN2015100000000,"Pratt County, KS",0,T,2402
+F,CN2015300000000,"Rawlins County, KS",0,T,2403
+F,CN2015500000000,"Reno County, KS",0,T,2404
+F,CN2015700000000,"Republic County, KS",0,T,2405
+F,CN2015900000000,"Rice County, KS",0,T,2406
+F,CN2016100000000,"Riley County, KS",0,T,2407
+F,CN2016300000000,"Rooks County, KS",0,T,2408
+F,CN2016500000000,"Rush County, KS",0,T,2409
+F,CN2016700000000,"Russell County, KS",0,T,2410
+F,CN2016900000000,"Saline County, KS",0,T,2411
+F,CN2017100000000,"Scott County, KS",0,T,2412
+F,CN2017300000000,"Sedgwick County, KS",0,T,2413
+F,CN2017500000000,"Seward County, KS",0,T,2414
+F,CN2017700000000,"Shawnee County, KS",0,T,2415
+F,CN2017900000000,"Sheridan County, KS",0,T,2416
+F,CN2018100000000,"Sherman County, KS",0,T,2417
+F,CN2018300000000,"Smith County, KS",0,T,2418
+F,CN2018500000000,"Stafford County, KS",0,T,2419
+F,CN2018700000000,"Stanton County, KS",0,T,2420
+F,CN2018900000000,"Stevens County, KS",0,T,2421
+F,CN2019100000000,"Sumner County, KS",0,T,2422
+F,CN2019300000000,"Thomas County, KS",0,T,2423
+F,CN2019500000000,"Trego County, KS",0,T,2424
+F,CN2019700000000,"Wabaunsee County, KS",0,T,2425
+F,CN2019900000000,"Wallace County, KS",0,T,2426
+F,CN2020100000000,"Washington County, KS",0,T,2427
+F,CN2020300000000,"Wichita County, KS",0,T,2428
+F,CN2020500000000,"Wilson County, KS",0,T,2429
+F,CN2020700000000,"Woodson County, KS",0,T,2430
+F,CN2020900000000,"Wyandotte County, KS",0,T,2431
+F,CN2100100000000,"Adair County, KY",0,T,2480
+F,CN2100300000000,"Allen County, KY",0,T,2481
+F,CN2100500000000,"Anderson County, KY",0,T,2482
+F,CN2100700000000,"Ballard County, KY",0,T,2483
+F,CN2100900000000,"Barren County, KY",0,T,2484
+F,CN2101100000000,"Bath County, KY",0,T,2485
+F,CN2101300000000,"Bell County, KY",0,T,2486
+F,CN2101500000000,"Boone County, KY",0,T,2487
+F,CN2101700000000,"Bourbon County, KY",0,T,2488
+F,CN2101900000000,"Boyd County, KY",0,T,2489
+F,CN2102100000000,"Boyle County, KY",0,T,2490
+F,CN2102300000000,"Bracken County, KY",0,T,2491
+F,CN2102500000000,"Breathitt County, KY",0,T,2492
+F,CN2102700000000,"Breckinridge County, KY",0,T,2493
+F,CN2102900000000,"Bullitt County, KY",0,T,2494
+F,CN2103100000000,"Butler County, KY",0,T,2495
+F,CN2103300000000,"Caldwell County, KY",0,T,2496
+F,CN2103500000000,"Calloway County, KY",0,T,2497
+F,CN2103700000000,"Campbell County, KY",0,T,2498
+F,CN2103900000000,"Carlisle County, KY",0,T,2499
+F,CN2104100000000,"Carroll County, KY",0,T,2500
+F,CN2104300000000,"Carter County, KY",0,T,2501
+F,CN2104500000000,"Casey County, KY",0,T,2502
+F,CN2104700000000,"Christian County, KY",0,T,2503
+F,CN2104900000000,"Clark County, KY",0,T,2504
+F,CN2105100000000,"Clay County, KY",0,T,2505
+F,CN2105300000000,"Clinton County, KY",0,T,2506
+F,CN2105500000000,"Crittenden County, KY",0,T,2507
+F,CN2105700000000,"Cumberland County, KY",0,T,2508
+F,CN2105900000000,"Daviess County, KY",0,T,2509
+F,CN2106100000000,"Edmonson County, KY",0,T,2510
+F,CN2106300000000,"Elliott County, KY",0,T,2511
+F,CN2106500000000,"Estill County, KY",0,T,2512
+F,CN2106700000000,"Fayette County, KY",0,T,2513
+F,CN2106900000000,"Fleming County, KY",0,T,2514
+F,CN2107100000000,"Floyd County, KY",0,T,2515
+F,CN2107300000000,"Franklin County, KY",0,T,2516
+F,CN2107500000000,"Fulton County, KY",0,T,2517
+F,CN2107700000000,"Gallatin County, KY",0,T,2518
+F,CN2107900000000,"Garrard County, KY",0,T,2519
+F,CN2108100000000,"Grant County, KY",0,T,2520
+F,CN2108300000000,"Graves County, KY",0,T,2521
+F,CN2108500000000,"Grayson County, KY",0,T,2522
+F,CN2108700000000,"Green County, KY",0,T,2523
+F,CN2108900000000,"Greenup County, KY",0,T,2524
+F,CN2109100000000,"Hancock County, KY",0,T,2525
+F,CN2109300000000,"Hardin County, KY",0,T,2526
+F,CN2109500000000,"Harlan County, KY",0,T,2527
+F,CN2109700000000,"Harrison County, KY",0,T,2528
+F,CN2109900000000,"Hart County, KY",0,T,2529
+F,CN2110100000000,"Henderson County, KY",0,T,2530
+F,CN2110300000000,"Henry County, KY",0,T,2531
+F,CN2110500000000,"Hickman County, KY",0,T,2532
+F,CN2110700000000,"Hopkins County, KY",0,T,2533
+F,CN2110900000000,"Jackson County, KY",0,T,2534
+F,CN2111100000000,"Jefferson County, KY",0,T,2535
+F,CN2111300000000,"Jessamine County, KY",0,T,2536
+F,CN2111500000000,"Johnson County, KY",0,T,2537
+F,CN2111700000000,"Kenton County, KY",0,T,2538
+F,CN2111900000000,"Knott County, KY",0,T,2539
+F,CN2112100000000,"Knox County, KY",0,T,2540
+F,CN2112300000000,"Larue County, KY",0,T,2541
+F,CN2112500000000,"Laurel County, KY",0,T,2542
+F,CN2112700000000,"Lawrence County, KY",0,T,2543
+F,CN2112900000000,"Lee County, KY",0,T,2544
+F,CN2113100000000,"Leslie County, KY",0,T,2545
+F,CN2113300000000,"Letcher County, KY",0,T,2546
+F,CN2113500000000,"Lewis County, KY",0,T,2547
+F,CN2113700000000,"Lincoln County, KY",0,T,2548
+F,CN2113900000000,"Livingston County, KY",0,T,2549
+F,CN2114100000000,"Logan County, KY",0,T,2550
+F,CN2114300000000,"Lyon County, KY",0,T,2551
+F,CN2114500000000,"McCracken County, KY",0,T,2552
+F,CN2114700000000,"McCreary County, KY",0,T,2553
+F,CN2114900000000,"McLean County, KY",0,T,2554
+F,CN2115100000000,"Madison County, KY",0,T,2555
+F,CN2115300000000,"Magoffin County, KY",0,T,2556
+F,CN2115500000000,"Marion County, KY",0,T,2557
+F,CN2115700000000,"Marshall County, KY",0,T,2558
+F,CN2115900000000,"Martin County, KY",0,T,2559
+F,CN2116100000000,"Mason County, KY",0,T,2560
+F,CN2116300000000,"Meade County, KY",0,T,2561
+F,CN2116500000000,"Menifee County, KY",0,T,2562
+F,CN2116700000000,"Mercer County, KY",0,T,2563
+F,CN2116900000000,"Metcalfe County, KY",0,T,2564
+F,CN2117100000000,"Monroe County, KY",0,T,2565
+F,CN2117300000000,"Montgomery County, KY",0,T,2566
+F,CN2117500000000,"Morgan County, KY",0,T,2567
+F,CN2117700000000,"Muhlenberg County, KY",0,T,2568
+F,CN2117900000000,"Nelson County, KY",0,T,2569
+F,CN2118100000000,"Nicholas County, KY",0,T,2570
+F,CN2118300000000,"Ohio County, KY",0,T,2571
+F,CN2118500000000,"Oldham County, KY",0,T,2572
+F,CN2118700000000,"Owen County, KY",0,T,2573
+F,CN2118900000000,"Owsley County, KY",0,T,2574
+F,CN2119100000000,"Pendleton County, KY",0,T,2575
+F,CN2119300000000,"Perry County, KY",0,T,2576
+F,CN2119500000000,"Pike County, KY",0,T,2577
+F,CN2119700000000,"Powell County, KY",0,T,2578
+F,CN2119900000000,"Pulaski County, KY",0,T,2579
+F,CN2120100000000,"Robertson County, KY",0,T,2580
+F,CN2120300000000,"Rockcastle County, KY",0,T,2581
+F,CN2120500000000,"Rowan County, KY",0,T,2582
+F,CN2120700000000,"Russell County, KY",0,T,2583
+F,CN2120900000000,"Scott County, KY",0,T,2584
+F,CN2121100000000,"Shelby County, KY",0,T,2585
+F,CN2121300000000,"Simpson County, KY",0,T,2586
+F,CN2121500000000,"Spencer County, KY",0,T,2587
+F,CN2121700000000,"Taylor County, KY",0,T,2588
+F,CN2121900000000,"Todd County, KY",0,T,2589
+F,CN2122100000000,"Trigg County, KY",0,T,2590
+F,CN2122300000000,"Trimble County, KY",0,T,2591
+F,CN2122500000000,"Union County, KY",0,T,2592
+F,CN2122700000000,"Warren County, KY",0,T,2593
+F,CN2122900000000,"Washington County, KY",0,T,2594
+F,CN2123100000000,"Wayne County, KY",0,T,2595
+F,CN2123300000000,"Webster County, KY",0,T,2596
+F,CN2123500000000,"Whitley County, KY",0,T,2597
+F,CN2123700000000,"Wolfe County, KY",0,T,2598
+F,CN2123900000000,"Woodford County, KY",0,T,2599
+F,CN2200100000000,"Acadia Parish, LA",0,T,2650
+F,CN2200300000000,"Allen Parish, LA",0,T,2651
+F,CN2200500000000,"Ascension Parish, LA",0,T,2652
+F,CN2200700000000,"Assumption Parish, LA",0,T,2653
+F,CN2200900000000,"Avoyelles Parish, LA",0,T,2654
+F,CN2201100000000,"Beauregard Parish, LA",0,T,2655
+F,CN2201300000000,"Bienville Parish, LA",0,T,2656
+F,CN2201500000000,"Bossier Parish, LA",0,T,2657
+F,CN2201700000000,"Caddo Parish, LA",0,T,2658
+F,CN2201900000000,"Calcasieu Parish, LA",0,T,2659
+F,CN2202100000000,"Caldwell Parish, LA",0,T,2660
+F,CN2202300000000,"Cameron Parish, LA",0,T,2661
+F,CN2202500000000,"Catahoula Parish, LA",0,T,2662
+F,CN2202700000000,"Claiborne Parish, LA",0,T,2663
+F,CN2202900000000,"Concordia Parish, LA",0,T,2664
+F,CN2203100000000,"De Soto Parish, LA",0,T,2665
+F,CN2203300000000,"East Baton Rouge Parish, LA",0,T,2666
+F,CN2203500000000,"East Carroll Parish, LA",0,T,2667
+F,CN2203700000000,"East Feliciana Parish, LA",0,T,2668
+F,CN2203900000000,"Evangeline Parish, LA",0,T,2669
+F,CN2204100000000,"Franklin Parish, LA",0,T,2670
+F,CN2204300000000,"Grant Parish, LA",0,T,2671
+F,CN2204500000000,"Iberia Parish, LA",0,T,2672
+F,CN2204700000000,"Iberville Parish, LA",0,T,2673
+F,CN2204900000000,"Jackson Parish, LA",0,T,2674
+F,CN2205100000000,"Jefferson Parish, LA",0,T,2675
+F,CN2205300000000,"Jefferson Davis Parish, LA",0,T,2676
+F,CN2205500000000,"Lafayette Parish, LA",0,T,2677
+F,CN2205700000000,"Lafourche Parish, LA",0,T,2678
+F,CN2205900000000,"LaSalle Parish, LA",0,T,2679
+F,CN2206100000000,"Lincoln Parish, LA",0,T,2680
+F,CN2206300000000,"Livingston Parish, LA",0,T,2681
+F,CN2206500000000,"Madison Parish, LA",0,T,2682
+F,CN2206700000000,"Morehouse Parish, LA",0,T,2683
+F,CN2206900000000,"Natchitoches Parish, LA",0,T,2684
+F,CN2207100000000,"Orleans Parish, LA",0,T,2685
+F,CN2207300000000,"Ouachita Parish, LA",0,T,2686
+F,CN2207500000000,"Plaquemines Parish, LA",0,T,2687
+F,CN2207700000000,"Pointe Coupee Parish, LA",0,T,2688
+F,CN2207900000000,"Rapides Parish, LA",0,T,2689
+F,CN2208100000000,"Red River Parish, LA",0,T,2690
+F,CN2208300000000,"Richland Parish, LA",0,T,2691
+F,CN2208500000000,"Sabine Parish, LA",0,T,2692
+F,CN2208700000000,"St. Bernard Parish, LA",0,T,2693
+F,CN2208900000000,"St. Charles Parish, LA",0,T,2694
+F,CN2209100000000,"St. Helena Parish, LA",0,T,2695
+F,CN2209300000000,"St. James Parish, LA",0,T,2696
+F,CN2209500000000,"St. John the Baptist Parish, LA",0,T,2697
+F,CN2209700000000,"St. Landry Parish, LA",0,T,2698
+F,CN2209900000000,"St. Martin Parish, LA",0,T,2699
+F,CN2210100000000,"St. Mary Parish, LA",0,T,2700
+F,CN2210300000000,"St. Tammany Parish, LA",0,T,2701
+F,CN2210500000000,"Tangipahoa Parish, LA",0,T,2702
+F,CN2210700000000,"Tensas Parish, LA",0,T,2703
+F,CN2210900000000,"Terrebonne Parish, LA",0,T,2704
+F,CN2211100000000,"Union Parish, LA",0,T,2705
+F,CN2211300000000,"Vermilion Parish, LA",0,T,2706
+F,CN2211500000000,"Vernon Parish, LA",0,T,2707
+F,CN2211700000000,"Washington Parish, LA",0,T,2708
+F,CN2211900000000,"Webster Parish, LA",0,T,2709
+F,CN2212100000000,"West Baton Rouge Parish, LA",0,T,2710
+F,CN2212300000000,"West Carroll Parish, LA",0,T,2711
+F,CN2212500000000,"West Feliciana Parish, LA",0,T,2712
+F,CN2212700000000,"Winn Parish, LA",0,T,2713
+F,CN2300100000000,"Androscoggin County, ME",0,T,2740
+F,CN2300300000000,"Aroostook County, ME",0,T,2741
+F,CN2300500000000,"Cumberland County, ME",0,T,2742
+F,CN2300700000000,"Franklin County, ME",0,T,2743
+F,CN2300900000000,"Hancock County, ME",0,T,2744
+F,CN2301100000000,"Kennebec County, ME",0,T,2745
+F,CN2301300000000,"Knox County, ME",0,T,2746
+F,CN2301500000000,"Lincoln County, ME",0,T,2747
+F,CN2301700000000,"Oxford County, ME",0,T,2748
+F,CN2301900000000,"Penobscot County, ME",0,T,2749
+F,CN2302100000000,"Piscataquis County, ME",0,T,2750
+F,CN2302300000000,"Sagadahoc County, ME",0,T,2751
+F,CN2302500000000,"Somerset County, ME",0,T,2752
+F,CN2302700000000,"Waldo County, ME",0,T,2753
+F,CN2302900000000,"Washington County, ME",0,T,2754
+F,CN2303100000000,"York County, ME",0,T,2755
+F,CN2400100000000,"Allegany County, MD",0,T,3310
+F,CN2400300000000,"Anne Arundel County, MD",0,T,3311
+F,CN2400500000000,"Baltimore County, MD",0,T,3312
+F,CN2400900000000,"Calvert County, MD",0,T,3313
+F,CN2401100000000,"Caroline County, MD",0,T,3314
+F,CN2401300000000,"Carroll County, MD",0,T,3315
+F,CN2401500000000,"Cecil County, MD",0,T,3316
+F,CN2401700000000,"Charles County, MD",0,T,3317
+F,CN2401900000000,"Dorchester County, MD",0,T,3318
+F,CN2402100000000,"Frederick County, MD",0,T,3319
+F,CN2402300000000,"Garrett County, MD",0,T,3320
+F,CN2402500000000,"Harford County, MD",0,T,3321
+F,CN2402700000000,"Howard County, MD",0,T,3322
+F,CN2402900000000,"Kent County, MD",0,T,3323
+F,CN2403100000000,"Montgomery County, MD",0,T,3324
+F,CN2403300000000,"Prince George's County, MD",0,T,3325
+F,CN2403500000000,"Queen Anne's County, MD",0,T,3326
+F,CN2403700000000,"St. Mary's County, MD",0,T,3327
+F,CN2403900000000,"Somerset County, MD",0,T,3328
+F,CN2404100000000,"Talbot County, MD",0,T,3329
+F,CN2404300000000,"Washington County, MD",0,T,3330
+F,CN2404500000000,"Wicomico County, MD",0,T,3331
+F,CN2404700000000,"Worcester County, MD",0,T,3332
+F,CN2451000000000,"Baltimore city, MD",0,T,3333
+F,CN2500100000000,"Barnstable County, MA",0,T,3372
+F,CN2500300000000,"Berkshire County, MA",0,T,3373
+F,CN2500500000000,"Bristol County, MA",0,T,3374
+F,CN2500700000000,"Dukes County, MA",0,T,3375
+F,CN2500900000000,"Essex County, MA",0,T,3376
+F,CN2501100000000,"Franklin County, MA",0,T,3377
+F,CN2501300000000,"Hampden County, MA",0,T,3378
+F,CN2501500000000,"Hampshire County, MA",0,T,3379
+F,CN2501700000000,"Middlesex County, MA",0,T,3380
+F,CN2501900000000,"Nantucket County/town, MA",0,T,3381
+F,CN2502100000000,"Norfolk County, MA",0,T,3382
+F,CN2502300000000,"Plymouth County, MA",0,T,3383
+F,CN2502500000000,"Suffolk County, MA",0,T,3384
+F,CN2502700000000,"Worcester County, MA",0,T,3385
+F,CN2600100000000,"Alcona County, MI",0,T,3789
+F,CN2600300000000,"Alger County, MI",0,T,3790
+F,CN2600500000000,"Allegan County, MI",0,T,3791
+F,CN2600700000000,"Alpena County, MI",0,T,3792
+F,CN2600900000000,"Antrim County, MI",0,T,3793
+F,CN2601100000000,"Arenac County, MI",0,T,3794
+F,CN2601300000000,"Baraga County, MI",0,T,3795
+F,CN2601500000000,"Barry County, MI",0,T,3796
+F,CN2601700000000,"Bay County, MI",0,T,3797
+F,CN2601900000000,"Benzie County, MI",0,T,3798
+F,CN2602100000000,"Berrien County, MI",0,T,3799
+F,CN2602300000000,"Branch County, MI",0,T,3800
+F,CN2602500000000,"Calhoun County, MI",0,T,3801
+F,CN2602700000000,"Cass County, MI",0,T,3802
+F,CN2602900000000,"Charlevoix County, MI",0,T,3803
+F,CN2603100000000,"Cheboygan County, MI",0,T,3804
+F,CN2603300000000,"Chippewa County, MI",0,T,3805
+F,CN2603500000000,"Clare County, MI",0,T,3806
+F,CN2603700000000,"Clinton County, MI",0,T,3807
+F,CN2603900000000,"Crawford County, MI",0,T,3808
+F,CN2604100000000,"Delta County, MI",0,T,3809
+F,CN2604300000000,"Dickinson County, MI",0,T,3810
+F,CN2604500000000,"Eaton County, MI",0,T,3811
+F,CN2604700000000,"Emmet County, MI",0,T,3812
+F,CN2604900000000,"Genesee County, MI",0,T,3813
+F,CN2605100000000,"Gladwin County, MI",0,T,3814
+F,CN2605300000000,"Gogebic County, MI",0,T,3815
+F,CN2605500000000,"Grand Traverse County, MI",0,T,3816
+F,CN2605700000000,"Gratiot County, MI",0,T,3817
+F,CN2605900000000,"Hillsdale County, MI",0,T,3818
+F,CN2606100000000,"Houghton County, MI",0,T,3819
+F,CN2606300000000,"Huron County, MI",0,T,3820
+F,CN2606500000000,"Ingham County, MI",0,T,3821
+F,CN2606700000000,"Ionia County, MI",0,T,3822
+F,CN2606900000000,"Iosco County, MI",0,T,3823
+F,CN2607100000000,"Iron County, MI",0,T,3824
+F,CN2607300000000,"Isabella County, MI",0,T,3825
+F,CN2607500000000,"Jackson County, MI",0,T,3826
+F,CN2607700000000,"Kalamazoo County, MI",0,T,3827
+F,CN2607900000000,"Kalkaska County, MI",0,T,3828
+F,CN2608100000000,"Kent County, MI",0,T,3829
+F,CN2608300000000,"Keweenaw County, MI",0,T,3830
+F,CN2608500000000,"Lake County, MI",0,T,3831
+F,CN2608700000000,"Lapeer County, MI",0,T,3832
+F,CN2608900000000,"Leelanau County, MI",0,T,3833
+F,CN2609100000000,"Lenawee County, MI",0,T,3834
+F,CN2609300000000,"Livingston County, MI",0,T,3835
+F,CN2609500000000,"Luce County, MI",0,T,3836
+F,CN2609700000000,"Mackinac County, MI",0,T,3837
+F,CN2609900000000,"Macomb County, MI",0,T,3838
+F,CN2610100000000,"Manistee County, MI",0,T,3839
+F,CN2610300000000,"Marquette County, MI",0,T,3840
+F,CN2610500000000,"Mason County, MI",0,T,3841
+F,CN2610700000000,"Mecosta County, MI",0,T,3842
+F,CN2610900000000,"Menominee County, MI",0,T,3843
+F,CN2611100000000,"Midland County, MI",0,T,3844
+F,CN2611300000000,"Missaukee County, MI",0,T,3845
+F,CN2611500000000,"Monroe County, MI",0,T,3846
+F,CN2611700000000,"Montcalm County, MI",0,T,3847
+F,CN2611900000000,"Montmorency County, MI",0,T,3848
+F,CN2612100000000,"Muskegon County, MI",0,T,3849
+F,CN2612300000000,"Newaygo County, MI",0,T,3850
+F,CN2612500000000,"Oakland County, MI",0,T,3851
+F,CN2612700000000,"Oceana County, MI",0,T,3852
+F,CN2612900000000,"Ogemaw County, MI",0,T,3853
+F,CN2613100000000,"Ontonagon County, MI",0,T,3854
+F,CN2613300000000,"Osceola County, MI",0,T,3855
+F,CN2613500000000,"Oscoda County, MI",0,T,3856
+F,CN2613700000000,"Otsego County, MI",0,T,3857
+F,CN2613900000000,"Ottawa County, MI",0,T,3858
+F,CN2614100000000,"Presque Isle County, MI",0,T,3859
+F,CN2614300000000,"Roscommon County, MI",0,T,3860
+F,CN2614500000000,"Saginaw County, MI",0,T,3861
+F,CN2614700000000,"St. Clair County, MI",0,T,3862
+F,CN2614900000000,"St. Joseph County, MI",0,T,3863
+F,CN2615100000000,"Sanilac County, MI",0,T,3864
+F,CN2615300000000,"Schoolcraft County, MI",0,T,3865
+F,CN2615500000000,"Shiawassee County, MI",0,T,3866
+F,CN2615700000000,"Tuscola County, MI",0,T,3867
+F,CN2615900000000,"Van Buren County, MI",0,T,3868
+F,CN2616100000000,"Washtenaw County, MI",0,T,3869
+F,CN2616300000000,"Wayne County, MI",0,T,3870
+F,CN2616500000000,"Wexford County, MI",0,T,3871
+F,CN2700100000000,"Aitkin County, MN",0,T,3998
+F,CN2700300000000,"Anoka County, MN",0,T,3999
+F,CN2700500000000,"Becker County, MN",0,T,4000
+F,CN2700700000000,"Beltrami County, MN",0,T,4001
+F,CN2700900000000,"Benton County, MN",0,T,4002
+F,CN2701100000000,"Big Stone County, MN",0,T,4003
+F,CN2701300000000,"Blue Earth County, MN",0,T,4004
+F,CN2701500000000,"Brown County, MN",0,T,4005
+F,CN2701700000000,"Carlton County, MN",0,T,4006
+F,CN2701900000000,"Carver County, MN",0,T,4007
+F,CN2702100000000,"Cass County, MN",0,T,4008
+F,CN2702300000000,"Chippewa County, MN",0,T,4009
+F,CN2702500000000,"Chisago County, MN",0,T,4010
+F,CN2702700000000,"Clay County, MN",0,T,4011
+F,CN2702900000000,"Clearwater County, MN",0,T,4012
+F,CN2703100000000,"Cook County, MN",0,T,4013
+F,CN2703300000000,"Cottonwood County, MN",0,T,4014
+F,CN2703500000000,"Crow Wing County, MN",0,T,4015
+F,CN2703700000000,"Dakota County, MN",0,T,4016
+F,CN2703900000000,"Dodge County, MN",0,T,4017
+F,CN2704100000000,"Douglas County, MN",0,T,4018
+F,CN2704300000000,"Faribault County, MN",0,T,4019
+F,CN2704500000000,"Fillmore County, MN",0,T,4020
+F,CN2704700000000,"Freeborn County, MN",0,T,4021
+F,CN2704900000000,"Goodhue County, MN",0,T,4022
+F,CN2705100000000,"Grant County, MN",0,T,4023
+F,CN2705300000000,"Hennepin County, MN",0,T,4024
+F,CN2705500000000,"Houston County, MN",0,T,4025
+F,CN2705700000000,"Hubbard County, MN",0,T,4026
+F,CN2705900000000,"Isanti County, MN",0,T,4027
+F,CN2706100000000,"Itasca County, MN",0,T,4028
+F,CN2706300000000,"Jackson County, MN",0,T,4029
+F,CN2706500000000,"Kanabec County, MN",0,T,4030
+F,CN2706700000000,"Kandiyohi County, MN",0,T,4031
+F,CN2706900000000,"Kittson County, MN",0,T,4032
+F,CN2707100000000,"Koochiching County, MN",0,T,4033
+F,CN2707300000000,"Lac qui Parle County, MN",0,T,4034
+F,CN2707500000000,"Lake County, MN",0,T,4035
+F,CN2707700000000,"Lake of the Woods County, MN",0,T,4036
+F,CN2707900000000,"Le Sueur County, MN",0,T,4037
+F,CN2708100000000,"Lincoln County, MN",0,T,4038
+F,CN2708300000000,"Lyon County, MN",0,T,4039
+F,CN2708500000000,"McLeod County, MN",0,T,4040
+F,CN2708700000000,"Mahnomen County, MN",0,T,4041
+F,CN2708900000000,"Marshall County, MN",0,T,4042
+F,CN2709100000000,"Martin County, MN",0,T,4043
+F,CN2709300000000,"Meeker County, MN",0,T,4044
+F,CN2709500000000,"Mille Lacs County, MN",0,T,4045
+F,CN2709700000000,"Morrison County, MN",0,T,4046
+F,CN2709900000000,"Mower County, MN",0,T,4047
+F,CN2710100000000,"Murray County, MN",0,T,4048
+F,CN2710300000000,"Nicollet County, MN",0,T,4049
+F,CN2710500000000,"Nobles County, MN",0,T,4050
+F,CN2710700000000,"Norman County, MN",0,T,4051
+F,CN2710900000000,"Olmsted County, MN",0,T,4052
+F,CN2711100000000,"Otter Tail County, MN",0,T,4053
+F,CN2711300000000,"Pennington County, MN",0,T,4054
+F,CN2711500000000,"Pine County, MN",0,T,4055
+F,CN2711700000000,"Pipestone County, MN",0,T,4056
+F,CN2711900000000,"Polk County, MN",0,T,4057
+F,CN2712100000000,"Pope County, MN",0,T,4058
+F,CN2712300000000,"Ramsey County, MN",0,T,4059
+F,CN2712500000000,"Red Lake County, MN",0,T,4060
+F,CN2712700000000,"Redwood County, MN",0,T,4061
+F,CN2712900000000,"Renville County, MN",0,T,4062
+F,CN2713100000000,"Rice County, MN",0,T,4063
+F,CN2713300000000,"Rock County, MN",0,T,4064
+F,CN2713500000000,"Roseau County, MN",0,T,4065
+F,CN2713700000000,"St. Louis County, MN",0,T,4066
+F,CN2713900000000,"Scott County, MN",0,T,4067
+F,CN2714100000000,"Sherburne County, MN",0,T,4068
+F,CN2714300000000,"Sibley County, MN",0,T,4069
+F,CN2714500000000,"Stearns County, MN",0,T,4070
+F,CN2714700000000,"Steele County, MN",0,T,4071
+F,CN2714900000000,"Stevens County, MN",0,T,4072
+F,CN2715100000000,"Swift County, MN",0,T,4073
+F,CN2715300000000,"Todd County, MN",0,T,4074
+F,CN2715500000000,"Traverse County, MN",0,T,4075
+F,CN2715700000000,"Wabasha County, MN",0,T,4076
+F,CN2715900000000,"Wadena County, MN",0,T,4077
+F,CN2716100000000,"Waseca County, MN",0,T,4078
+F,CN2716300000000,"Washington County, MN",0,T,4079
+F,CN2716500000000,"Watonwan County, MN",0,T,4080
+F,CN2716700000000,"Wilkin County, MN",0,T,4081
+F,CN2716900000000,"Winona County, MN",0,T,4082
+F,CN2717100000000,"Wright County, MN",0,T,4083
+F,CN2717300000000,"Yellow Medicine County, MN",0,T,4084
+F,CN2800100000000,"Adams County, MS",0,T,4170
+F,CN2800300000000,"Alcorn County, MS",0,T,4171
+F,CN2800500000000,"Amite County, MS",0,T,4172
+F,CN2800700000000,"Attala County, MS",0,T,4173
+F,CN2800900000000,"Benton County, MS",0,T,4174
+F,CN2801100000000,"Bolivar County, MS",0,T,4175
+F,CN2801300000000,"Calhoun County, MS",0,T,4176
+F,CN2801500000000,"Carroll County, MS",0,T,4177
+F,CN2801700000000,"Chickasaw County, MS",0,T,4178
+F,CN2801900000000,"Choctaw County, MS",0,T,4179
+F,CN2802100000000,"Claiborne County, MS",0,T,4180
+F,CN2802300000000,"Clarke County, MS",0,T,4181
+F,CN2802500000000,"Clay County, MS",0,T,4182
+F,CN2802700000000,"Coahoma County, MS",0,T,4183
+F,CN2802900000000,"Copiah County, MS",0,T,4184
+F,CN2803100000000,"Covington County, MS",0,T,4185
+F,CN2803300000000,"DeSoto County, MS",0,T,4186
+F,CN2803500000000,"Forrest County, MS",0,T,4187
+F,CN2803700000000,"Franklin County, MS",0,T,4188
+F,CN2803900000000,"George County, MS",0,T,4189
+F,CN2804100000000,"Greene County, MS",0,T,4190
+F,CN2804300000000,"Grenada County, MS",0,T,4191
+F,CN2804500000000,"Hancock County, MS",0,T,4192
+F,CN2804700000000,"Harrison County, MS",0,T,4193
+F,CN2804900000000,"Hinds County, MS",0,T,4194
+F,CN2805100000000,"Holmes County, MS",0,T,4195
+F,CN2805300000000,"Humphreys County, MS",0,T,4196
+F,CN2805500000000,"Issaquena County, MS",0,T,4197
+F,CN2805700000000,"Itawamba County, MS",0,T,4198
+F,CN2805900000000,"Jackson County, MS",0,T,4199
+F,CN2806100000000,"Jasper County, MS",0,T,4200
+F,CN2806300000000,"Jefferson County, MS",0,T,4201
+F,CN2806500000000,"Jefferson Davis County, MS",0,T,4202
+F,CN2806700000000,"Jones County, MS",0,T,4203
+F,CN2806900000000,"Kemper County, MS",0,T,4204
+F,CN2807100000000,"Lafayette County, MS",0,T,4205
+F,CN2807300000000,"Lamar County, MS",0,T,4206
+F,CN2807500000000,"Lauderdale County, MS",0,T,4207
+F,CN2807700000000,"Lawrence County, MS",0,T,4208
+F,CN2807900000000,"Leake County, MS",0,T,4209
+F,CN2808100000000,"Lee County, MS",0,T,4210
+F,CN2808300000000,"Leflore County, MS",0,T,4211
+F,CN2808500000000,"Lincoln County, MS",0,T,4212
+F,CN2808700000000,"Lowndes County, MS",0,T,4213
+F,CN2808900000000,"Madison County, MS",0,T,4214
+F,CN2809100000000,"Marion County, MS",0,T,4215
+F,CN2809300000000,"Marshall County, MS",0,T,4216
+F,CN2809500000000,"Monroe County, MS",0,T,4217
+F,CN2809700000000,"Montgomery County, MS",0,T,4218
+F,CN2809900000000,"Neshoba County, MS",0,T,4219
+F,CN2810100000000,"Newton County, MS",0,T,4220
+F,CN2810300000000,"Noxubee County, MS",0,T,4221
+F,CN2810500000000,"Oktibbeha County, MS",0,T,4222
+F,CN2810700000000,"Panola County, MS",0,T,4223
+F,CN2810900000000,"Pearl River County, MS",0,T,4224
+F,CN2811100000000,"Perry County, MS",0,T,4225
+F,CN2811300000000,"Pike County, MS",0,T,4226
+F,CN2811500000000,"Pontotoc County, MS",0,T,4227
+F,CN2811700000000,"Prentiss County, MS",0,T,4228
+F,CN2811900000000,"Quitman County, MS",0,T,4229
+F,CN2812100000000,"Rankin County, MS",0,T,4230
+F,CN2812300000000,"Scott County, MS",0,T,4231
+F,CN2812500000000,"Sharkey County, MS",0,T,4232
+F,CN2812700000000,"Simpson County, MS",0,T,4233
+F,CN2812900000000,"Smith County, MS",0,T,4234
+F,CN2813100000000,"Stone County, MS",0,T,4235
+F,CN2813300000000,"Sunflower County, MS",0,T,4236
+F,CN2813500000000,"Tallahatchie County, MS",0,T,4237
+F,CN2813700000000,"Tate County, MS",0,T,4238
+F,CN2813900000000,"Tippah County, MS",0,T,4239
+F,CN2814100000000,"Tishomingo County, MS",0,T,4240
+F,CN2814300000000,"Tunica County, MS",0,T,4241
+F,CN2814500000000,"Union County, MS",0,T,4242
+F,CN2814700000000,"Walthall County, MS",0,T,4243
+F,CN2814900000000,"Warren County, MS",0,T,4244
+F,CN2815100000000,"Washington County, MS",0,T,4245
+F,CN2815300000000,"Wayne County, MS",0,T,4246
+F,CN2815500000000,"Webster County, MS",0,T,4247
+F,CN2815700000000,"Wilkinson County, MS",0,T,4248
+F,CN2815900000000,"Winston County, MS",0,T,4249
+F,CN2816100000000,"Yalobusha County, MS",0,T,4250
+F,CN2816300000000,"Yazoo County, MS",0,T,4251
+F,CN2900100000000,"Adair County, MO",0,T,4310
+F,CN2900300000000,"Andrew County, MO",0,T,4311
+F,CN2900500000000,"Atchison County, MO",0,T,4312
+F,CN2900700000000,"Audrain County, MO",0,T,4313
+F,CN2900900000000,"Barry County, MO",0,T,4314
+F,CN2901100000000,"Barton County, MO",0,T,4315
+F,CN2901300000000,"Bates County, MO",0,T,4316
+F,CN2901500000000,"Benton County, MO",0,T,4317
+F,CN2901700000000,"Bollinger County, MO",0,T,4318
+F,CN2901900000000,"Boone County, MO",0,T,4319
+F,CN2902100000000,"Buchanan County, MO",0,T,4320
+F,CN2902300000000,"Butler County, MO",0,T,4321
+F,CN2902500000000,"Caldwell County, MO",0,T,4322
+F,CN2902700000000,"Callaway County, MO",0,T,4323
+F,CN2902900000000,"Camden County, MO",0,T,4324
+F,CN2903100000000,"Cape Girardeau County, MO",0,T,4325
+F,CN2903300000000,"Carroll County, MO",0,T,4326
+F,CN2903500000000,"Carter County, MO",0,T,4327
+F,CN2903700000000,"Cass County, MO",0,T,4328
+F,CN2903900000000,"Cedar County, MO",0,T,4329
+F,CN2904100000000,"Chariton County, MO",0,T,4330
+F,CN2904300000000,"Christian County, MO",0,T,4331
+F,CN2904500000000,"Clark County, MO",0,T,4332
+F,CN2904700000000,"Clay County, MO",0,T,4333
+F,CN2904900000000,"Clinton County, MO",0,T,4334
+F,CN2905100000000,"Cole County, MO",0,T,4335
+F,CN2905300000000,"Cooper County, MO",0,T,4336
+F,CN2905500000000,"Crawford County, MO",0,T,4337
+F,CN2905700000000,"Dade County, MO",0,T,4338
+F,CN2905900000000,"Dallas County, MO",0,T,4339
+F,CN2906100000000,"Daviess County, MO",0,T,4340
+F,CN2906300000000,"DeKalb County, MO",0,T,4341
+F,CN2906500000000,"Dent County, MO",0,T,4342
+F,CN2906700000000,"Douglas County, MO",0,T,4343
+F,CN2906900000000,"Dunklin County, MO",0,T,4344
+F,CN2907100000000,"Franklin County, MO",0,T,4345
+F,CN2907300000000,"Gasconade County, MO",0,T,4346
+F,CN2907500000000,"Gentry County, MO",0,T,4347
+F,CN2907700000000,"Greene County, MO",0,T,4348
+F,CN2907900000000,"Grundy County, MO",0,T,4349
+F,CN2908100000000,"Harrison County, MO",0,T,4350
+F,CN2908300000000,"Henry County, MO",0,T,4351
+F,CN2908500000000,"Hickory County, MO",0,T,4352
+F,CN2908700000000,"Holt County, MO",0,T,4353
+F,CN2908900000000,"Howard County, MO",0,T,4354
+F,CN2909100000000,"Howell County, MO",0,T,4355
+F,CN2909300000000,"Iron County, MO",0,T,4356
+F,CN2909500000000,"Jackson County, MO",0,T,4357
+F,CN2909700000000,"Jasper County, MO",0,T,4358
+F,CN2909900000000,"Jefferson County, MO",0,T,4359
+F,CN2910100000000,"Johnson County, MO",0,T,4360
+F,CN2910300000000,"Knox County, MO",0,T,4361
+F,CN2910500000000,"Laclede County, MO",0,T,4362
+F,CN2910700000000,"Lafayette County, MO",0,T,4363
+F,CN2910900000000,"Lawrence County, MO",0,T,4364
+F,CN2911100000000,"Lewis County, MO",0,T,4365
+F,CN2911300000000,"Lincoln County, MO",0,T,4366
+F,CN2911500000000,"Linn County, MO",0,T,4367
+F,CN2911700000000,"Livingston County, MO",0,T,4368
+F,CN2911900000000,"McDonald County, MO",0,T,4369
+F,CN2912100000000,"Macon County, MO",0,T,4370
+F,CN2912300000000,"Madison County, MO",0,T,4371
+F,CN2912500000000,"Maries County, MO",0,T,4372
+F,CN2912700000000,"Marion County, MO",0,T,4373
+F,CN2912900000000,"Mercer County, MO",0,T,4374
+F,CN2913100000000,"Miller County, MO",0,T,4375
+F,CN2913300000000,"Mississippi County, MO",0,T,4376
+F,CN2913500000000,"Moniteau County, MO",0,T,4377
+F,CN2913700000000,"Monroe County, MO",0,T,4378
+F,CN2913900000000,"Montgomery County, MO",0,T,4379
+F,CN2914100000000,"Morgan County, MO",0,T,4380
+F,CN2914300000000,"New Madrid County, MO",0,T,4381
+F,CN2914500000000,"Newton County, MO",0,T,4382
+F,CN2914700000000,"Nodaway County, MO",0,T,4383
+F,CN2914900000000,"Oregon County, MO",0,T,4384
+F,CN2915100000000,"Osage County, MO",0,T,4385
+F,CN2915300000000,"Ozark County, MO",0,T,4386
+F,CN2915500000000,"Pemiscot County, MO",0,T,4387
+F,CN2915700000000,"Perry County, MO",0,T,4388
+F,CN2915900000000,"Pettis County, MO",0,T,4389
+F,CN2916100000000,"Phelps County, MO",0,T,4390
+F,CN2916300000000,"Pike County, MO",0,T,4391
+F,CN2916500000000,"Platte County, MO",0,T,4392
+F,CN2916700000000,"Polk County, MO",0,T,4393
+F,CN2916900000000,"Pulaski County, MO",0,T,4394
+F,CN2917100000000,"Putnam County, MO",0,T,4395
+F,CN2917300000000,"Ralls County, MO",0,T,4396
+F,CN2917500000000,"Randolph County, MO",0,T,4397
+F,CN2917700000000,"Ray County, MO",0,T,4398
+F,CN2917900000000,"Reynolds County, MO",0,T,4399
+F,CN2918100000000,"Ripley County, MO",0,T,4400
+F,CN2918300000000,"St. Charles County, MO",0,T,4401
+F,CN2918500000000,"St. Clair County, MO",0,T,4402
+F,CN2918600000000,"Ste. Genevieve County, MO",0,T,4403
+F,CN2918700000000,"St. Francois County, MO",0,T,4404
+F,CN2918900000000,"St. Louis County, MO",0,T,4405
+F,CN2919500000000,"Saline County, MO",0,T,4406
+F,CN2919700000000,"Schuyler County, MO",0,T,4407
+F,CN2919900000000,"Scotland County, MO",0,T,4408
+F,CN2920100000000,"Scott County, MO",0,T,4409
+F,CN2920300000000,"Shannon County, MO",0,T,4410
+F,CN2920500000000,"Shelby County, MO",0,T,4411
+F,CN2920700000000,"Stoddard County, MO",0,T,4412
+F,CN2920900000000,"Stone County, MO",0,T,4413
+F,CN2921100000000,"Sullivan County, MO",0,T,4414
+F,CN2921300000000,"Taney County, MO",0,T,4415
+F,CN2921500000000,"Texas County, MO",0,T,4416
+F,CN2921700000000,"Vernon County, MO",0,T,4417
+F,CN2921900000000,"Warren County, MO",0,T,4418
+F,CN2922100000000,"Washington County, MO",0,T,4419
+F,CN2922300000000,"Wayne County, MO",0,T,4420
+F,CN2922500000000,"Webster County, MO",0,T,4421
+F,CN2922700000000,"Worth County, MO",0,T,4422
+F,CN2922900000000,"Wright County, MO",0,T,4423
+F,CN2951000000000,"St. Louis city, MO",0,T,4424
+F,CN3000100000000,"Beaverhead County, MT",0,T,4477
+F,CN3000300000000,"Big Horn County, MT",0,T,4478
+F,CN3000500000000,"Blaine County, MT",0,T,4479
+F,CN3000700000000,"Broadwater County, MT",0,T,4480
+F,CN3000900000000,"Carbon County, MT",0,T,4481
+F,CN3001100000000,"Carter County, MT",0,T,4482
+F,CN3001300000000,"Cascade County, MT",0,T,4483
+F,CN3001500000000,"Chouteau County, MT",0,T,4484
+F,CN3001700000000,"Custer County, MT",0,T,4485
+F,CN3001900000000,"Daniels County, MT",0,T,4486
+F,CN3002100000000,"Dawson County, MT",0,T,4487
+F,CN3002300000000,"Deer Lodge County, MT",0,T,4488
+F,CN3002500000000,"Fallon County, MT",0,T,4489
+F,CN3002700000000,"Fergus County, MT",0,T,4490
+F,CN3002900000000,"Flathead County, MT",0,T,4491
+F,CN3003100000000,"Gallatin County, MT",0,T,4492
+F,CN3003300000000,"Garfield County, MT",0,T,4493
+F,CN3003500000000,"Glacier County, MT",0,T,4494
+F,CN3003700000000,"Golden Valley County, MT",0,T,4495
+F,CN3003900000000,"Granite County, MT",0,T,4496
+F,CN3004100000000,"Hill County, MT",0,T,4497
+F,CN3004300000000,"Jefferson County, MT",0,T,4498
+F,CN3004500000000,"Judith Basin County, MT",0,T,4499
+F,CN3004700000000,"Lake County, MT",0,T,4500
+F,CN3004900000000,"Lewis and Clark County, MT",0,T,4501
+F,CN3005100000000,"Liberty County, MT",0,T,4502
+F,CN3005300000000,"Lincoln County, MT",0,T,4503
+F,CN3005500000000,"McCone County, MT",0,T,4504
+F,CN3005700000000,"Madison County, MT",0,T,4505
+F,CN3005900000000,"Meagher County, MT",0,T,4506
+F,CN3006100000000,"Mineral County, MT",0,T,4507
+F,CN3006300000000,"Missoula County, MT",0,T,4508
+F,CN3006500000000,"Musselshell County, MT",0,T,4509
+F,CN3006700000000,"Park County, MT",0,T,4510
+F,CN3006900000000,"Petroleum County, MT",0,T,4511
+F,CN3007100000000,"Phillips County, MT",0,T,4512
+F,CN3007300000000,"Pondera County, MT",0,T,4513
+F,CN3007500000000,"Powder River County, MT",0,T,4514
+F,CN3007700000000,"Powell County, MT",0,T,4515
+F,CN3007900000000,"Prairie County, MT",0,T,4516
+F,CN3008100000000,"Ravalli County, MT",0,T,4517
+F,CN3008300000000,"Richland County, MT",0,T,4518
+F,CN3008500000000,"Roosevelt County, MT",0,T,4519
+F,CN3008700000000,"Rosebud County, MT",0,T,4520
+F,CN3008900000000,"Sanders County, MT",0,T,4521
+F,CN3009100000000,"Sheridan County, MT",0,T,4522
+F,CN3009300000000,"Silver Bow County, MT",0,T,4523
+F,CN3009500000000,"Stillwater County, MT",0,T,4524
+F,CN3009700000000,"Sweet Grass County, MT",0,T,4525
+F,CN3009900000000,"Teton County, MT",0,T,4526
+F,CN3010100000000,"Toole County, MT",0,T,4527
+F,CN3010300000000,"Treasure County, MT",0,T,4528
+F,CN3010500000000,"Valley County, MT",0,T,4529
+F,CN3010700000000,"Wheatland County, MT",0,T,4530
+F,CN3010900000000,"Wibaux County, MT",0,T,4531
+F,CN3011100000000,"Yellowstone County, MT",0,T,4532
+F,CN3100100000000,"Adams County, NE",0,T,4557
+F,CN3100300000000,"Antelope County, NE",0,T,4558
+F,CN3100500000000,"Arthur County, NE",0,T,4559
+F,CN3100700000000,"Banner County, NE",0,T,4560
+F,CN3100900000000,"Blaine County, NE",0,T,4561
+F,CN3101100000000,"Boone County, NE",0,T,4562
+F,CN3101300000000,"Box Butte County, NE",0,T,4563
+F,CN3101500000000,"Boyd County, NE",0,T,4564
+F,CN3101700000000,"Brown County, NE",0,T,4565
+F,CN3101900000000,"Buffalo County, NE",0,T,4566
+F,CN3102100000000,"Burt County, NE",0,T,4567
+F,CN3102300000000,"Butler County, NE",0,T,4568
+F,CN3102500000000,"Cass County, NE",0,T,4569
+F,CN3102700000000,"Cedar County, NE",0,T,4570
+F,CN3102900000000,"Chase County, NE",0,T,4571
+F,CN3103100000000,"Cherry County, NE",0,T,4572
+F,CN3103300000000,"Cheyenne County, NE",0,T,4573
+F,CN3103500000000,"Clay County, NE",0,T,4574
+F,CN3103700000000,"Colfax County, NE",0,T,4575
+F,CN3103900000000,"Cuming County, NE",0,T,4576
+F,CN3104100000000,"Custer County, NE",0,T,4577
+F,CN3104300000000,"Dakota County, NE",0,T,4578
+F,CN3104500000000,"Dawes County, NE",0,T,4579
+F,CN3104700000000,"Dawson County, NE",0,T,4580
+F,CN3104900000000,"Deuel County, NE",0,T,4581
+F,CN3105100000000,"Dixon County, NE",0,T,4582
+F,CN3105300000000,"Dodge County, NE",0,T,4583
+F,CN3105500000000,"Douglas County, NE",0,T,4584
+F,CN3105700000000,"Dundy County, NE",0,T,4585
+F,CN3105900000000,"Fillmore County, NE",0,T,4586
+F,CN3106100000000,"Franklin County, NE",0,T,4587
+F,CN3106300000000,"Frontier County, NE",0,T,4588
+F,CN3106500000000,"Furnas County, NE",0,T,4589
+F,CN3106700000000,"Gage County, NE",0,T,4590
+F,CN3106900000000,"Garden County, NE",0,T,4591
+F,CN3107100000000,"Garfield County, NE",0,T,4592
+F,CN3107300000000,"Gosper County, NE",0,T,4593
+F,CN3107500000000,"Grant County, NE",0,T,4594
+F,CN3107700000000,"Greeley County, NE",0,T,4595
+F,CN3107900000000,"Hall County, NE",0,T,4596
+F,CN3108100000000,"Hamilton County, NE",0,T,4597
+F,CN3108300000000,"Harlan County, NE",0,T,4598
+F,CN3108500000000,"Hayes County, NE",0,T,4599
+F,CN3108700000000,"Hitchcock County, NE",0,T,4600
+F,CN3108900000000,"Holt County, NE",0,T,4601
+F,CN3109100000000,"Hooker County, NE",0,T,4602
+F,CN3109300000000,"Howard County, NE",0,T,4603
+F,CN3109500000000,"Jefferson County, NE",0,T,4604
+F,CN3109700000000,"Johnson County, NE",0,T,4605
+F,CN3109900000000,"Kearney County, NE",0,T,4606
+F,CN3110100000000,"Keith County, NE",0,T,4607
+F,CN3110300000000,"Keya Paha County, NE",0,T,4608
+F,CN3110500000000,"Kimball County, NE",0,T,4609
+F,CN3110700000000,"Knox County, NE",0,T,4610
+F,CN3110900000000,"Lancaster County, NE",0,T,4611
+F,CN3111100000000,"Lincoln County, NE",0,T,4612
+F,CN3111300000000,"Logan County, NE",0,T,4613
+F,CN3111500000000,"Loup County, NE",0,T,4614
+F,CN3111700000000,"McPherson County, NE",0,T,4615
+F,CN3111900000000,"Madison County, NE",0,T,4616
+F,CN3112100000000,"Merrick County, NE",0,T,4617
+F,CN3112300000000,"Morrill County, NE",0,T,4618
+F,CN3112500000000,"Nance County, NE",0,T,4619
+F,CN3112700000000,"Nemaha County, NE",0,T,4620
+F,CN3112900000000,"Nuckolls County, NE",0,T,4621
+F,CN3113100000000,"Otoe County, NE",0,T,4622
+F,CN3113300000000,"Pawnee County, NE",0,T,4623
+F,CN3113500000000,"Perkins County, NE",0,T,4624
+F,CN3113700000000,"Phelps County, NE",0,T,4625
+F,CN3113900000000,"Pierce County, NE",0,T,4626
+F,CN3114100000000,"Platte County, NE",0,T,4627
+F,CN3114300000000,"Polk County, NE",0,T,4628
+F,CN3114500000000,"Red Willow County, NE",0,T,4629
+F,CN3114700000000,"Richardson County, NE",0,T,4630
+F,CN3114900000000,"Rock County, NE",0,T,4631
+F,CN3115100000000,"Saline County, NE",0,T,4632
+F,CN3115300000000,"Sarpy County, NE",0,T,4633
+F,CN3115500000000,"Saunders County, NE",0,T,4634
+F,CN3115700000000,"Scotts Bluff County, NE",0,T,4635
+F,CN3115900000000,"Seward County, NE",0,T,4636
+F,CN3116100000000,"Sheridan County, NE",0,T,4637
+F,CN3116300000000,"Sherman County, NE",0,T,4638
+F,CN3116500000000,"Sioux County, NE",0,T,4639
+F,CN3116700000000,"Stanton County, NE",0,T,4640
+F,CN3116900000000,"Thayer County, NE",0,T,4641
+F,CN3117100000000,"Thomas County, NE",0,T,4642
+F,CN3117300000000,"Thurston County, NE",0,T,4643
+F,CN3117500000000,"Valley County, NE",0,T,4644
+F,CN3117700000000,"Washington County, NE",0,T,4645
+F,CN3117900000000,"Wayne County, NE",0,T,4646
+F,CN3118100000000,"Webster County, NE",0,T,4647
+F,CN3118300000000,"Wheeler County, NE",0,T,4648
+F,CN3118500000000,"York County, NE",0,T,4649
+F,CN3200100000000,"Churchill County, NV",0,T,4672
+F,CN3200300000000,"Clark County, NV",0,T,4673
+F,CN3200500000000,"Douglas County, NV",0,T,4674
+F,CN3200700000000,"Elko County, NV",0,T,4675
+F,CN3200900000000,"Esmeralda County, NV",0,T,4676
+F,CN3201100000000,"Eureka County, NV",0,T,4677
+F,CN3201300000000,"Humboldt County, NV",0,T,4678
+F,CN3201500000000,"Lander County, NV",0,T,4679
+F,CN3201700000000,"Lincoln County, NV",0,T,4680
+F,CN3201900000000,"Lyon County, NV",0,T,4681
+F,CN3202100000000,"Mineral County, NV",0,T,4682
+F,CN3202300000000,"Nye County, NV",0,T,4683
+F,CN3202700000000,"Pershing County, NV",0,T,4684
+F,CN3202900000000,"Storey County, NV",0,T,4685
+F,CN3203100000000,"Washoe County, NV",0,T,4686
+F,CN3203300000000,"White Pine County, NV",0,T,4687
+F,CN3251000000000,"Carson City, NV",0,T,4688
+F,CN3300100000000,"Belknap County, NH",0,T,4707
+F,CN3300300000000,"Carroll County, NH",0,T,4708
+F,CN3300500000000,"Cheshire County, NH",0,T,4709
+F,CN3300700000000,"Coos County, NH",0,T,4710
+F,CN3300900000000,"Grafton County, NH",0,T,4711
+F,CN3301100000000,"Hillsborough County, NH",0,T,4712
+F,CN3301300000000,"Merrimack County, NH",0,T,4713
+F,CN3301500000000,"Rockingham County, NH",0,T,4714
+F,CN3301700000000,"Strafford County, NH",0,T,4715
+F,CN3301900000000,"Sullivan County, NH",0,T,4716
+F,CN3400100000000,"Atlantic County, NJ",0,T,4990
+F,CN3400300000000,"Bergen County, NJ",0,T,4991
+F,CN3400500000000,"Burlington County, NJ",0,T,4992
+F,CN3400700000000,"Camden County, NJ",0,T,4993
+F,CN3400900000000,"Cape May County, NJ",0,T,4994
+F,CN3401100000000,"Cumberland County, NJ",0,T,4995
+F,CN3401300000000,"Essex County, NJ",0,T,4996
+F,CN3401500000000,"Gloucester County, NJ",0,T,4997
+F,CN3401700000000,"Hudson County, NJ",0,T,4998
+F,CN3401900000000,"Hunterdon County, NJ",0,T,4999
+F,CN3402100000000,"Mercer County, NJ",0,T,5000
+F,CN3402300000000,"Middlesex County, NJ",0,T,5001
+F,CN3402500000000,"Monmouth County, NJ",0,T,5002
+F,CN3402700000000,"Morris County, NJ",0,T,5003
+F,CN3402900000000,"Ocean County, NJ",0,T,5004
+F,CN3403100000000,"Passaic County, NJ",0,T,5005
+F,CN3403300000000,"Salem County, NJ",0,T,5006
+F,CN3403500000000,"Somerset County, NJ",0,T,5007
+F,CN3403700000000,"Sussex County, NJ",0,T,5008
+F,CN3403900000000,"Union County, NJ",0,T,5009
+F,CN3404100000000,"Warren County, NJ",0,T,5010
+F,CN3500100000000,"Bernalillo County, NM",0,T,5143
+F,CN3500300000000,"Catron County, NM",0,T,5144
+F,CN3500500000000,"Chaves County, NM",0,T,5145
+F,CN3500600000000,"Cibola County, NM",0,T,5146
+F,CN3500700000000,"Colfax County, NM",0,T,5147
+F,CN3500900000000,"Curry County, NM",0,T,5148
+F,CN3501100000000,"De Baca County, NM",0,T,5149
+F,CN3501300000000,"Dona Ana County, NM",0,T,5150
+F,CN3501500000000,"Eddy County, NM",0,T,5151
+F,CN3501700000000,"Grant County, NM",0,T,5152
+F,CN3501900000000,"Guadalupe County, NM",0,T,5153
+F,CN3502100000000,"Harding County, NM",0,T,5154
+F,CN3502300000000,"Hidalgo County, NM",0,T,5155
+F,CN3502500000000,"Lea County, NM",0,T,5156
+F,CN3502700000000,"Lincoln County, NM",0,T,5157
+F,CN3502800000000,"Los Alamos County, NM",0,T,5158
+F,CN3502900000000,"Luna County, NM",0,T,5159
+F,CN3503100000000,"McKinley County, NM",0,T,5160
+F,CN3503300000000,"Mora County, NM",0,T,5161
+F,CN3503500000000,"Otero County, NM",0,T,5162
+F,CN3503700000000,"Quay County, NM",0,T,5163
+F,CN3503900000000,"Rio Arriba County, NM",0,T,5164
+F,CN3504100000000,"Roosevelt County, NM",0,T,5165
+F,CN3504300000000,"Sandoval County, NM",0,T,5166
+F,CN3504500000000,"San Juan County, NM",0,T,5167
+F,CN3504700000000,"San Miguel County, NM",0,T,5168
+F,CN3504900000000,"Santa Fe County, NM",0,T,5169
+F,CN3505100000000,"Sierra County, NM",0,T,5170
+F,CN3505300000000,"Socorro County, NM",0,T,5171
+F,CN3505500000000,"Taos County, NM",0,T,5172
+F,CN3505700000000,"Torrance County, NM",0,T,5173
+F,CN3505900000000,"Union County, NM",0,T,5174
+F,CN3506100000000,"Valencia County, NM",0,T,5175
+F,CN3600100000000,"Albany County, NY",0,T,5223
+F,CN3600300000000,"Allegany County, NY",0,T,5224
+F,CN3600500000000,"Bronx County, NY",0,T,5225
+F,CN3600700000000,"Broome County, NY",0,T,5226
+F,CN3600900000000,"Cattaraugus County, NY",0,T,5227
+F,CN3601100000000,"Cayuga County, NY",0,T,5228
+F,CN3601300000000,"Chautauqua County, NY",0,T,5229
+F,CN3601500000000,"Chemung County, NY",0,T,5230
+F,CN3601700000000,"Chenango County, NY",0,T,5231
+F,CN3601900000000,"Clinton County, NY",0,T,5232
+F,CN3602100000000,"Columbia County, NY",0,T,5233
+F,CN3602300000000,"Cortland County, NY",0,T,5234
+F,CN3602500000000,"Delaware County, NY",0,T,5235
+F,CN3602700000000,"Dutchess County, NY",0,T,5236
+F,CN3602900000000,"Erie County, NY",0,T,5237
+F,CN3603100000000,"Essex County, NY",0,T,5238
+F,CN3603300000000,"Franklin County, NY",0,T,5239
+F,CN3603500000000,"Fulton County, NY",0,T,5240
+F,CN3603700000000,"Genesee County, NY",0,T,5241
+F,CN3603900000000,"Greene County, NY",0,T,5242
+F,CN3604100000000,"Hamilton County, NY",0,T,5243
+F,CN3604300000000,"Herkimer County, NY",0,T,5244
+F,CN3604500000000,"Jefferson County, NY",0,T,5245
+F,CN3604700000000,"Kings County, NY",0,T,5246
+F,CN3604900000000,"Lewis County, NY",0,T,5247
+F,CN3605100000000,"Livingston County, NY",0,T,5248
+F,CN3605300000000,"Madison County, NY",0,T,5249
+F,CN3605500000000,"Monroe County, NY",0,T,5250
+F,CN3605700000000,"Montgomery County, NY",0,T,5251
+F,CN3605900000000,"Nassau County, NY",0,T,5252
+F,CN3606100000000,"New York County, NY",0,T,5253
+F,CN3606300000000,"Niagara County, NY",0,T,5254
+F,CN3606500000000,"Oneida County, NY",0,T,5255
+F,CN3606700000000,"Onondaga County, NY",0,T,5256
+F,CN3606900000000,"Ontario County, NY",0,T,5257
+F,CN3607100000000,"Orange County, NY",0,T,5258
+F,CN3607300000000,"Orleans County, NY",0,T,5259
+F,CN3607500000000,"Oswego County, NY",0,T,5260
+F,CN3607700000000,"Otsego County, NY",0,T,5261
+F,CN3607900000000,"Putnam County, NY",0,T,5262
+F,CN3608100000000,"Queens County, NY",0,T,5263
+F,CN3608300000000,"Rensselaer County, NY",0,T,5264
+F,CN3608500000000,"Richmond County, NY",0,T,5265
+F,CN3608700000000,"Rockland County, NY",0,T,5266
+F,CN3608900000000,"St. Lawrence County, NY",0,T,5267
+F,CN3609100000000,"Saratoga County, NY",0,T,5268
+F,CN3609300000000,"Schenectady County, NY",0,T,5269
+F,CN3609500000000,"Schoharie County, NY",0,T,5270
+F,CN3609700000000,"Schuyler County, NY",0,T,5271
+F,CN3609900000000,"Seneca County, NY",0,T,5272
+F,CN3610100000000,"Steuben County, NY",0,T,5273
+F,CN3610300000000,"Suffolk County, NY",0,T,5274
+F,CN3610500000000,"Sullivan County, NY",0,T,5275
+F,CN3610700000000,"Tioga County, NY",0,T,5276
+F,CN3610900000000,"Tompkins County, NY",0,T,5277
+F,CN3611100000000,"Ulster County, NY",0,T,5278
+F,CN3611300000000,"Warren County, NY",0,T,5279
+F,CN3611500000000,"Washington County, NY",0,T,5280
+F,CN3611700000000,"Wayne County, NY",0,T,5281
+F,CN3611900000000,"Westchester County, NY",0,T,5282
+F,CN3612100000000,"Wyoming County, NY",0,T,5283
+F,CN3612300000000,"Yates County, NY",0,T,5284
+F,CN3700100000000,"Alamance County, NC",0,T,5442
+F,CN3700300000000,"Alexander County, NC",0,T,5443
+F,CN3700500000000,"Alleghany County, NC",0,T,5444
+F,CN3700700000000,"Anson County, NC",0,T,5445
+F,CN3700900000000,"Ashe County, NC",0,T,5446
+F,CN3701100000000,"Avery County, NC",0,T,5447
+F,CN3701300000000,"Beaufort County, NC",0,T,5448
+F,CN3701500000000,"Bertie County, NC",0,T,5449
+F,CN3701700000000,"Bladen County, NC",0,T,5450
+F,CN3701900000000,"Brunswick County, NC",0,T,5451
+F,CN3702100000000,"Buncombe County, NC",0,T,5452
+F,CN3702300000000,"Burke County, NC",0,T,5453
+F,CN3702500000000,"Cabarrus County, NC",0,T,5454
+F,CN3702700000000,"Caldwell County, NC",0,T,5455
+F,CN3702900000000,"Camden County, NC",0,T,5456
+F,CN3703100000000,"Carteret County, NC",0,T,5457
+F,CN3703300000000,"Caswell County, NC",0,T,5458
+F,CN3703500000000,"Catawba County, NC",0,T,5459
+F,CN3703700000000,"Chatham County, NC",0,T,5460
+F,CN3703900000000,"Cherokee County, NC",0,T,5461
+F,CN3704100000000,"Chowan County, NC",0,T,5462
+F,CN3704300000000,"Clay County, NC",0,T,5463
+F,CN3704500000000,"Cleveland County, NC",0,T,5464
+F,CN3704700000000,"Columbus County, NC",0,T,5465
+F,CN3704900000000,"Craven County, NC",0,T,5466
+F,CN3705100000000,"Cumberland County, NC",0,T,5467
+F,CN3705300000000,"Currituck County, NC",0,T,5468
+F,CN3705500000000,"Dare County, NC",0,T,5469
+F,CN3705700000000,"Davidson County, NC",0,T,5470
+F,CN3705900000000,"Davie County, NC",0,T,5471
+F,CN3706100000000,"Duplin County, NC",0,T,5472
+F,CN3706300000000,"Durham County, NC",0,T,5473
+F,CN3706500000000,"Edgecombe County, NC",0,T,5474
+F,CN3706700000000,"Forsyth County, NC",0,T,5475
+F,CN3706900000000,"Franklin County, NC",0,T,5476
+F,CN3707100000000,"Gaston County, NC",0,T,5477
+F,CN3707300000000,"Gates County, NC",0,T,5478
+F,CN3707500000000,"Graham County, NC",0,T,5479
+F,CN3707700000000,"Granville County, NC",0,T,5480
+F,CN3707900000000,"Greene County, NC",0,T,5481
+F,CN3708100000000,"Guilford County, NC",0,T,5482
+F,CN3708300000000,"Halifax County, NC",0,T,5483
+F,CN3708500000000,"Harnett County, NC",0,T,5484
+F,CN3708700000000,"Haywood County, NC",0,T,5485
+F,CN3708900000000,"Henderson County, NC",0,T,5486
+F,CN3709100000000,"Hertford County, NC",0,T,5487
+F,CN3709300000000,"Hoke County, NC",0,T,5488
+F,CN3709500000000,"Hyde County, NC",0,T,5489
+F,CN3709700000000,"Iredell County, NC",0,T,5490
+F,CN3709900000000,"Jackson County, NC",0,T,5491
+F,CN3710100000000,"Johnston County, NC",0,T,5492
+F,CN3710300000000,"Jones County, NC",0,T,5493
+F,CN3710500000000,"Lee County, NC",0,T,5494
+F,CN3710700000000,"Lenoir County, NC",0,T,5495
+F,CN3710900000000,"Lincoln County, NC",0,T,5496
+F,CN3711100000000,"McDowell County, NC",0,T,5497
+F,CN3711300000000,"Macon County, NC",0,T,5498
+F,CN3711500000000,"Madison County, NC",0,T,5499
+F,CN3711700000000,"Martin County, NC",0,T,5500
+F,CN3711900000000,"Mecklenburg County, NC",0,T,5501
+F,CN3712100000000,"Mitchell County, NC",0,T,5502
+F,CN3712300000000,"Montgomery County, NC",0,T,5503
+F,CN3712500000000,"Moore County, NC",0,T,5504
+F,CN3712700000000,"Nash County, NC",0,T,5505
+F,CN3712900000000,"New Hanover County, NC",0,T,5506
+F,CN3713100000000,"Northampton County, NC",0,T,5507
+F,CN3713300000000,"Onslow County, NC",0,T,5508
+F,CN3713500000000,"Orange County, NC",0,T,5509
+F,CN3713700000000,"Pamlico County, NC",0,T,5510
+F,CN3713900000000,"Pasquotank County, NC",0,T,5511
+F,CN3714100000000,"Pender County, NC",0,T,5512
+F,CN3714300000000,"Perquimans County, NC",0,T,5513
+F,CN3714500000000,"Person County, NC",0,T,5514
+F,CN3714700000000,"Pitt County, NC",0,T,5515
+F,CN3714900000000,"Polk County, NC",0,T,5516
+F,CN3715100000000,"Randolph County, NC",0,T,5517
+F,CN3715300000000,"Richmond County, NC",0,T,5518
+F,CN3715500000000,"Robeson County, NC",0,T,5519
+F,CN3715700000000,"Rockingham County, NC",0,T,5520
+F,CN3715900000000,"Rowan County, NC",0,T,5521
+F,CN3716100000000,"Rutherford County, NC",0,T,5522
+F,CN3716300000000,"Sampson County, NC",0,T,5523
+F,CN3716500000000,"Scotland County, NC",0,T,5524
+F,CN3716700000000,"Stanly County, NC",0,T,5525
+F,CN3716900000000,"Stokes County, NC",0,T,5526
+F,CN3717100000000,"Surry County, NC",0,T,5527
+F,CN3717300000000,"Swain County, NC",0,T,5528
+F,CN3717500000000,"Transylvania County, NC",0,T,5529
+F,CN3717700000000,"Tyrrell County, NC",0,T,5530
+F,CN3717900000000,"Union County, NC",0,T,5531
+F,CN3718100000000,"Vance County, NC",0,T,5532
+F,CN3718300000000,"Wake County, NC",0,T,5533
+F,CN3718500000000,"Warren County, NC",0,T,5534
+F,CN3718700000000,"Washington County, NC",0,T,5535
+F,CN3718900000000,"Watauga County, NC",0,T,5536
+F,CN3719100000000,"Wayne County, NC",0,T,5537
+F,CN3719300000000,"Wilkes County, NC",0,T,5538
+F,CN3719500000000,"Wilson County, NC",0,T,5539
+F,CN3719700000000,"Yadkin County, NC",0,T,5540
+F,CN3719900000000,"Yancey County, NC",0,T,5541
+F,CN3800100000000,"Adams County, ND",0,T,5625
+F,CN3800300000000,"Barnes County, ND",0,T,5626
+F,CN3800500000000,"Benson County, ND",0,T,5627
+F,CN3800700000000,"Billings County, ND",0,T,5628
+F,CN3800900000000,"Bottineau County, ND",0,T,5629
+F,CN3801100000000,"Bowman County, ND",0,T,5630
+F,CN3801300000000,"Burke County, ND",0,T,5631
+F,CN3801500000000,"Burleigh County, ND",0,T,5632
+F,CN3801700000000,"Cass County, ND",0,T,5633
+F,CN3801900000000,"Cavalier County, ND",0,T,5634
+F,CN3802100000000,"Dickey County, ND",0,T,5635
+F,CN3802300000000,"Divide County, ND",0,T,5636
+F,CN3802500000000,"Dunn County, ND",0,T,5637
+F,CN3802700000000,"Eddy County, ND",0,T,5638
+F,CN3802900000000,"Emmons County, ND",0,T,5639
+F,CN3803100000000,"Foster County, ND",0,T,5640
+F,CN3803300000000,"Golden Valley County, ND",0,T,5641
+F,CN3803500000000,"Grand Forks County, ND",0,T,5642
+F,CN3803700000000,"Grant County, ND",0,T,5643
+F,CN3803900000000,"Griggs County, ND",0,T,5644
+F,CN3804100000000,"Hettinger County, ND",0,T,5645
+F,CN3804300000000,"Kidder County, ND",0,T,5646
+F,CN3804500000000,"LaMoure County, ND",0,T,5647
+F,CN3804700000000,"Logan County, ND",0,T,5648
+F,CN3804900000000,"McHenry County, ND",0,T,5649
+F,CN3805100000000,"McIntosh County, ND",0,T,5650
+F,CN3805300000000,"McKenzie County, ND",0,T,5651
+F,CN3805500000000,"McLean County, ND",0,T,5652
+F,CN3805700000000,"Mercer County, ND",0,T,5653
+F,CN3805900000000,"Morton County, ND",0,T,5654
+F,CN3806100000000,"Mountrail County, ND",0,T,5655
+F,CN3806300000000,"Nelson County, ND",0,T,5656
+F,CN3806500000000,"Oliver County, ND",0,T,5657
+F,CN3806700000000,"Pembina County, ND",0,T,5658
+F,CN3806900000000,"Pierce County, ND",0,T,5659
+F,CN3807100000000,"Ramsey County, ND",0,T,5660
+F,CN3807300000000,"Ransom County, ND",0,T,5661
+F,CN3807500000000,"Renville County, ND",0,T,5662
+F,CN3807700000000,"Richland County, ND",0,T,5663
+F,CN3807900000000,"Rolette County, ND",0,T,5664
+F,CN3808100000000,"Sargent County, ND",0,T,5665
+F,CN3808300000000,"Sheridan County, ND",0,T,5666
+F,CN3808500000000,"Sioux County, ND",0,T,5667
+F,CN3808700000000,"Slope County, ND",0,T,5668
+F,CN3808900000000,"Stark County, ND",0,T,5669
+F,CN3809100000000,"Steele County, ND",0,T,5670
+F,CN3809300000000,"Stutsman County, ND",0,T,5671
+F,CN3809500000000,"Towner County, ND",0,T,5672
+F,CN3809700000000,"Traill County, ND",0,T,5673
+F,CN3809900000000,"Walsh County, ND",0,T,5674
+F,CN3810100000000,"Ward County, ND",0,T,5675
+F,CN3810300000000,"Wells County, ND",0,T,5676
+F,CN3810500000000,"Williams County, ND",0,T,5677
+F,CN3900100000000,"Adams County, OH",0,T,5743
+F,CN3900300000000,"Allen County, OH",0,T,5744
+F,CN3900500000000,"Ashland County, OH",0,T,5745
+F,CN3900700000000,"Ashtabula County, OH",0,T,5746
+F,CN3900900000000,"Athens County, OH",0,T,5747
+F,CN3901100000000,"Auglaize County, OH",0,T,5748
+F,CN3901300000000,"Belmont County, OH",0,T,5749
+F,CN3901500000000,"Brown County, OH",0,T,5750
+F,CN3901700000000,"Butler County, OH",0,T,5751
+F,CN3901900000000,"Carroll County, OH",0,T,5752
+F,CN3902100000000,"Champaign County, OH",0,T,5753
+F,CN3902300000000,"Clark County, OH",0,T,5754
+F,CN3902500000000,"Clermont County, OH",0,T,5755
+F,CN3902700000000,"Clinton County, OH",0,T,5756
+F,CN3902900000000,"Columbiana County, OH",0,T,5757
+F,CN3903100000000,"Coshocton County, OH",0,T,5758
+F,CN3903300000000,"Crawford County, OH",0,T,5759
+F,CN3903500000000,"Cuyahoga County, OH",0,T,5760
+F,CN3903700000000,"Darke County, OH",0,T,5761
+F,CN3903900000000,"Defiance County, OH",0,T,5762
+F,CN3904100000000,"Delaware County, OH",0,T,5763
+F,CN3904300000000,"Erie County, OH",0,T,5764
+F,CN3904500000000,"Fairfield County, OH",0,T,5765
+F,CN3904700000000,"Fayette County, OH",0,T,5766
+F,CN3904900000000,"Franklin County, OH",0,T,5767
+F,CN3905100000000,"Fulton County, OH",0,T,5768
+F,CN3905300000000,"Gallia County, OH",0,T,5769
+F,CN3905500000000,"Geauga County, OH",0,T,5770
+F,CN3905700000000,"Greene County, OH",0,T,5771
+F,CN3905900000000,"Guernsey County, OH",0,T,5772
+F,CN3906100000000,"Hamilton County, OH",0,T,5773
+F,CN3906300000000,"Hancock County, OH",0,T,5774
+F,CN3906500000000,"Hardin County, OH",0,T,5775
+F,CN3906700000000,"Harrison County, OH",0,T,5776
+F,CN3906900000000,"Henry County, OH",0,T,5777
+F,CN3907100000000,"Highland County, OH",0,T,5778
+F,CN3907300000000,"Hocking County, OH",0,T,5779
+F,CN3907500000000,"Holmes County, OH",0,T,5780
+F,CN3907700000000,"Huron County, OH",0,T,5781
+F,CN3907900000000,"Jackson County, OH",0,T,5782
+F,CN3908100000000,"Jefferson County, OH",0,T,5783
+F,CN3908300000000,"Knox County, OH",0,T,5784
+F,CN3908500000000,"Lake County, OH",0,T,5785
+F,CN3908700000000,"Lawrence County, OH",0,T,5786
+F,CN3908900000000,"Licking County, OH",0,T,5787
+F,CN3909100000000,"Logan County, OH",0,T,5788
+F,CN3909300000000,"Lorain County, OH",0,T,5789
+F,CN3909500000000,"Lucas County, OH",0,T,5790
+F,CN3909700000000,"Madison County, OH",0,T,5791
+F,CN3909900000000,"Mahoning County, OH",0,T,5792
+F,CN3910100000000,"Marion County, OH",0,T,5793
+F,CN3910300000000,"Medina County, OH",0,T,5794
+F,CN3910500000000,"Meigs County, OH",0,T,5795
+F,CN3910700000000,"Mercer County, OH",0,T,5796
+F,CN3910900000000,"Miami County, OH",0,T,5797
+F,CN3911100000000,"Monroe County, OH",0,T,5798
+F,CN3911300000000,"Montgomery County, OH",0,T,5799
+F,CN3911500000000,"Morgan County, OH",0,T,5800
+F,CN3911700000000,"Morrow County, OH",0,T,5801
+F,CN3911900000000,"Muskingum County, OH",0,T,5802
+F,CN3912100000000,"Noble County, OH",0,T,5803
+F,CN3912300000000,"Ottawa County, OH",0,T,5804
+F,CN3912500000000,"Paulding County, OH",0,T,5805
+F,CN3912700000000,"Perry County, OH",0,T,5806
+F,CN3912900000000,"Pickaway County, OH",0,T,5807
+F,CN3913100000000,"Pike County, OH",0,T,5808
+F,CN3913300000000,"Portage County, OH",0,T,5809
+F,CN3913500000000,"Preble County, OH",0,T,5810
+F,CN3913700000000,"Putnam County, OH",0,T,5811
+F,CN3913900000000,"Richland County, OH",0,T,5812
+F,CN3914100000000,"Ross County, OH",0,T,5813
+F,CN3914300000000,"Sandusky County, OH",0,T,5814
+F,CN3914500000000,"Scioto County, OH",0,T,5815
+F,CN3914700000000,"Seneca County, OH",0,T,5816
+F,CN3914900000000,"Shelby County, OH",0,T,5817
+F,CN3915100000000,"Stark County, OH",0,T,5818
+F,CN3915300000000,"Summit County, OH",0,T,5819
+F,CN3915500000000,"Trumbull County, OH",0,T,5820
+F,CN3915700000000,"Tuscarawas County, OH",0,T,5821
+F,CN3915900000000,"Union County, OH",0,T,5822
+F,CN3916100000000,"Van Wert County, OH",0,T,5823
+F,CN3916300000000,"Vinton County, OH",0,T,5824
+F,CN3916500000000,"Warren County, OH",0,T,5825
+F,CN3916700000000,"Washington County, OH",0,T,5826
+F,CN3916900000000,"Wayne County, OH",0,T,5827
+F,CN3917100000000,"Williams County, OH",0,T,5828
+F,CN3917300000000,"Wood County, OH",0,T,5829
+F,CN3917500000000,"Wyandot County, OH",0,T,5830
+F,CN4000100000000,"Adair County, OK",0,T,5948
+F,CN4000300000000,"Alfalfa County, OK",0,T,5949
+F,CN4000500000000,"Atoka County, OK",0,T,5950
+F,CN4000700000000,"Beaver County, OK",0,T,5951
+F,CN4000900000000,"Beckham County, OK",0,T,5952
+F,CN4001100000000,"Blaine County, OK",0,T,5953
+F,CN4001300000000,"Bryan County, OK",0,T,5954
+F,CN4001500000000,"Caddo County, OK",0,T,5955
+F,CN4001700000000,"Canadian County, OK",0,T,5956
+F,CN4001900000000,"Carter County, OK",0,T,5957
+F,CN4002100000000,"Cherokee County, OK",0,T,5958
+F,CN4002300000000,"Choctaw County, OK",0,T,5959
+F,CN4002500000000,"Cimarron County, OK",0,T,5960
+F,CN4002700000000,"Cleveland County, OK",0,T,5961
+F,CN4002900000000,"Coal County, OK",0,T,5962
+F,CN4003100000000,"Comanche County, OK",0,T,5963
+F,CN4003300000000,"Cotton County, OK",0,T,5964
+F,CN4003500000000,"Craig County, OK",0,T,5965
+F,CN4003700000000,"Creek County, OK",0,T,5966
+F,CN4003900000000,"Custer County, OK",0,T,5967
+F,CN4004100000000,"Delaware County, OK",0,T,5968
+F,CN4004300000000,"Dewey County, OK",0,T,5969
+F,CN4004500000000,"Ellis County, OK",0,T,5970
+F,CN4004700000000,"Garfield County, OK",0,T,5971
+F,CN4004900000000,"Garvin County, OK",0,T,5972
+F,CN4005100000000,"Grady County, OK",0,T,5973
+F,CN4005300000000,"Grant County, OK",0,T,5974
+F,CN4005500000000,"Greer County, OK",0,T,5975
+F,CN4005700000000,"Harmon County, OK",0,T,5976
+F,CN4005900000000,"Harper County, OK",0,T,5977
+F,CN4006100000000,"Haskell County, OK",0,T,5978
+F,CN4006300000000,"Hughes County, OK",0,T,5979
+F,CN4006500000000,"Jackson County, OK",0,T,5980
+F,CN4006700000000,"Jefferson County, OK",0,T,5981
+F,CN4006900000000,"Johnston County, OK",0,T,5982
+F,CN4007100000000,"Kay County, OK",0,T,5983
+F,CN4007300000000,"Kingfisher County, OK",0,T,5984
+F,CN4007500000000,"Kiowa County, OK",0,T,5985
+F,CN4007700000000,"Latimer County, OK",0,T,5986
+F,CN4007900000000,"Le Flore County, OK",0,T,5987
+F,CN4008100000000,"Lincoln County, OK",0,T,5988
+F,CN4008300000000,"Logan County, OK",0,T,5989
+F,CN4008500000000,"Love County, OK",0,T,5990
+F,CN4008700000000,"McClain County, OK",0,T,5991
+F,CN4008900000000,"McCurtain County, OK",0,T,5992
+F,CN4009100000000,"McIntosh County, OK",0,T,5993
+F,CN4009300000000,"Major County, OK",0,T,5994
+F,CN4009500000000,"Marshall County, OK",0,T,5995
+F,CN4009700000000,"Mayes County, OK",0,T,5996
+F,CN4009900000000,"Murray County, OK",0,T,5997
+F,CN4010100000000,"Muskogee County, OK",0,T,5998
+F,CN4010300000000,"Noble County, OK",0,T,5999
+F,CN4010500000000,"Nowata County, OK",0,T,6000
+F,CN4010700000000,"Okfuskee County, OK",0,T,6001
+F,CN4010900000000,"Oklahoma County, OK",0,T,6002
+F,CN4011100000000,"Okmulgee County, OK",0,T,6003
+F,CN4011300000000,"Osage County, OK",0,T,6004
+F,CN4011500000000,"Ottawa County, OK",0,T,6005
+F,CN4011700000000,"Pawnee County, OK",0,T,6006
+F,CN4011900000000,"Payne County, OK",0,T,6007
+F,CN4012100000000,"Pittsburg County, OK",0,T,6008
+F,CN4012300000000,"Pontotoc County, OK",0,T,6009
+F,CN4012500000000,"Pottawatomie County, OK",0,T,6010
+F,CN4012700000000,"Pushmataha County, OK",0,T,6011
+F,CN4012900000000,"Roger Mills County, OK",0,T,6012
+F,CN4013100000000,"Rogers County, OK",0,T,6013
+F,CN4013300000000,"Seminole County, OK",0,T,6014
+F,CN4013500000000,"Sequoyah County, OK",0,T,6015
+F,CN4013700000000,"Stephens County, OK",0,T,6016
+F,CN4013900000000,"Texas County, OK",0,T,6017
+F,CN4014100000000,"Tillman County, OK",0,T,6018
+F,CN4014300000000,"Tulsa County, OK",0,T,6019
+F,CN4014500000000,"Wagoner County, OK",0,T,6020
+F,CN4014700000000,"Washington County, OK",0,T,6021
+F,CN4014900000000,"Washita County, OK",0,T,6022
+F,CN4015100000000,"Woods County, OK",0,T,6023
+F,CN4015300000000,"Woodward County, OK",0,T,6024
+F,CN4100100000000,"Baker County, OR",0,T,6083
+F,CN4100300000000,"Benton County, OR",0,T,6084
+F,CN4100500000000,"Clackamas County, OR",0,T,6085
+F,CN4100700000000,"Clatsop County, OR",0,T,6086
+F,CN4100900000000,"Columbia County, OR",0,T,6087
+F,CN4101100000000,"Coos County, OR",0,T,6088
+F,CN4101300000000,"Crook County, OR",0,T,6089
+F,CN4101500000000,"Curry County, OR",0,T,6090
+F,CN4101700000000,"Deschutes County, OR",0,T,6091
+F,CN4101900000000,"Douglas County, OR",0,T,6092
+F,CN4102100000000,"Gilliam County, OR",0,T,6093
+F,CN4102300000000,"Grant County, OR",0,T,6094
+F,CN4102500000000,"Harney County, OR",0,T,6095
+F,CN4102700000000,"Hood River County, OR",0,T,6096
+F,CN4102900000000,"Jackson County, OR",0,T,6097
+F,CN4103100000000,"Jefferson County, OR",0,T,6098
+F,CN4103300000000,"Josephine County, OR",0,T,6099
+F,CN4103500000000,"Klamath County, OR",0,T,6100
+F,CN4103700000000,"Lake County, OR",0,T,6101
+F,CN4103900000000,"Lane County, OR",0,T,6102
+F,CN4104100000000,"Lincoln County, OR",0,T,6103
+F,CN4104300000000,"Linn County, OR",0,T,6104
+F,CN4104500000000,"Malheur County, OR",0,T,6105
+F,CN4104700000000,"Marion County, OR",0,T,6106
+F,CN4104900000000,"Morrow County, OR",0,T,6107
+F,CN4105100000000,"Multnomah County, OR",0,T,6108
+F,CN4105300000000,"Polk County, OR",0,T,6109
+F,CN4105500000000,"Sherman County, OR",0,T,6110
+F,CN4105700000000,"Tillamook County, OR",0,T,6111
+F,CN4105900000000,"Umatilla County, OR",0,T,6112
+F,CN4106100000000,"Union County, OR",0,T,6113
+F,CN4106300000000,"Wallowa County, OR",0,T,6114
+F,CN4106500000000,"Wasco County, OR",0,T,6115
+F,CN4106700000000,"Washington County, OR",0,T,6116
+F,CN4106900000000,"Wheeler County, OR",0,T,6117
+F,CN4107100000000,"Yamhill County, OR",0,T,6118
+F,CN4200100000000,"Adams County, PA",0,T,6205
+F,CN4200300000000,"Allegheny County, PA",0,T,6206
+F,CN4200500000000,"Armstrong County, PA",0,T,6207
+F,CN4200700000000,"Beaver County, PA",0,T,6208
+F,CN4200900000000,"Bedford County, PA",0,T,6209
+F,CN4201100000000,"Berks County, PA",0,T,6210
+F,CN4201300000000,"Blair County, PA",0,T,6211
+F,CN4201500000000,"Bradford County, PA",0,T,6212
+F,CN4201700000000,"Bucks County, PA",0,T,6213
+F,CN4201900000000,"Butler County, PA",0,T,6214
+F,CN4202100000000,"Cambria County, PA",0,T,6215
+F,CN4202300000000,"Cameron County, PA",0,T,6216
+F,CN4202500000000,"Carbon County, PA",0,T,6217
+F,CN4202700000000,"Centre County, PA",0,T,6218
+F,CN4202900000000,"Chester County, PA",0,T,6219
+F,CN4203100000000,"Clarion County, PA",0,T,6220
+F,CN4203300000000,"Clearfield County, PA",0,T,6221
+F,CN4203500000000,"Clinton County, PA",0,T,6222
+F,CN4203700000000,"Columbia County, PA",0,T,6223
+F,CN4203900000000,"Crawford County, PA",0,T,6224
+F,CN4204100000000,"Cumberland County, PA",0,T,6225
+F,CN4204300000000,"Dauphin County, PA",0,T,6226
+F,CN4204500000000,"Delaware County, PA",0,T,6227
+F,CN4204700000000,"Elk County, PA",0,T,6228
+F,CN4204900000000,"Erie County, PA",0,T,6229
+F,CN4205100000000,"Fayette County, PA",0,T,6230
+F,CN4205300000000,"Forest County, PA",0,T,6231
+F,CN4205500000000,"Franklin County, PA",0,T,6232
+F,CN4205700000000,"Fulton County, PA",0,T,6233
+F,CN4205900000000,"Greene County, PA",0,T,6234
+F,CN4206100000000,"Huntingdon County, PA",0,T,6235
+F,CN4206300000000,"Indiana County, PA",0,T,6236
+F,CN4206500000000,"Jefferson County, PA",0,T,6237
+F,CN4206700000000,"Juniata County, PA",0,T,6238
+F,CN4206900000000,"Lackawanna County, PA",0,T,6239
+F,CN4207100000000,"Lancaster County, PA",0,T,6240
+F,CN4207300000000,"Lawrence County, PA",0,T,6241
+F,CN4207500000000,"Lebanon County, PA",0,T,6242
+F,CN4207700000000,"Lehigh County, PA",0,T,6243
+F,CN4207900000000,"Luzerne County, PA",0,T,6244
+F,CN4208100000000,"Lycoming County, PA",0,T,6245
+F,CN4208300000000,"McKean County, PA",0,T,6246
+F,CN4208500000000,"Mercer County, PA",0,T,6247
+F,CN4208700000000,"Mifflin County, PA",0,T,6248
+F,CN4208900000000,"Monroe County, PA",0,T,6249
+F,CN4209100000000,"Montgomery County, PA",0,T,6250
+F,CN4209300000000,"Montour County, PA",0,T,6251
+F,CN4209500000000,"Northampton County, PA",0,T,6252
+F,CN4209700000000,"Northumberland County, PA",0,T,6253
+F,CN4209900000000,"Perry County, PA",0,T,6254
+F,CN4210100000000,"Philadelphia County/city, PA",0,T,6255
+F,CN4210300000000,"Pike County, PA",0,T,6256
+F,CN4210500000000,"Potter County, PA",0,T,6257
+F,CN4210700000000,"Schuylkill County, PA",0,T,6258
+F,CN4210900000000,"Snyder County, PA",0,T,6259
+F,CN4211100000000,"Somerset County, PA",0,T,6260
+F,CN4211300000000,"Sullivan County, PA",0,T,6261
+F,CN4211500000000,"Susquehanna County, PA",0,T,6262
+F,CN4211700000000,"Tioga County, PA",0,T,6263
+F,CN4211900000000,"Union County, PA",0,T,6264
+F,CN4212100000000,"Venango County, PA",0,T,6265
+F,CN4212300000000,"Warren County, PA",0,T,6266
+F,CN4212500000000,"Washington County, PA",0,T,6267
+F,CN4212700000000,"Wayne County, PA",0,T,6268
+F,CN4212900000000,"Westmoreland County, PA",0,T,6269
+F,CN4213100000000,"Wyoming County, PA",0,T,6270
+F,CN4213300000000,"York County, PA",0,T,6271
+F,CN4400100000000,"Bristol County, RI",0,T,6352
+F,CN4400300000000,"Kent County, RI",0,T,6353
+F,CN4400500000000,"Newport County, RI",0,T,6354
+F,CN4400700000000,"Providence County, RI",0,T,6355
+F,CN4400900000000,"Washington County, RI",0,T,6356
+F,CN4500100000000,"Abbeville County, SC",0,T,6417
+F,CN4500300000000,"Aiken County, SC",0,T,6418
+F,CN4500500000000,"Allendale County, SC",0,T,6419
+F,CN4500700000000,"Anderson County, SC",0,T,6420
+F,CN4500900000000,"Bamberg County, SC",0,T,6421
+F,CN4501100000000,"Barnwell County, SC",0,T,6422
+F,CN4501300000000,"Beaufort County, SC",0,T,6423
+F,CN4501500000000,"Berkeley County, SC",0,T,6424
+F,CN4501700000000,"Calhoun County, SC",0,T,6425
+F,CN4501900000000,"Charleston County, SC",0,T,6426
+F,CN4502100000000,"Cherokee County, SC",0,T,6427
+F,CN4502300000000,"Chester County, SC",0,T,6428
+F,CN4502500000000,"Chesterfield County, SC",0,T,6429
+F,CN4502700000000,"Clarendon County, SC",0,T,6430
+F,CN4502900000000,"Colleton County, SC",0,T,6431
+F,CN4503100000000,"Darlington County, SC",0,T,6432
+F,CN4503300000000,"Dillon County, SC",0,T,6433
+F,CN4503500000000,"Dorchester County, SC",0,T,6434
+F,CN4503700000000,"Edgefield County, SC",0,T,6435
+F,CN4503900000000,"Fairfield County, SC",0,T,6436
+F,CN4504100000000,"Florence County, SC",0,T,6437
+F,CN4504300000000,"Georgetown County, SC",0,T,6438
+F,CN4504500000000,"Greenville County, SC",0,T,6439
+F,CN4504700000000,"Greenwood County, SC",0,T,6440
+F,CN4504900000000,"Hampton County, SC",0,T,6441
+F,CN4505100000000,"Horry County, SC",0,T,6442
+F,CN4505300000000,"Jasper County, SC",0,T,6443
+F,CN4505500000000,"Kershaw County, SC",0,T,6444
+F,CN4505700000000,"Lancaster County, SC",0,T,6445
+F,CN4505900000000,"Laurens County, SC",0,T,6446
+F,CN4506100000000,"Lee County, SC",0,T,6447
+F,CN4506300000000,"Lexington County, SC",0,T,6448
+F,CN4506500000000,"McCormick County, SC",0,T,6449
+F,CN4506700000000,"Marion County, SC",0,T,6450
+F,CN4506900000000,"Marlboro County, SC",0,T,6451
+F,CN4507100000000,"Newberry County, SC",0,T,6452
+F,CN4507300000000,"Oconee County, SC",0,T,6453
+F,CN4507500000000,"Orangeburg County, SC",0,T,6454
+F,CN4507700000000,"Pickens County, SC",0,T,6455
+F,CN4507900000000,"Richland County, SC",0,T,6456
+F,CN4508100000000,"Saluda County, SC",0,T,6457
+F,CN4508300000000,"Spartanburg County, SC",0,T,6458
+F,CN4508500000000,"Sumter County, SC",0,T,6459
+F,CN4508700000000,"Union County, SC",0,T,6460
+F,CN4508900000000,"Williamsburg County, SC",0,T,6461
+F,CN4509100000000,"York County, SC",0,T,6462
+F,CN4600300000000,"Aurora County, SD",0,T,6511
+F,CN4600500000000,"Beadle County, SD",0,T,6512
+F,CN4600700000000,"Bennett County, SD",0,T,6513
+F,CN4600900000000,"Bon Homme County, SD",0,T,6514
+F,CN4601100000000,"Brookings County, SD",0,T,6515
+F,CN4601300000000,"Brown County, SD",0,T,6516
+F,CN4601500000000,"Brule County, SD",0,T,6517
+F,CN4601700000000,"Buffalo County, SD",0,T,6518
+F,CN4601900000000,"Butte County, SD",0,T,6519
+F,CN4602100000000,"Campbell County, SD",0,T,6520
+F,CN4602300000000,"Charles Mix County, SD",0,T,6521
+F,CN4602500000000,"Clark County, SD",0,T,6522
+F,CN4602700000000,"Clay County, SD",0,T,6523
+F,CN4602900000000,"Codington County, SD",0,T,6524
+F,CN4603100000000,"Corson County, SD",0,T,6525
+F,CN4603300000000,"Custer County, SD",0,T,6526
+F,CN4603500000000,"Davison County, SD",0,T,6527
+F,CN4603700000000,"Day County, SD",0,T,6528
+F,CN4603900000000,"Deuel County, SD",0,T,6529
+F,CN4604100000000,"Dewey County, SD",0,T,6530
+F,CN4604300000000,"Douglas County, SD",0,T,6531
+F,CN4604500000000,"Edmunds County, SD",0,T,6532
+F,CN4604700000000,"Fall River County, SD",0,T,6533
+F,CN4604900000000,"Faulk County, SD",0,T,6534
+F,CN4605100000000,"Grant County, SD",0,T,6535
+F,CN4605300000000,"Gregory County, SD",0,T,6536
+F,CN4605500000000,"Haakon County, SD",0,T,6537
+F,CN4605700000000,"Hamlin County, SD",0,T,6538
+F,CN4605900000000,"Hand County, SD",0,T,6539
+F,CN4606100000000,"Hanson County, SD",0,T,6540
+F,CN4606300000000,"Harding County, SD",0,T,6541
+F,CN4606500000000,"Hughes County, SD",0,T,6542
+F,CN4606700000000,"Hutchinson County, SD",0,T,6543
+F,CN4606900000000,"Hyde County, SD",0,T,6544
+F,CN4607100000000,"Jackson County, SD",0,T,6545
+F,CN4607300000000,"Jerauld County, SD",0,T,6546
+F,CN4607500000000,"Jones County, SD",0,T,6547
+F,CN4607700000000,"Kingsbury County, SD",0,T,6548
+F,CN4607900000000,"Lake County, SD",0,T,6549
+F,CN4608100000000,"Lawrence County, SD",0,T,6550
+F,CN4608300000000,"Lincoln County, SD",0,T,6551
+F,CN4608500000000,"Lyman County, SD",0,T,6552
+F,CN4608700000000,"McCook County, SD",0,T,6553
+F,CN4608900000000,"McPherson County, SD",0,T,6554
+F,CN4609100000000,"Marshall County, SD",0,T,6555
+F,CN4609300000000,"Meade County, SD",0,T,6556
+F,CN4609500000000,"Mellette County, SD",0,T,6557
+F,CN4609700000000,"Miner County, SD",0,T,6558
+F,CN4609900000000,"Minnehaha County, SD",0,T,6559
+F,CN4610100000000,"Moody County, SD",0,T,6560
+F,CN4610200000000,"Oglala Lakota County, SD",0,T,6561
+F,CN4610300000000,"Pennington County, SD",0,T,6562
+F,CN4610500000000,"Perkins County, SD",0,T,6563
+F,CN4610700000000,"Potter County, SD",0,T,6564
+F,CN4610900000000,"Roberts County, SD",0,T,6565
+F,CN4611100000000,"Sanborn County, SD",0,T,6566
+F,CN4611500000000,"Spink County, SD",0,T,6567
+F,CN4611700000000,"Stanley County, SD",0,T,6568
+F,CN4611900000000,"Sully County, SD",0,T,6569
+F,CN4612100000000,"Todd County, SD",0,T,6570
+F,CN4612300000000,"Tripp County, SD",0,T,6571
+F,CN4612500000000,"Turner County, SD",0,T,6572
+F,CN4612700000000,"Union County, SD",0,T,6573
+F,CN4612900000000,"Walworth County, SD",0,T,6574
+F,CN4613500000000,"Yankton County, SD",0,T,6575
+F,CN4613700000000,"Ziebach County, SD",0,T,6576
+F,CN4700100000000,"Anderson County, TN",0,T,6619
+F,CN4700300000000,"Bedford County, TN",0,T,6620
+F,CN4700500000000,"Benton County, TN",0,T,6621
+F,CN4700700000000,"Bledsoe County, TN",0,T,6622
+F,CN4700900000000,"Blount County, TN",0,T,6623
+F,CN4701100000000,"Bradley County, TN",0,T,6624
+F,CN4701300000000,"Campbell County, TN",0,T,6625
+F,CN4701500000000,"Cannon County, TN",0,T,6626
+F,CN4701700000000,"Carroll County, TN",0,T,6627
+F,CN4701900000000,"Carter County, TN",0,T,6628
+F,CN4702100000000,"Cheatham County, TN",0,T,6629
+F,CN4702300000000,"Chester County, TN",0,T,6630
+F,CN4702500000000,"Claiborne County, TN",0,T,6631
+F,CN4702700000000,"Clay County, TN",0,T,6632
+F,CN4702900000000,"Cocke County, TN",0,T,6633
+F,CN4703100000000,"Coffee County, TN",0,T,6634
+F,CN4703300000000,"Crockett County, TN",0,T,6635
+F,CN4703500000000,"Cumberland County, TN",0,T,6636
+F,CN4703700000000,"Davidson County, TN",0,T,6637
+F,CN4703900000000,"Decatur County, TN",0,T,6638
+F,CN4704100000000,"DeKalb County, TN",0,T,6639
+F,CN4704300000000,"Dickson County, TN",0,T,6640
+F,CN4704500000000,"Dyer County, TN",0,T,6641
+F,CN4704700000000,"Fayette County, TN",0,T,6642
+F,CN4704900000000,"Fentress County, TN",0,T,6643
+F,CN4705100000000,"Franklin County, TN",0,T,6644
+F,CN4705300000000,"Gibson County, TN",0,T,6645
+F,CN4705500000000,"Giles County, TN",0,T,6646
+F,CN4705700000000,"Grainger County, TN",0,T,6647
+F,CN4705900000000,"Greene County, TN",0,T,6648
+F,CN4706100000000,"Grundy County, TN",0,T,6649
+F,CN4706300000000,"Hamblen County, TN",0,T,6650
+F,CN4706500000000,"Hamilton County, TN",0,T,6651
+F,CN4706700000000,"Hancock County, TN",0,T,6652
+F,CN4706900000000,"Hardeman County, TN",0,T,6653
+F,CN4707100000000,"Hardin County, TN",0,T,6654
+F,CN4707300000000,"Hawkins County, TN",0,T,6655
+F,CN4707500000000,"Haywood County, TN",0,T,6656
+F,CN4707700000000,"Henderson County, TN",0,T,6657
+F,CN4707900000000,"Henry County, TN",0,T,6658
+F,CN4708100000000,"Hickman County, TN",0,T,6659
+F,CN4708300000000,"Houston County, TN",0,T,6660
+F,CN4708500000000,"Humphreys County, TN",0,T,6661
+F,CN4708700000000,"Jackson County, TN",0,T,6662
+F,CN4708900000000,"Jefferson County, TN",0,T,6663
+F,CN4709100000000,"Johnson County, TN",0,T,6664
+F,CN4709300000000,"Knox County, TN",0,T,6665
+F,CN4709500000000,"Lake County, TN",0,T,6666
+F,CN4709700000000,"Lauderdale County, TN",0,T,6667
+F,CN4709900000000,"Lawrence County, TN",0,T,6668
+F,CN4710100000000,"Lewis County, TN",0,T,6669
+F,CN4710300000000,"Lincoln County, TN",0,T,6670
+F,CN4710500000000,"Loudon County, TN",0,T,6671
+F,CN4710700000000,"McMinn County, TN",0,T,6672
+F,CN4710900000000,"McNairy County, TN",0,T,6673
+F,CN4711100000000,"Macon County, TN",0,T,6674
+F,CN4711300000000,"Madison County, TN",0,T,6675
+F,CN4711500000000,"Marion County, TN",0,T,6676
+F,CN4711700000000,"Marshall County, TN",0,T,6677
+F,CN4711900000000,"Maury County, TN",0,T,6678
+F,CN4712100000000,"Meigs County, TN",0,T,6679
+F,CN4712300000000,"Monroe County, TN",0,T,6680
+F,CN4712500000000,"Montgomery County, TN",0,T,6681
+F,CN4712700000000,"Moore County, TN",0,T,6682
+F,CN4712900000000,"Morgan County, TN",0,T,6683
+F,CN4713100000000,"Obion County, TN",0,T,6684
+F,CN4713300000000,"Overton County, TN",0,T,6685
+F,CN4713500000000,"Perry County, TN",0,T,6686
+F,CN4713700000000,"Pickett County, TN",0,T,6687
+F,CN4713900000000,"Polk County, TN",0,T,6688
+F,CN4714100000000,"Putnam County, TN",0,T,6689
+F,CN4714300000000,"Rhea County, TN",0,T,6690
+F,CN4714500000000,"Roane County, TN",0,T,6691
+F,CN4714700000000,"Robertson County, TN",0,T,6692
+F,CN4714900000000,"Rutherford County, TN",0,T,6693
+F,CN4715100000000,"Scott County, TN",0,T,6694
+F,CN4715300000000,"Sequatchie County, TN",0,T,6695
+F,CN4715500000000,"Sevier County, TN",0,T,6696
+F,CN4715700000000,"Shelby County, TN",0,T,6697
+F,CN4715900000000,"Smith County, TN",0,T,6698
+F,CN4716100000000,"Stewart County, TN",0,T,6699
+F,CN4716300000000,"Sullivan County, TN",0,T,6700
+F,CN4716500000000,"Sumner County, TN",0,T,6701
+F,CN4716700000000,"Tipton County, TN",0,T,6702
+F,CN4716900000000,"Trousdale County, TN",0,T,6703
+F,CN4717100000000,"Unicoi County, TN",0,T,6704
+F,CN4717300000000,"Union County, TN",0,T,6705
+F,CN4717500000000,"Van Buren County, TN",0,T,6706
+F,CN4717700000000,"Warren County, TN",0,T,6707
+F,CN4717900000000,"Washington County, TN",0,T,6708
+F,CN4718100000000,"Wayne County, TN",0,T,6709
+F,CN4718300000000,"Weakley County, TN",0,T,6710
+F,CN4718500000000,"White County, TN",0,T,6711
+F,CN4718700000000,"Williamson County, TN",0,T,6712
+F,CN4718900000000,"Wilson County, TN",0,T,6713
+F,CN4800100000000,"Anderson County, TX",0,T,6842
+F,CN4800300000000,"Andrews County, TX",0,T,6843
+F,CN4800500000000,"Angelina County, TX",0,T,6844
+F,CN4800700000000,"Aransas County, TX",0,T,6845
+F,CN4800900000000,"Archer County, TX",0,T,6846
+F,CN4801100000000,"Armstrong County, TX",0,T,6847
+F,CN4801300000000,"Atascosa County, TX",0,T,6848
+F,CN4801500000000,"Austin County, TX",0,T,6849
+F,CN4801700000000,"Bailey County, TX",0,T,6850
+F,CN4801900000000,"Bandera County, TX",0,T,6851
+F,CN4802100000000,"Bastrop County, TX",0,T,6852
+F,CN4802300000000,"Baylor County, TX",0,T,6853
+F,CN4802500000000,"Bee County, TX",0,T,6854
+F,CN4802700000000,"Bell County, TX",0,T,6855
+F,CN4802900000000,"Bexar County, TX",0,T,6856
+F,CN4803100000000,"Blanco County, TX",0,T,6857
+F,CN4803300000000,"Borden County, TX",0,T,6858
+F,CN4803500000000,"Bosque County, TX",0,T,6859
+F,CN4803700000000,"Bowie County, TX",0,T,6860
+F,CN4803900000000,"Brazoria County, TX",0,T,6861
+F,CN4804100000000,"Brazos County, TX",0,T,6862
+F,CN4804300000000,"Brewster County, TX",0,T,6863
+F,CN4804500000000,"Briscoe County, TX",0,T,6864
+F,CN4804700000000,"Brooks County, TX",0,T,6865
+F,CN4804900000000,"Brown County, TX",0,T,6866
+F,CN4805100000000,"Burleson County, TX",0,T,6867
+F,CN4805300000000,"Burnet County, TX",0,T,6868
+F,CN4805500000000,"Caldwell County, TX",0,T,6869
+F,CN4805700000000,"Calhoun County, TX",0,T,6870
+F,CN4805900000000,"Callahan County, TX",0,T,6871
+F,CN4806100000000,"Cameron County, TX",0,T,6872
+F,CN4806300000000,"Camp County, TX",0,T,6873
+F,CN4806500000000,"Carson County, TX",0,T,6874
+F,CN4806700000000,"Cass County, TX",0,T,6875
+F,CN4806900000000,"Castro County, TX",0,T,6876
+F,CN4807100000000,"Chambers County, TX",0,T,6877
+F,CN4807300000000,"Cherokee County, TX",0,T,6878
+F,CN4807500000000,"Childress County, TX",0,T,6879
+F,CN4807700000000,"Clay County, TX",0,T,6880
+F,CN4807900000000,"Cochran County, TX",0,T,6881
+F,CN4808100000000,"Coke County, TX",0,T,6882
+F,CN4808300000000,"Coleman County, TX",0,T,6883
+F,CN4808500000000,"Collin County, TX",0,T,6884
+F,CN4808700000000,"Collingsworth County, TX",0,T,6885
+F,CN4808900000000,"Colorado County, TX",0,T,6886
+F,CN4809100000000,"Comal County, TX",0,T,6887
+F,CN4809300000000,"Comanche County, TX",0,T,6888
+F,CN4809500000000,"Concho County, TX",0,T,6889
+F,CN4809700000000,"Cooke County, TX",0,T,6890
+F,CN4809900000000,"Coryell County, TX",0,T,6891
+F,CN4810100000000,"Cottle County, TX",0,T,6892
+F,CN4810300000000,"Crane County, TX",0,T,6893
+F,CN4810500000000,"Crockett County, TX",0,T,6894
+F,CN4810700000000,"Crosby County, TX",0,T,6895
+F,CN4810900000000,"Culberson County, TX",0,T,6896
+F,CN4811100000000,"Dallam County, TX",0,T,6897
+F,CN4811300000000,"Dallas County, TX",0,T,6898
+F,CN4811500000000,"Dawson County, TX",0,T,6899
+F,CN4811700000000,"Deaf Smith County, TX",0,T,6900
+F,CN4811900000000,"Delta County, TX",0,T,6901
+F,CN4812100000000,"Denton County, TX",0,T,6902
+F,CN4812300000000,"DeWitt County, TX",0,T,6903
+F,CN4812500000000,"Dickens County, TX",0,T,6904
+F,CN4812700000000,"Dimmit County, TX",0,T,6905
+F,CN4812900000000,"Donley County, TX",0,T,6906
+F,CN4813100000000,"Duval County, TX",0,T,6907
+F,CN4813300000000,"Eastland County, TX",0,T,6908
+F,CN4813500000000,"Ector County, TX",0,T,6909
+F,CN4813700000000,"Edwards County, TX",0,T,6910
+F,CN4813900000000,"Ellis County, TX",0,T,6911
+F,CN4814100000000,"El Paso County, TX",0,T,6912
+F,CN4814300000000,"Erath County, TX",0,T,6913
+F,CN4814500000000,"Falls County, TX",0,T,6914
+F,CN4814700000000,"Fannin County, TX",0,T,6915
+F,CN4814900000000,"Fayette County, TX",0,T,6916
+F,CN4815100000000,"Fisher County, TX",0,T,6917
+F,CN4815300000000,"Floyd County, TX",0,T,6918
+F,CN4815500000000,"Foard County, TX",0,T,6919
+F,CN4815700000000,"Fort Bend County, TX",0,T,6920
+F,CN4815900000000,"Franklin County, TX",0,T,6921
+F,CN4816100000000,"Freestone County, TX",0,T,6922
+F,CN4816300000000,"Frio County, TX",0,T,6923
+F,CN4816500000000,"Gaines County, TX",0,T,6924
+F,CN4816700000000,"Galveston County, TX",0,T,6925
+F,CN4816900000000,"Garza County, TX",0,T,6926
+F,CN4817100000000,"Gillespie County, TX",0,T,6927
+F,CN4817300000000,"Glasscock County, TX",0,T,6928
+F,CN4817500000000,"Goliad County, TX",0,T,6929
+F,CN4817700000000,"Gonzales County, TX",0,T,6930
+F,CN4817900000000,"Gray County, TX",0,T,6931
+F,CN4818100000000,"Grayson County, TX",0,T,6932
+F,CN4818300000000,"Gregg County, TX",0,T,6933
+F,CN4818500000000,"Grimes County, TX",0,T,6934
+F,CN4818700000000,"Guadalupe County, TX",0,T,6935
+F,CN4818900000000,"Hale County, TX",0,T,6936
+F,CN4819100000000,"Hall County, TX",0,T,6937
+F,CN4819300000000,"Hamilton County, TX",0,T,6938
+F,CN4819500000000,"Hansford County, TX",0,T,6939
+F,CN4819700000000,"Hardeman County, TX",0,T,6940
+F,CN4819900000000,"Hardin County, TX",0,T,6941
+F,CN4820100000000,"Harris County, TX",0,T,6942
+F,CN4820300000000,"Harrison County, TX",0,T,6943
+F,CN4820500000000,"Hartley County, TX",0,T,6944
+F,CN4820700000000,"Haskell County, TX",0,T,6945
+F,CN4820900000000,"Hays County, TX",0,T,6946
+F,CN4821100000000,"Hemphill County, TX",0,T,6947
+F,CN4821300000000,"Henderson County, TX",0,T,6948
+F,CN4821500000000,"Hidalgo County, TX",0,T,6949
+F,CN4821700000000,"Hill County, TX",0,T,6950
+F,CN4821900000000,"Hockley County, TX",0,T,6951
+F,CN4822100000000,"Hood County, TX",0,T,6952
+F,CN4822300000000,"Hopkins County, TX",0,T,6953
+F,CN4822500000000,"Houston County, TX",0,T,6954
+F,CN4822700000000,"Howard County, TX",0,T,6955
+F,CN4822900000000,"Hudspeth County, TX",0,T,6956
+F,CN4823100000000,"Hunt County, TX",0,T,6957
+F,CN4823300000000,"Hutchinson County, TX",0,T,6958
+F,CN4823500000000,"Irion County, TX",0,T,6959
+F,CN4823700000000,"Jack County, TX",0,T,6960
+F,CN4823900000000,"Jackson County, TX",0,T,6961
+F,CN4824100000000,"Jasper County, TX",0,T,6962
+F,CN4824300000000,"Jeff Davis County, TX",0,T,6963
+F,CN4824500000000,"Jefferson County, TX",0,T,6964
+F,CN4824700000000,"Jim Hogg County, TX",0,T,6965
+F,CN4824900000000,"Jim Wells County, TX",0,T,6966
+F,CN4825100000000,"Johnson County, TX",0,T,6967
+F,CN4825300000000,"Jones County, TX",0,T,6968
+F,CN4825500000000,"Karnes County, TX",0,T,6969
+F,CN4825700000000,"Kaufman County, TX",0,T,6970
+F,CN4825900000000,"Kendall County, TX",0,T,6971
+F,CN4826100000000,"Kenedy County, TX",0,T,6972
+F,CN4826300000000,"Kent County, TX",0,T,6973
+F,CN4826500000000,"Kerr County, TX",0,T,6974
+F,CN4826700000000,"Kimble County, TX",0,T,6975
+F,CN4826900000000,"King County, TX",0,T,6976
+F,CN4827100000000,"Kinney County, TX",0,T,6977
+F,CN4827300000000,"Kleberg County, TX",0,T,6978
+F,CN4827500000000,"Knox County, TX",0,T,6979
+F,CN4827700000000,"Lamar County, TX",0,T,6980
+F,CN4827900000000,"Lamb County, TX",0,T,6981
+F,CN4828100000000,"Lampasas County, TX",0,T,6982
+F,CN4828300000000,"La Salle County, TX",0,T,6983
+F,CN4828500000000,"Lavaca County, TX",0,T,6984
+F,CN4828700000000,"Lee County, TX",0,T,6985
+F,CN4828900000000,"Leon County, TX",0,T,6986
+F,CN4829100000000,"Liberty County, TX",0,T,6987
+F,CN4829300000000,"Limestone County, TX",0,T,6988
+F,CN4829500000000,"Lipscomb County, TX",0,T,6989
+F,CN4829700000000,"Live Oak County, TX",0,T,6990
+F,CN4829900000000,"Llano County, TX",0,T,6991
+F,CN4830100000000,"Loving County, TX",0,T,6992
+F,CN4830300000000,"Lubbock County, TX",0,T,6993
+F,CN4830500000000,"Lynn County, TX",0,T,6994
+F,CN4830700000000,"McCulloch County, TX",0,T,6995
+F,CN4830900000000,"McLennan County, TX",0,T,6996
+F,CN4831100000000,"McMullen County, TX",0,T,6997
+F,CN4831300000000,"Madison County, TX",0,T,6998
+F,CN4831500000000,"Marion County, TX",0,T,6999
+F,CN4831700000000,"Martin County, TX",0,T,7000
+F,CN4831900000000,"Mason County, TX",0,T,7001
+F,CN4832100000000,"Matagorda County, TX",0,T,7002
+F,CN4832300000000,"Maverick County, TX",0,T,7003
+F,CN4832500000000,"Medina County, TX",0,T,7004
+F,CN4832700000000,"Menard County, TX",0,T,7005
+F,CN4832900000000,"Midland County, TX",0,T,7006
+F,CN4833100000000,"Milam County, TX",0,T,7007
+F,CN4833300000000,"Mills County, TX",0,T,7008
+F,CN4833500000000,"Mitchell County, TX",0,T,7009
+F,CN4833700000000,"Montague County, TX",0,T,7010
+F,CN4833900000000,"Montgomery County, TX",0,T,7011
+F,CN4834100000000,"Moore County, TX",0,T,7012
+F,CN4834300000000,"Morris County, TX",0,T,7013
+F,CN4834500000000,"Motley County, TX",0,T,7014
+F,CN4834700000000,"Nacogdoches County, TX",0,T,7015
+F,CN4834900000000,"Navarro County, TX",0,T,7016
+F,CN4835100000000,"Newton County, TX",0,T,7017
+F,CN4835300000000,"Nolan County, TX",0,T,7018
+F,CN4835500000000,"Nueces County, TX",0,T,7019
+F,CN4835700000000,"Ochiltree County, TX",0,T,7020
+F,CN4835900000000,"Oldham County, TX",0,T,7021
+F,CN4836100000000,"Orange County, TX",0,T,7022
+F,CN4836300000000,"Palo Pinto County, TX",0,T,7023
+F,CN4836500000000,"Panola County, TX",0,T,7024
+F,CN4836700000000,"Parker County, TX",0,T,7025
+F,CN4836900000000,"Parmer County, TX",0,T,7026
+F,CN4837100000000,"Pecos County, TX",0,T,7027
+F,CN4837300000000,"Polk County, TX",0,T,7028
+F,CN4837500000000,"Potter County, TX",0,T,7029
+F,CN4837700000000,"Presidio County, TX",0,T,7030
+F,CN4837900000000,"Rains County, TX",0,T,7031
+F,CN4838100000000,"Randall County, TX",0,T,7032
+F,CN4838300000000,"Reagan County, TX",0,T,7033
+F,CN4838500000000,"Real County, TX",0,T,7034
+F,CN4838700000000,"Red River County, TX",0,T,7035
+F,CN4838900000000,"Reeves County, TX",0,T,7036
+F,CN4839100000000,"Refugio County, TX",0,T,7037
+F,CN4839300000000,"Roberts County, TX",0,T,7038
+F,CN4839500000000,"Robertson County, TX",0,T,7039
+F,CN4839700000000,"Rockwall County, TX",0,T,7040
+F,CN4839900000000,"Runnels County, TX",0,T,7041
+F,CN4840100000000,"Rusk County, TX",0,T,7042
+F,CN4840300000000,"Sabine County, TX",0,T,7043
+F,CN4840500000000,"San Augustine County, TX",0,T,7044
+F,CN4840700000000,"San Jacinto County, TX",0,T,7045
+F,CN4840900000000,"San Patricio County, TX",0,T,7046
+F,CN4841100000000,"San Saba County, TX",0,T,7047
+F,CN4841300000000,"Schleicher County, TX",0,T,7048
+F,CN4841500000000,"Scurry County, TX",0,T,7049
+F,CN4841700000000,"Shackelford County, TX",0,T,7050
+F,CN4841900000000,"Shelby County, TX",0,T,7051
+F,CN4842100000000,"Sherman County, TX",0,T,7052
+F,CN4842300000000,"Smith County, TX",0,T,7053
+F,CN4842500000000,"Somervell County, TX",0,T,7054
+F,CN4842700000000,"Starr County, TX",0,T,7055
+F,CN4842900000000,"Stephens County, TX",0,T,7056
+F,CN4843100000000,"Sterling County, TX",0,T,7057
+F,CN4843300000000,"Stonewall County, TX",0,T,7058
+F,CN4843500000000,"Sutton County, TX",0,T,7059
+F,CN4843700000000,"Swisher County, TX",0,T,7060
+F,CN4843900000000,"Tarrant County, TX",0,T,7061
+F,CN4844100000000,"Taylor County, TX",0,T,7062
+F,CN4844300000000,"Terrell County, TX",0,T,7063
+F,CN4844500000000,"Terry County, TX",0,T,7064
+F,CN4844700000000,"Throckmorton County, TX",0,T,7065
+F,CN4844900000000,"Titus County, TX",0,T,7066
+F,CN4845100000000,"Tom Green County, TX",0,T,7067
+F,CN4845300000000,"Travis County, TX",0,T,7068
+F,CN4845500000000,"Trinity County, TX",0,T,7069
+F,CN4845700000000,"Tyler County, TX",0,T,7070
+F,CN4845900000000,"Upshur County, TX",0,T,7071
+F,CN4846100000000,"Upton County, TX",0,T,7072
+F,CN4846300000000,"Uvalde County, TX",0,T,7073
+F,CN4846500000000,"Val Verde County, TX",0,T,7074
+F,CN4846700000000,"Van Zandt County, TX",0,T,7075
+F,CN4846900000000,"Victoria County, TX",0,T,7076
+F,CN4847100000000,"Walker County, TX",0,T,7077
+F,CN4847300000000,"Waller County, TX",0,T,7078
+F,CN4847500000000,"Ward County, TX",0,T,7079
+F,CN4847700000000,"Washington County, TX",0,T,7080
+F,CN4847900000000,"Webb County, TX",0,T,7081
+F,CN4848100000000,"Wharton County, TX",0,T,7082
+F,CN4848300000000,"Wheeler County, TX",0,T,7083
+F,CN4848500000000,"Wichita County, TX",0,T,7084
+F,CN4848700000000,"Wilbarger County, TX",0,T,7085
+F,CN4848900000000,"Willacy County, TX",0,T,7086
+F,CN4849100000000,"Williamson County, TX",0,T,7087
+F,CN4849300000000,"Wilson County, TX",0,T,7088
+F,CN4849500000000,"Winkler County, TX",0,T,7089
+F,CN4849700000000,"Wise County, TX",0,T,7090
+F,CN4849900000000,"Wood County, TX",0,T,7091
+F,CN4850100000000,"Yoakum County, TX",0,T,7092
+F,CN4850300000000,"Young County, TX",0,T,7093
+F,CN4850500000000,"Zapata County, TX",0,T,7094
+F,CN4850700000000,"Zavala County, TX",0,T,7095
+F,CN4900100000000,"Beaver County, UT",0,T,7322
+F,CN4900300000000,"Box Elder County, UT",0,T,7323
+F,CN4900500000000,"Cache County, UT",0,T,7324
+F,CN4900700000000,"Carbon County, UT",0,T,7325
+F,CN4900900000000,"Daggett County, UT",0,T,7326
+F,CN4901100000000,"Davis County, UT",0,T,7327
+F,CN4901300000000,"Duchesne County, UT",0,T,7328
+F,CN4901500000000,"Emery County, UT",0,T,7329
+F,CN4901700000000,"Garfield County, UT",0,T,7330
+F,CN4901900000000,"Grand County, UT",0,T,7331
+F,CN4902100000000,"Iron County, UT",0,T,7332
+F,CN4902300000000,"Juab County, UT",0,T,7333
+F,CN4902500000000,"Kane County, UT",0,T,7334
+F,CN4902700000000,"Millard County, UT",0,T,7335
+F,CN4902900000000,"Morgan County, UT",0,T,7336
+F,CN4903100000000,"Piute County, UT",0,T,7337
+F,CN4903300000000,"Rich County, UT",0,T,7338
+F,CN4903500000000,"Salt Lake County, UT",0,T,7339
+F,CN4903700000000,"San Juan County, UT",0,T,7340
+F,CN4903900000000,"Sanpete County, UT",0,T,7341
+F,CN4904100000000,"Sevier County, UT",0,T,7342
+F,CN4904300000000,"Summit County, UT",0,T,7343
+F,CN4904500000000,"Tooele County, UT",0,T,7344
+F,CN4904700000000,"Uintah County, UT",0,T,7345
+F,CN4904900000000,"Utah County, UT",0,T,7346
+F,CN4905100000000,"Wasatch County, UT",0,T,7347
+F,CN4905300000000,"Washington County, UT",0,T,7348
+F,CN4905500000000,"Wayne County, UT",0,T,7349
+F,CN4905700000000,"Weber County, UT",0,T,7350
+F,CN5000100000000,"Addison County, VT",0,T,7398
+F,CN5000300000000,"Bennington County, VT",0,T,7399
+F,CN5000500000000,"Caledonia County, VT",0,T,7400
+F,CN5000700000000,"Chittenden County, VT",0,T,7401
+F,CN5000900000000,"Essex County, VT",0,T,7402
+F,CN5001100000000,"Franklin County, VT",0,T,7403
+F,CN5001300000000,"Grand Isle County, VT",0,T,7404
+F,CN5001500000000,"Lamoille County, VT",0,T,7405
+F,CN5001700000000,"Orange County, VT",0,T,7406
+F,CN5001900000000,"Orleans County, VT",0,T,7407
+F,CN5002100000000,"Rutland County, VT",0,T,7408
+F,CN5002300000000,"Washington County, VT",0,T,7409
+F,CN5002500000000,"Windham County, VT",0,T,7410
+F,CN5002700000000,"Windsor County, VT",0,T,7411
+F,CN5100100000000,"Accomack County, VA",0,T,7695
+F,CN5100300000000,"Albemarle County, VA",0,T,7696
+F,CN5100500000000,"Alleghany County, VA",0,T,7697
+F,CN5100700000000,"Amelia County, VA",0,T,7698
+F,CN5100900000000,"Amherst County, VA",0,T,7699
+F,CN5101100000000,"Appomattox County, VA",0,T,7700
+F,CN5101300000000,"Arlington County, VA",0,T,7701
+F,CN5101500000000,"Augusta County, VA",0,T,7702
+F,CN5101700000000,"Bath County, VA",0,T,7703
+F,CN5101900000000,"Bedford County, VA",0,T,7704
+F,CN5102100000000,"Bland County, VA",0,T,7705
+F,CN5102300000000,"Botetourt County, VA",0,T,7706
+F,CN5102500000000,"Brunswick County, VA",0,T,7707
+F,CN5102700000000,"Buchanan County, VA",0,T,7708
+F,CN5102900000000,"Buckingham County, VA",0,T,7709
+F,CN5103100000000,"Campbell County, VA",0,T,7710
+F,CN5103300000000,"Caroline County, VA",0,T,7711
+F,CN5103500000000,"Carroll County, VA",0,T,7712
+F,CN5103600000000,"Charles City County, VA",0,T,7713
+F,CN5103700000000,"Charlotte County, VA",0,T,7714
+F,CN5104100000000,"Chesterfield County, VA",0,T,7715
+F,CN5104300000000,"Clarke County, VA",0,T,7716
+F,CN5104500000000,"Craig County, VA",0,T,7717
+F,CN5104700000000,"Culpeper County, VA",0,T,7718
+F,CN5104900000000,"Cumberland County, VA",0,T,7719
+F,CN5105100000000,"Dickenson County, VA",0,T,7720
+F,CN5105300000000,"Dinwiddie County, VA",0,T,7721
+F,CN5105700000000,"Essex County, VA",0,T,7722
+F,CN5105900000000,"Fairfax County, VA",0,T,7723
+F,CN5106100000000,"Fauquier County, VA",0,T,7724
+F,CN5106300000000,"Floyd County, VA",0,T,7725
+F,CN5106500000000,"Fluvanna County, VA",0,T,7726
+F,CN5106700000000,"Franklin County, VA",0,T,7727
+F,CN5106900000000,"Frederick County, VA",0,T,7728
+F,CN5107100000000,"Giles County, VA",0,T,7729
+F,CN5107300000000,"Gloucester County, VA",0,T,7730
+F,CN5107500000000,"Goochland County, VA",0,T,7731
+F,CN5107700000000,"Grayson County, VA",0,T,7732
+F,CN5107900000000,"Greene County, VA",0,T,7733
+F,CN5108100000000,"Greensville County, VA",0,T,7734
+F,CN5108300000000,"Halifax County, VA",0,T,7735
+F,CN5108500000000,"Hanover County, VA",0,T,7736
+F,CN5108700000000,"Henrico County, VA",0,T,7737
+F,CN5108900000000,"Henry County, VA",0,T,7738
+F,CN5109100000000,"Highland County, VA",0,T,7739
+F,CN5109300000000,"Isle of Wight County, VA",0,T,7740
+F,CN5109500000000,"James City County, VA",0,T,7741
+F,CN5109700000000,"King and Queen County, VA",0,T,7742
+F,CN5109900000000,"King George County, VA",0,T,7743
+F,CN5110100000000,"King William County, VA",0,T,7744
+F,CN5110300000000,"Lancaster County, VA",0,T,7745
+F,CN5110500000000,"Lee County, VA",0,T,7746
+F,CN5110700000000,"Loudoun County, VA",0,T,7747
+F,CN5110900000000,"Louisa County, VA",0,T,7748
+F,CN5111100000000,"Lunenburg County, VA",0,T,7749
+F,CN5111300000000,"Madison County, VA",0,T,7750
+F,CN5111500000000,"Mathews County, VA",0,T,7751
+F,CN5111700000000,"Mecklenburg County, VA",0,T,7752
+F,CN5111900000000,"Middlesex County, VA",0,T,7753
+F,CN5112100000000,"Montgomery County, VA",0,T,7754
+F,CN5112500000000,"Nelson County, VA",0,T,7755
+F,CN5112700000000,"New Kent County, VA",0,T,7756
+F,CN5113100000000,"Northampton County, VA",0,T,7757
+F,CN5113300000000,"Northumberland County, VA",0,T,7758
+F,CN5113500000000,"Nottoway County, VA",0,T,7759
+F,CN5113700000000,"Orange County, VA",0,T,7760
+F,CN5113900000000,"Page County, VA",0,T,7761
+F,CN5114100000000,"Patrick County, VA",0,T,7762
+F,CN5114300000000,"Pittsylvania County, VA",0,T,7763
+F,CN5114500000000,"Powhatan County, VA",0,T,7764
+F,CN5114700000000,"Prince Edward County, VA",0,T,7765
+F,CN5114900000000,"Prince George County, VA",0,T,7766
+F,CN5115300000000,"Prince William County, VA",0,T,7767
+F,CN5115500000000,"Pulaski County, VA",0,T,7768
+F,CN5115700000000,"Rappahannock County, VA",0,T,7769
+F,CN5115900000000,"Richmond County, VA",0,T,7770
+F,CN5116100000000,"Roanoke County, VA",0,T,7771
+F,CN5116300000000,"Rockbridge County, VA",0,T,7772
+F,CN5116500000000,"Rockingham County, VA",0,T,7773
+F,CN5116700000000,"Russell County, VA",0,T,7774
+F,CN5116900000000,"Scott County, VA",0,T,7775
+F,CN5117100000000,"Shenandoah County, VA",0,T,7776
+F,CN5117300000000,"Smyth County, VA",0,T,7777
+F,CN5117500000000,"Southampton County, VA",0,T,7778
+F,CN5117700000000,"Spotsylvania County, VA",0,T,7779
+F,CN5117900000000,"Stafford County, VA",0,T,7780
+F,CN5118100000000,"Surry County, VA",0,T,7781
+F,CN5118300000000,"Sussex County, VA",0,T,7782
+F,CN5118500000000,"Tazewell County, VA",0,T,7783
+F,CN5118700000000,"Warren County, VA",0,T,7784
+F,CN5119100000000,"Washington County, VA",0,T,7785
+F,CN5119300000000,"Westmoreland County, VA",0,T,7786
+F,CN5119500000000,"Wise County, VA",0,T,7787
+F,CN5119700000000,"Wythe County, VA",0,T,7788
+F,CN5119900000000,"York County, VA",0,T,7789
+F,CN5151000000000,"Alexandria city, VA",0,T,7790
+F,CN5152000000000,"Bristol city, VA",0,T,7791
+F,CN5153000000000,"Buena Vista city, VA",0,T,7792
+F,CN5154000000000,"Charlottesville city, VA",0,T,7793
+F,CN5155000000000,"Chesapeake city, VA",0,T,7794
+F,CN5157000000000,"Colonial Heights city, VA",0,T,7795
+F,CN5158000000000,"Covington city, VA",0,T,7796
+F,CN5159000000000,"Danville city, VA",0,T,7797
+F,CN5159500000000,"Emporia city, VA",0,T,7798
+F,CN5160000000000,"Fairfax city, VA",0,T,7799
+F,CN5161000000000,"Falls Church city, VA",0,T,7800
+F,CN5162000000000,"Franklin city, VA",0,T,7801
+F,CN5163000000000,"Fredericksburg city, VA",0,T,7802
+F,CN5164000000000,"Galax city, VA",0,T,7803
+F,CN5165000000000,"Hampton city, VA",0,T,7804
+F,CN5166000000000,"Harrisonburg city, VA",0,T,7805
+F,CN5167000000000,"Hopewell city, VA",0,T,7806
+F,CN5167800000000,"Lexington city, VA",0,T,7807
+F,CN5168000000000,"Lynchburg city, VA",0,T,7808
+F,CN5168300000000,"Manassas city, VA",0,T,7809
+F,CN5168500000000,"Manassas Park city, VA",0,T,7810
+F,CN5169000000000,"Martinsville city, VA",0,T,7811
+F,CN5170000000000,"Newport News city, VA",0,T,7812
+F,CN5171000000000,"Norfolk city, VA",0,T,7813
+F,CN5172000000000,"Norton city, VA",0,T,7814
+F,CN5173000000000,"Petersburg city, VA",0,T,7815
+F,CN5173500000000,"Poquoson city, VA",0,T,7816
+F,CN5174000000000,"Portsmouth city, VA",0,T,7817
+F,CN5175000000000,"Radford city, VA",0,T,7818
+F,CN5176000000000,"Richmond city, VA",0,T,7819
+F,CN5177000000000,"Roanoke city, VA",0,T,7820
+F,CN5177500000000,"Salem city, VA",0,T,7821
+F,CN5179000000000,"Staunton city, VA",0,T,7822
+F,CN5180000000000,"Suffolk city, VA",0,T,7823
+F,CN5181000000000,"Virginia Beach city, VA",0,T,7824
+F,CN5182000000000,"Waynesboro city, VA",0,T,7825
+F,CN5183000000000,"Williamsburg city, VA",0,T,7826
+F,CN5184000000000,"Winchester city, VA",0,T,7827
+F,CN5300100000000,"Adams County, WA",0,T,7906
+F,CN5300300000000,"Asotin County, WA",0,T,7907
+F,CN5300500000000,"Benton County, WA",0,T,7908
+F,CN5300700000000,"Chelan County, WA",0,T,7909
+F,CN5300900000000,"Clallam County, WA",0,T,7910
+F,CN5301100000000,"Clark County, WA",0,T,7911
+F,CN5301300000000,"Columbia County, WA",0,T,7912
+F,CN5301500000000,"Cowlitz County, WA",0,T,7913
+F,CN5301700000000,"Douglas County, WA",0,T,7914
+F,CN5301900000000,"Ferry County, WA",0,T,7915
+F,CN5302100000000,"Franklin County, WA",0,T,7916
+F,CN5302300000000,"Garfield County, WA",0,T,7917
+F,CN5302500000000,"Grant County, WA",0,T,7918
+F,CN5302700000000,"Grays Harbor County, WA",0,T,7919
+F,CN5302900000000,"Island County, WA",0,T,7920
+F,CN5303100000000,"Jefferson County, WA",0,T,7921
+F,CN5303300000000,"King County, WA",0,T,7922
+F,CN5303500000000,"Kitsap County, WA",0,T,7923
+F,CN5303700000000,"Kittitas County, WA",0,T,7924
+F,CN5303900000000,"Klickitat County, WA",0,T,7925
+F,CN5304100000000,"Lewis County, WA",0,T,7926
+F,CN5304300000000,"Lincoln County, WA",0,T,7927
+F,CN5304500000000,"Mason County, WA",0,T,7928
+F,CN5304700000000,"Okanogan County, WA",0,T,7929
+F,CN5304900000000,"Pacific County, WA",0,T,7930
+F,CN5305100000000,"Pend Oreille County, WA",0,T,7931
+F,CN5305300000000,"Pierce County, WA",0,T,7932
+F,CN5305500000000,"San Juan County, WA",0,T,7933
+F,CN5305700000000,"Skagit County, WA",0,T,7934
+F,CN5305900000000,"Skamania County, WA",0,T,7935
+F,CN5306100000000,"Snohomish County, WA",0,T,7936
+F,CN5306300000000,"Spokane County, WA",0,T,7937
+F,CN5306500000000,"Stevens County, WA",0,T,7938
+F,CN5306700000000,"Thurston County, WA",0,T,7939
+F,CN5306900000000,"Wahkiakum County, WA",0,T,7940
+F,CN5307100000000,"Walla Walla County, WA",0,T,7941
+F,CN5307300000000,"Whatcom County, WA",0,T,7942
+F,CN5307500000000,"Whitman County, WA",0,T,7943
+F,CN5307700000000,"Yakima County, WA",0,T,7944
+F,CN5400100000000,"Barbour County, WV",0,T,8013
+F,CN5400300000000,"Berkeley County, WV",0,T,8014
+F,CN5400500000000,"Boone County, WV",0,T,8015
+F,CN5400700000000,"Braxton County, WV",0,T,8016
+F,CN5400900000000,"Brooke County, WV",0,T,8017
+F,CN5401100000000,"Cabell County, WV",0,T,8018
+F,CN5401300000000,"Calhoun County, WV",0,T,8019
+F,CN5401500000000,"Clay County, WV",0,T,8020
+F,CN5401700000000,"Doddridge County, WV",0,T,8021
+F,CN5401900000000,"Fayette County, WV",0,T,8022
+F,CN5402100000000,"Gilmer County, WV",0,T,8023
+F,CN5402300000000,"Grant County, WV",0,T,8024
+F,CN5402500000000,"Greenbrier County, WV",0,T,8025
+F,CN5402700000000,"Hampshire County, WV",0,T,8026
+F,CN5402900000000,"Hancock County, WV",0,T,8027
+F,CN5403100000000,"Hardy County, WV",0,T,8028
+F,CN5403300000000,"Harrison County, WV",0,T,8029
+F,CN5403500000000,"Jackson County, WV",0,T,8030
+F,CN5403700000000,"Jefferson County, WV",0,T,8031
+F,CN5403900000000,"Kanawha County, WV",0,T,8032
+F,CN5404100000000,"Lewis County, WV",0,T,8033
+F,CN5404300000000,"Lincoln County, WV",0,T,8034
+F,CN5404500000000,"Logan County, WV",0,T,8035
+F,CN5404700000000,"McDowell County, WV",0,T,8036
+F,CN5404900000000,"Marion County, WV",0,T,8037
+F,CN5405100000000,"Marshall County, WV",0,T,8038
+F,CN5405300000000,"Mason County, WV",0,T,8039
+F,CN5405500000000,"Mercer County, WV",0,T,8040
+F,CN5405700000000,"Mineral County, WV",0,T,8041
+F,CN5405900000000,"Mingo County, WV",0,T,8042
+F,CN5406100000000,"Monongalia County, WV",0,T,8043
+F,CN5406300000000,"Monroe County, WV",0,T,8044
+F,CN5406500000000,"Morgan County, WV",0,T,8045
+F,CN5406700000000,"Nicholas County, WV",0,T,8046
+F,CN5406900000000,"Ohio County, WV",0,T,8047
+F,CN5407100000000,"Pendleton County, WV",0,T,8048
+F,CN5407300000000,"Pleasants County, WV",0,T,8049
+F,CN5407500000000,"Pocahontas County, WV",0,T,8050
+F,CN5407700000000,"Preston County, WV",0,T,8051
+F,CN5407900000000,"Putnam County, WV",0,T,8052
+F,CN5408100000000,"Raleigh County, WV",0,T,8053
+F,CN5408300000000,"Randolph County, WV",0,T,8054
+F,CN5408500000000,"Ritchie County, WV",0,T,8055
+F,CN5408700000000,"Roane County, WV",0,T,8056
+F,CN5408900000000,"Summers County, WV",0,T,8057
+F,CN5409100000000,"Taylor County, WV",0,T,8058
+F,CN5409300000000,"Tucker County, WV",0,T,8059
+F,CN5409500000000,"Tyler County, WV",0,T,8060
+F,CN5409700000000,"Upshur County, WV",0,T,8061
+F,CN5409900000000,"Wayne County, WV",0,T,8062
+F,CN5410100000000,"Webster County, WV",0,T,8063
+F,CN5410300000000,"Wetzel County, WV",0,T,8064
+F,CN5410500000000,"Wirt County, WV",0,T,8065
+F,CN5410700000000,"Wood County, WV",0,T,8066
+F,CN5410900000000,"Wyoming County, WV",0,T,8067
+F,CN5500100000000,"Adams County, WI",0,T,8117
+F,CN5500300000000,"Ashland County, WI",0,T,8118
+F,CN5500500000000,"Barron County, WI",0,T,8119
+F,CN5500700000000,"Bayfield County, WI",0,T,8120
+F,CN5500900000000,"Brown County, WI",0,T,8121
+F,CN5501100000000,"Buffalo County, WI",0,T,8122
+F,CN5501300000000,"Burnett County, WI",0,T,8123
+F,CN5501500000000,"Calumet County, WI",0,T,8124
+F,CN5501700000000,"Chippewa County, WI",0,T,8125
+F,CN5501900000000,"Clark County, WI",0,T,8126
+F,CN5502100000000,"Columbia County, WI",0,T,8127
+F,CN5502300000000,"Crawford County, WI",0,T,8128
+F,CN5502500000000,"Dane County, WI",0,T,8129
+F,CN5502700000000,"Dodge County, WI",0,T,8130
+F,CN5502900000000,"Door County, WI",0,T,8131
+F,CN5503100000000,"Douglas County, WI",0,T,8132
+F,CN5503300000000,"Dunn County, WI",0,T,8133
+F,CN5503500000000,"Eau Claire County, WI",0,T,8134
+F,CN5503700000000,"Florence County, WI",0,T,8135
+F,CN5503900000000,"Fond du Lac County, WI",0,T,8136
+F,CN5504100000000,"Forest County, WI",0,T,8137
+F,CN5504300000000,"Grant County, WI",0,T,8138
+F,CN5504500000000,"Green County, WI",0,T,8139
+F,CN5504700000000,"Green Lake County, WI",0,T,8140
+F,CN5504900000000,"Iowa County, WI",0,T,8141
+F,CN5505100000000,"Iron County, WI",0,T,8142
+F,CN5505300000000,"Jackson County, WI",0,T,8143
+F,CN5505500000000,"Jefferson County, WI",0,T,8144
+F,CN5505700000000,"Juneau County, WI",0,T,8145
+F,CN5505900000000,"Kenosha County, WI",0,T,8146
+F,CN5506100000000,"Kewaunee County, WI",0,T,8147
+F,CN5506300000000,"La Crosse County, WI",0,T,8148
+F,CN5506500000000,"Lafayette County, WI",0,T,8149
+F,CN5506700000000,"Langlade County, WI",0,T,8150
+F,CN5506900000000,"Lincoln County, WI",0,T,8151
+F,CN5507100000000,"Manitowoc County, WI",0,T,8152
+F,CN5507300000000,"Marathon County, WI",0,T,8153
+F,CN5507500000000,"Marinette County, WI",0,T,8154
+F,CN5507700000000,"Marquette County, WI",0,T,8155
+F,CN5507800000000,"Menominee County, WI",0,T,8156
+F,CN5507900000000,"Milwaukee County, WI",0,T,8157
+F,CN5508100000000,"Monroe County, WI",0,T,8158
+F,CN5508300000000,"Oconto County, WI",0,T,8159
+F,CN5508500000000,"Oneida County, WI",0,T,8160
+F,CN5508700000000,"Outagamie County, WI",0,T,8161
+F,CN5508900000000,"Ozaukee County, WI",0,T,8162
+F,CN5509100000000,"Pepin County, WI",0,T,8163
+F,CN5509300000000,"Pierce County, WI",0,T,8164
+F,CN5509500000000,"Polk County, WI",0,T,8165
+F,CN5509700000000,"Portage County, WI",0,T,8166
+F,CN5509900000000,"Price County, WI",0,T,8167
+F,CN5510100000000,"Racine County, WI",0,T,8168
+F,CN5510300000000,"Richland County, WI",0,T,8169
+F,CN5510500000000,"Rock County, WI",0,T,8170
+F,CN5510700000000,"Rusk County, WI",0,T,8171
+F,CN5510900000000,"St. Croix County, WI",0,T,8172
+F,CN5511100000000,"Sauk County, WI",0,T,8173
+F,CN5511300000000,"Sawyer County, WI",0,T,8174
+F,CN5511500000000,"Shawano County, WI",0,T,8175
+F,CN5511700000000,"Sheboygan County, WI",0,T,8176
+F,CN5511900000000,"Taylor County, WI",0,T,8177
+F,CN5512100000000,"Trempealeau County, WI",0,T,8178
+F,CN5512300000000,"Vernon County, WI",0,T,8179
+F,CN5512500000000,"Vilas County, WI",0,T,8180
+F,CN5512700000000,"Walworth County, WI",0,T,8181
+F,CN5512900000000,"Washburn County, WI",0,T,8182
+F,CN5513100000000,"Washington County, WI",0,T,8183
+F,CN5513300000000,"Waukesha County, WI",0,T,8184
+F,CN5513500000000,"Waupaca County, WI",0,T,8185
+F,CN5513700000000,"Waushara County, WI",0,T,8186
+F,CN5513900000000,"Winnebago County, WI",0,T,8187
+F,CN5514100000000,"Wood County, WI",0,T,8188
+F,CN5600100000000,"Albany County, WY",0,T,8247
+F,CN5600300000000,"Big Horn County, WY",0,T,8248
+F,CN5600500000000,"Campbell County, WY",0,T,8249
+F,CN5600700000000,"Carbon County, WY",0,T,8250
+F,CN5600900000000,"Converse County, WY",0,T,8251
+F,CN5601100000000,"Crook County, WY",0,T,8252
+F,CN5601300000000,"Fremont County, WY",0,T,8253
+F,CN5601500000000,"Goshen County, WY",0,T,8254
+F,CN5601700000000,"Hot Springs County, WY",0,T,8255
+F,CN5601900000000,"Johnson County, WY",0,T,8256
+F,CN5602100000000,"Laramie County, WY",0,T,8257
+F,CN5602300000000,"Lincoln County, WY",0,T,8258
+F,CN5602500000000,"Natrona County, WY",0,T,8259
+F,CN5602700000000,"Niobrara County, WY",0,T,8260
+F,CN5602900000000,"Park County, WY",0,T,8261
+F,CN5603100000000,"Platte County, WY",0,T,8262
+F,CN5603300000000,"Sheridan County, WY",0,T,8263
+F,CN5603500000000,"Sublette County, WY",0,T,8264
+F,CN5603700000000,"Sweetwater County, WY",0,T,8265
+F,CN5603900000000,"Teton County, WY",0,T,8266
+F,CN5604100000000,"Uinta County, WY",0,T,8267
+F,CN5604300000000,"Washakie County, WY",0,T,8268
+F,CN5604500000000,"Weston County, WY",0,T,8269
+F,CN7200100000000,"Adjuntas Municipio, PR",0,T,8291
+F,CN7200300000000,"Aguada Municipio, PR",0,T,8292
+F,CN7200500000000,"Aguadilla Municipio, PR",0,T,8293
+F,CN7200700000000,"Aguas Buenas Municipio, PR",0,T,8294
+F,CN7200900000000,"Aibonito Municipio, PR",0,T,8295
+F,CN7201100000000,"Anasco Municipio, PR",0,T,8296
+F,CN7201300000000,"Arecibo Municipio, PR",0,T,8297
+F,CN7201500000000,"Arroyo Municipio, PR",0,T,8298
+F,CN7201700000000,"Barceloneta Municipio, PR",0,T,8299
+F,CN7201900000000,"Barranquitas Municipio, PR",0,T,8300
+F,CN7202100000000,"Bayamon Municipio, PR",0,T,8301
+F,CN7202300000000,"Cabo Rojo Municipio, PR",0,T,8302
+F,CN7202500000000,"Caguas Municipio, PR",0,T,8303
+F,CN7202700000000,"Camuy Municipio, PR",0,T,8304
+F,CN7202900000000,"Canovanas Municipio, PR",0,T,8305
+F,CN7203100000000,"Carolina Municipio, PR",0,T,8306
+F,CN7203300000000,"Catano Municipio, PR",0,T,8307
+F,CN7203500000000,"Cayey Municipio, PR",0,T,8308
+F,CN7203700000000,"Ceiba Municipio, PR",0,T,8309
+F,CN7203900000000,"Ciales Municipio, PR",0,T,8310
+F,CN7204100000000,"Cidra Municipio, PR",0,T,8311
+F,CN7204300000000,"Coamo Municipio, PR",0,T,8312
+F,CN7204500000000,"Comerio Municipio, PR",0,T,8313
+F,CN7204700000000,"Corozal Municipio, PR",0,T,8314
+F,CN7204900000000,"Culebra Municipio, PR",0,T,8315
+F,CN7205100000000,"Dorado Municipio, PR",0,T,8316
+F,CN7205300000000,"Fajardo Municipio, PR",0,T,8317
+F,CN7205400000000,"Florida Municipio, PR",0,T,8318
+F,CN7205500000000,"Guanica Municipio, PR",0,T,8319
+F,CN7205700000000,"Guayama Municipio, PR",0,T,8320
+F,CN7205900000000,"Guayanilla Municipio, PR",0,T,8321
+F,CN7206100000000,"Guaynabo Municipio, PR",0,T,8322
+F,CN7206300000000,"Gurabo Municipio, PR",0,T,8323
+F,CN7206500000000,"Hatillo Municipio, PR",0,T,8324
+F,CN7206700000000,"Hormigueros Municipio, PR",0,T,8325
+F,CN7206900000000,"Humacao Municipio, PR",0,T,8326
+F,CN7207100000000,"Isabela Municipio, PR",0,T,8327
+F,CN7207300000000,"Jayuya Municipio, PR",0,T,8328
+F,CN7207500000000,"Juana Diaz Municipio, PR",0,T,8329
+F,CN7207700000000,"Juncos Municipio, PR",0,T,8330
+F,CN7207900000000,"Lajas Municipio, PR",0,T,8331
+F,CN7208100000000,"Lares Municipio, PR",0,T,8332
+F,CN7208300000000,"Las Marias Municipio, PR",0,T,8333
+F,CN7208500000000,"Las Piedras Municipio, PR",0,T,8334
+F,CN7208700000000,"Loiza Municipio, PR",0,T,8335
+F,CN7208900000000,"Luquillo Municipio, PR",0,T,8336
+F,CN7209100000000,"Manati Municipio, PR",0,T,8337
+F,CN7209300000000,"Maricao Municipio, PR",0,T,8338
+F,CN7209500000000,"Maunabo Municipio, PR",0,T,8339
+F,CN7209700000000,"Mayaguez Municipio, PR",0,T,8340
+F,CN7209900000000,"Moca Municipio, PR",0,T,8341
+F,CN7210100000000,"Morovis Municipio, PR",0,T,8342
+F,CN7210300000000,"Naguabo Municipio, PR",0,T,8343
+F,CN7210500000000,"Naranjito Municipio, PR",0,T,8344
+F,CN7210700000000,"Orocovis Municipio, PR",0,T,8345
+F,CN7210900000000,"Patillas Municipio, PR",0,T,8346
+F,CN7211100000000,"Penuelas Municipio, PR",0,T,8347
+F,CN7211300000000,"Ponce Municipio, PR",0,T,8348
+F,CN7211500000000,"Quebradillas Municipio, PR",0,T,8349
+F,CN7211700000000,"Rincon Municipio, PR",0,T,8350
+F,CN7211900000000,"Rio Grande Municipio, PR",0,T,8351
+F,CN7212100000000,"Sabana Grande Municipio, PR",0,T,8352
+F,CN7212300000000,"Salinas Municipio, PR",0,T,8353
+F,CN7212500000000,"San German Municipio, PR",0,T,8354
+F,CN7212700000000,"San Juan Municipio, PR",0,T,8355
+F,CN7212900000000,"San Lorenzo Municipio, PR",0,T,8356
+F,CN7213100000000,"San Sebastian Municipio, PR",0,T,8357
+F,CN7213300000000,"Santa Isabel Municipio, PR",0,T,8358
+F,CN7213500000000,"Toa Alta Municipio, PR",0,T,8359
+F,CN7213700000000,"Toa Baja Municipio, PR",0,T,8360
+F,CN7213900000000,"Trujillo Alto Municipio, PR",0,T,8361
+F,CN7214100000000,"Utuado Municipio, PR",0,T,8362
+F,CN7214300000000,"Vega Alta Municipio, PR",0,T,8363
+F,CN7214500000000,"Vega Baja Municipio, PR",0,T,8364
+F,CN7214700000000,"Vieques Municipio, PR",0,T,8365
+F,CN7214900000000,"Villalba Municipio, PR",0,T,8366
+F,CN7215100000000,"Yabucoa Municipio, PR",0,T,8367
+F,CN7215300000000,"Yauco Municipio, PR",0,T,8368
+G,CS0907310000000,"Branford town, CT",0,T,939
+G,CS0914160000000,"Cheshire town, CT",0,T,950
+G,CS0922630000000,"East Hartford town, CT",0,T,968
+G,CS0922910000000,"East Haven town, CT",0,T,969
+G,CS0925990000000,"Enfield town, CT",0,T,974
+G,CS0926620000000,"Fairfield town, CT",0,T,976
+G,CS0927600000000,"Farmington town, CT",0,T,977
+G,CS0931240000000,"Glastonbury town, CT",0,T,979
+G,CS0933620000000,"Greenwich town, CT",0,T,982
+G,CS0934250000000,"Groton town, CT",0,T,984
+G,CS0935650000000,"Hamden town, CT",0,T,987
+G,CS0944700000000,"Manchester town, CT",0,T,1002
+G,CS0944910000000,"Mansfield town, CT",0,T,1003
+G,CS0952140000000,"Newington town, CT",0,T,1019
+G,CS0952630000000,"New Milford town, CT",0,T,1021
+G,CS0952980000000,"Newtown town, CT",0,T,1022
+G,CS0963970000000,"Ridgefield town, CT",0,T,1043
+G,CS0970550000000,"Southington town, CT",0,T,1056
+G,CS0971390000000,"South Windsor town, CT",0,T,1057
+G,CS0974190000000,"Stratford town, CT",0,T,1063
+G,CS0977200000000,"Trumbull town, CT",0,T,1069
+G,CS0978250000000,"Vernon town, CT",0,T,1071
+G,CS0978740000000,"Wallingford town, CT",0,T,1073
+G,CS0982590000000,"West Hartford town, CT",0,T,1080
+G,CS0983500000000,"Westport town, CT",0,T,1083
+G,CS0984900000000,"Wethersfield town, CT",0,T,1084
+G,CS0987000000000,"Windsor town, CT",0,T,1089
+G,CS2501465000000,"Andover town, MA",0,T,3394
+G,CS2501605000000,"Arlington town, MA",0,T,3396
+G,CS2505070000000,"Belmont town, MA",0,T,3412
+G,CS2505805000000,"Billerica town, MA",0,T,3417
+G,CS2509175000000,"Brookline town, MA",0,T,3432
+G,CS2509840000000,"Burlington town, MA",0,T,3434
+G,CS2513135000000,"Chelmsford town, MA",0,T,3442
+G,CS2516250000000,"Danvers town, MA",0,T,3457
+G,CS2516425000000,"Dartmouth town, MA",0,T,3458
+G,CS2516495000000,"Dedham town, MA",0,T,3459
+G,CS2517475000000,"Dracut town, MA",0,T,3465
+G,CS2520100000000,"Easton town, MA",0,T,3474
+G,CS2523105000000,"Falmouth town, MA",0,T,3482
+G,CS2535215000000,"Lexington town, MA",0,T,3540
+G,CS2538855000000,"Marshfield town, MA",0,T,3556
+G,CS2541165000000,"Milford town, MA",0,T,3570
+G,CS2541690000000,"Milton town, MA",0,T,3574
+G,CS2543895000000,"Natick town, MA",0,T,3583
+G,CS2544105000000,"Needham town, MA",0,T,3584
+G,CS2546365000000,"North Andover town, MA",0,T,3596
+G,CS2550250000000,"Norwood town, MA",0,T,3605
+G,CS2554310000000,"Plymouth town, MA",0,T,3624
+G,CS2556130000000,"Reading town, MA",0,T,3631
+G,CS2560015000000,"Saugus town, MA",0,T,3647
+G,CS2561800000000,"Shrewsbury town, MA",0,T,3656
+G,CS2567945000000,"Stoughton town, MA",0,T,3670
+G,CS2569415000000,"Tewksbury town, MA",0,T,3680
+G,CS2572215000000,"Wakefield town, MA",0,T,3690
+G,CS2572495000000,"Walpole town, MA",0,T,3692
+G,CS2574175000000,"Wellesley town, MA",0,T,3702
+G,CS2582525000000,"Yarmouth town, MA",0,T,3736
+G,CS2601360000000,"Allendale charter township, MI",0,T,3872
+G,CS2606740000000,"Bedford township (Monroe County), MI",0,T,3877
+G,CS2608760000000,"Blackman charter township, MI",0,T,3878
+G,CS2609110000000,"Bloomfield charter township (Oakland County), MI",0,T,3879
+G,CS2611220000000,"Brownstown charter township, MI",0,T,3880
+G,CS2612240000000,"Byron township, MI",0,T,3882
+G,CS2613120000000,"Canton charter township, MI",0,T,3883
+G,CS2615340000000,"Chesterfield township, MI",0,T,3884
+G,CS2616520000000,"Clinton charter township (Macomb County), MI",0,T,3885
+G,CS2617640000000,"Commerce charter township, MI",0,T,3886
+G,CS2621420000000,"Delhi charter township, MI",0,T,3889
+G,CS2621520000000,"Delta charter township, MI",0,T,3890
+G,CS2629020000000,"Flint charter township, MI",0,T,3897
+G,CS2631240000000,"Gaines charter township, MI",0,T,3898
+G,CS2631880000000,"Georgetown charter township, MI",0,T,3900
+G,CS2633300000000,"Grand Blanc charter township, MI",0,T,3901
+G,CS2636820000000,"Harrison charter township, MI",0,T,3904
+G,CS2638660000000,"Holland charter township (Ottawa County), MI",0,T,3906
+G,CS2640400000000,"Independence charter township, MI",0,T,3907
+G,CS2650480000000,"Macomb township, MI",0,T,3915
+G,CS2653140000000,"Meridian charter township, MI",0,T,3917
+G,CS2655980000000,"Mount Morris township, MI",0,T,3919
+G,CS2659000000000,"Northville township, MI",0,T,3922
+G,CS2661100000000,"Orion charter township, MI",0,T,3926
+G,CS2664560000000,"Pittsfield charter township, MI",0,T,3927
+G,CS2664660000000,"Plainfield charter township (Kent County), MI",0,T,3928
+G,CS2665080000000,"Plymouth charter township, MI",0,T,3929
+G,CS2667625000000,"Redford charter township, MI",0,T,3933
+G,CS2670540000000,"Saginaw charter township, MI",0,T,3939
+G,CS2672820000000,"Shelby charter township (Macomb County), MI",0,T,3941
+G,CS2681660000000,"Van Buren charter township, MI",0,T,3947
+G,CS2684120000000,"Washington charter township (Macomb County), MI",0,T,3950
+G,CS2684240000000,"Waterford charter township, MI",0,T,3951
+G,CS2685480000000,"West Bloomfield charter township, MI",0,T,3952
+G,CS2686860000000,"White Lake charter township, MI",0,T,3954
+G,CS2689160000000,"Ypsilanti charter township, MI",0,T,3957
+G,CS3317940000000,"Derry town, NH",0,T,4772
+G,CS3337940000000,"Hudson town, NH",0,T,4827
+G,CS3343220000000,"Londonderry town, NH",0,T,4845
+G,CS3347540000000,"Merrimack town, NH",0,T,4857
+G,CS3366660000000,"Salem town, NH",0,T,4908
+G,CS3404695000000,"Belleville township, NJ",0,T,5013
+G,CS3405305000000,"Berkeley township, NJ",0,T,5015
+G,CS3405560000000,"Bernards township, NJ",0,T,5016
+G,CS3406260000000,"Bloomfield township, NJ",0,T,5017
+G,CS3407420000000,"Brick township, NJ",0,T,5018
+G,CS3407720000000,"Bridgewater township, NJ",0,T,5020
+G,CS3412280000000,"Cherry Hill township, NJ",0,T,5023
+G,CS3413045000000,"City of Orange township, NJ",0,T,5024
+G,CS3417710000000,"Deptford township, NJ",0,T,5027
+G,CS3419000000000,"East Brunswick township, NJ",0,T,5028
+G,CS3419780000000,"East Windsor township, NJ",0,T,5030
+G,CS3420230000000,"Edison township, NJ",0,T,5031
+G,CS3420290000000,"Egg Harbor township, NJ",0,T,5032
+G,CS3422110000000,"Evesham township, NJ",0,T,5035
+G,CS3422185000000,"Ewing township, NJ",0,T,5036
+G,CS3424900000000,"Franklin township (Somerset County), NJ",0,T,5039
+G,CS3425230000000,"Freehold township, NJ",0,T,5040
+G,CS3425560000000,"Galloway township, NJ",0,T,5041
+G,CS3426760000000,"Gloucester township, NJ",0,T,5043
+G,CS3429280000000,"Hamilton township (Atlantic County), NJ",0,T,5045
+G,CS3429310000000,"Hamilton township (Mercer County), NJ",0,T,5046
+G,CS3431890000000,"Hillsborough township, NJ",0,T,5047
+G,CS3433300000000,"Howell township, NJ",0,T,5049
+G,CS3434450000000,"Irvington township, NJ",0,T,5050
+G,CS3434680000000,"Jackson township, NJ",0,T,5051
+G,CS3437380000000,"Lacey township, NJ",0,T,5054
+G,CS3438550000000,"Lakewood township, NJ",0,T,5055
+G,CS3439510000000,"Lawrence township (Mercer County), NJ",0,T,5056
+G,CS3440890000000,"Livingston township, NJ",0,T,5058
+G,CS3442750000000,"Mahwah township, NJ",0,T,5061
+G,CS3442990000000,"Manalapan township, NJ",0,T,5062
+G,CS3443140000000,"Manchester township, NJ",0,T,5063
+G,CS3443800000000,"Maplewood township, NJ",0,T,5064
+G,CS3444070000000,"Marlboro township, NJ",0,T,5065
+G,CS3445990000000,"Middletown township, NJ",0,T,5066
+G,CS3447250000000,"Monroe township (Gloucester County), NJ",0,T,5068
+G,CS3447280000000,"Monroe township (Middlesex County), NJ",0,T,5069
+G,CS3447500000000,"Montclair township, NJ",0,T,5070
+G,CS3449020000000,"Mount Laurel township, NJ",0,T,5071
+G,CS3449080000000,"Mount Olive township, NJ",0,T,5072
+G,CS3449890000000,"Neptune township, NJ",0,T,5073
+G,CS3452470000000,"North Bergen township, NJ",0,T,5076
+G,CS3452560000000,"North Brunswick township, NJ",0,T,5077
+G,CS3453680000000,"Nutley township, NJ",0,T,5078
+G,CS3454270000000,"Ocean township (Monmouth County), NJ",0,T,5079
+G,CS3454705000000,"Old Bridge township, NJ",0,T,5080
+G,CS3456460000000,"Parsippany-Troy Hills township, NJ",0,T,5082
+G,CS3457510000000,"Pemberton township, NJ",0,T,5085
+G,CS3457660000000,"Pennsauken township, NJ",0,T,5086
+G,CS3459010000000,"Piscataway township, NJ",0,T,5088
+G,CS3461890000000,"Randolph township, NJ",0,T,5092
+G,CS3464080000000,"Rockaway township, NJ",0,T,5094
+G,CS3468790000000,"South Brunswick township, NJ",0,T,5096
+G,CS3470320000000,"Stafford township, NJ",0,T,5097
+G,CS3472360000000,"Teaneck township, NJ",0,T,5098
+G,CS3473125000000,"Toms River township, NJ",0,T,5099
+G,CS3474480000000,"Union township (Union County), NJ",0,T,5101
+G,CS3475740000000,"Vernon township, NJ",0,T,5103
+G,CS3476220000000,"Voorhees township, NJ",0,T,5105
+G,CS3476460000000,"Wall township, NJ",0,T,5106
+G,CS3477180000000,"Washington township (Gloucester County), NJ",0,T,5107
+G,CS3477840000000,"Wayne township, NJ",0,T,5108
+G,CS3479460000000,"West Milford township, NJ",0,T,5110
+G,CS3479800000000,"West Orange township, NJ",0,T,5112
+G,CS3480240000000,"West Windsor township, NJ",0,T,5113
+G,CS3481440000000,"Willingboro township, NJ",0,T,5114
+G,CS3481740000000,"Winslow township, NJ",0,T,5115
+G,CS3482000000000,"Woodbridge township, NJ",0,T,5116
+G,CS3602000000000,"Amherst town, NY",0,T,5286
+G,CS3604000000000,"Babylon town, NY",0,T,5288
+G,CS3606354000000,"Bethlehem town, NY",0,T,5289
+G,CS3608246000000,"Brighton town (Monroe County), NY",0,T,5291
+G,CS3610000000000,"Brookhaven town, NY",0,T,5292
+G,CS3611913000000,"Camillus town, NY",0,T,5294
+G,CS3612529000000,"Carmel town, NY",0,T,5295
+G,CS3615011000000,"Cheektowaga town, NY",0,T,5296
+G,CS3615462000000,"Chili town, NY",0,T,5297
+G,CS3615704000000,"Cicero town, NY",0,T,5298
+G,CS3615825000000,"Clarence town, NY",0,T,5299
+G,CS3615968000000,"Clarkstown town, NY",0,T,5300
+G,CS3616067000000,"Clay town, NY",0,T,5301
+G,CS3616353000000,"Clifton Park town, NY",0,T,5302
+G,CS3617343000000,"Colonie town, NY",0,T,5303
+G,CS3618410000000,"Cortlandt town, NY",0,T,5304
+G,CS3620478000000,"De Witt town, NY",0,T,5305
+G,CS3621820000000,"Eastchester town, NY",0,T,5306
+G,CS3621996000000,"East Fishkill town, NY",0,T,5307
+G,CS3622194000000,"East Hampton town, NY",0,T,5308
+G,CS3628442000000,"Gates town, NY",0,T,5311
+G,CS3629366000000,"Glenville town, NY",0,T,5313
+G,CS3630290000000,"Greece town, NY",0,T,5314
+G,CS3630367000000,"Greenburgh town, NY",0,T,5315
+G,CS3631104000000,"Guilderland town, NY",0,T,5316
+G,CS3631489000000,"Halfmoon town, NY",0,T,5317
+G,CS3631654000000,"Hamburg town, NY",0,T,5318
+G,CS3632765000000,"Haverstraw town, NY",0,T,5320
+G,CS3634000000000,"Hempstead town, NY",0,T,5322
+G,CS3634099000000,"Henrietta town, NY",0,T,5323
+G,CS3637000000000,"Huntington town, NY",0,T,5324
+G,CS3637726000000,"Irondequoit town, NY",0,T,5325
+G,CS3638000000000,"Islip town, NY",0,T,5326
+G,CS3641146000000,"Lancaster town, NY",0,T,5330
+G,CS3642015000000,"Le Ray town, NY",0,T,5331
+G,CS3644842000000,"Mamaroneck town, NY",0,T,5335
+G,CS3645029000000,"Manlius town, NY",0,T,5336
+G,CS3647999000000,"Monroe town, NY",0,T,5338
+G,CS3649011000000,"Mount Pleasant town, NY",0,T,5339
+G,CS3650045000000,"Newburgh town, NY",0,T,5342
+G,CS3650848000000,"New Windsor town, NY",0,T,5344
+G,CS3653000000000,"North Hempstead town, NY",0,T,5347
+G,CS3655211000000,"Orangetown town, NY",0,T,5349
+G,CS3655277000000,"Orchard Park town, NY",0,T,5350
+G,CS3655541000000,"Ossining town, NY",0,T,5352
+G,CS3656000000000,"Oyster Bay town, NY",0,T,5353
+G,CS3657144000000,"Penfield town, NY",0,T,5355
+G,CS3657221000000,"Perinton town, NY",0,T,5356
+G,CS3658365000000,"Pittsford town, NY",0,T,5357
+G,CS3659652000000,"Poughkeepsie town, NY",0,T,5360
+G,CS3660356000000,"Queensbury town, NY",0,T,5361
+G,CS3660510000000,"Ramapo town, NY",0,T,5362
+G,CS3661984000000,"Riverhead town, NY",0,T,5363
+G,CS3663935000000,"Rotterdam town, NY",0,T,5367
+G,CS3664320000000,"Rye town, NY",0,T,5368
+G,CS3664815000000,"Salina town, NY",0,T,5369
+G,CS3668000000000,"Smithtown town, NY",0,T,5372
+G,CS3668473000000,"Southampton town, NY",0,T,5373
+G,CS3675000000000,"Tonawanda town, NY",0,T,5376
+G,CS3676056000000,"Union town, NY",0,T,5378
+G,CS3677255000000,"Vestal town, NY",0,T,5381
+G,CS3677992000000,"Wallkill town, NY",0,T,5382
+G,CS3678157000000,"Wappinger town, NY",0,T,5383
+G,CS3678366000000,"Warwick town, NY",0,T,5384
+G,CS3678971000000,"Webster town, NY",0,T,5386
+G,CS3680918000000,"West Seneca town, NY",0,T,5387
+G,CS3684077000000,"Yorktown town, NY",0,T,5390
+G,CS4200156000000,"Abington township, PA",0,T,6272
+G,CS4205616000000,"Bensalem township, PA",0,T,6275
+G,CS4206096000000,"Bethlehem township, PA",0,T,6278
+G,CS4208768000000,"Bristol township, PA",0,T,6279
+G,CS4212968000000,"Cheltenham township, PA",0,T,6280
+G,CS4216920000000,"Cranberry township (Butler County), PA",0,T,6282
+G,CS4218936000000,"Derry township (Dauphin County), PA",0,T,6283
+G,CS4221232000000,"East Hempfield township, PA",0,T,6284
+G,CS4224384000000,"Exeter township (Berks County), PA",0,T,6287
+G,CS4225112000000,"Falls township (Bucks County), PA",0,T,6288
+G,CS4232296000000,"Hampden township, PA",0,T,6289
+G,CS4233144000000,"Haverford township, PA",0,T,6291
+G,CS4233792000000,"Hempfield township (Westmoreland County), PA",0,T,6293
+G,CS4235808000000,"Horsham township, PA",0,T,6294
+G,CS4244952000000,"Lower Macungie township, PA",0,T,6298
+G,CS4244968000000,"Lower Makefield township, PA",0,T,6299
+G,CS4244976000000,"Lower Merion township, PA",0,T,6300
+G,CS4245056000000,"Lower Paxton township, PA",0,T,6301
+G,CS4245080000000,"Lower Providence township, PA",0,T,6302
+G,CS4245900000000,"McCandless township, PA",0,T,6303
+G,CS4246896000000,"Manheim township (Lancaster County), PA",0,T,6304
+G,CS4249120000000,"Middletown township (Bucks County), PA",0,T,6305
+G,CS4249548000000,"Millcreek township (Erie County), PA",0,T,6306
+G,CS4250640000000,"Montgomery township (Montgomery County), PA",0,T,6308
+G,CS4250784000000,"Moon township, PA",0,T,6309
+G,CS4251696000000,"Mount Lebanon township, PA",0,T,6310
+G,CS4254688000000,"Northampton township (Bucks County), PA",0,T,6313
+G,CS4255128000000,"North Huntingdon township, PA",0,T,6314
+G,CS4259032000000,"Penn Hills township, PA",0,T,6315
+G,CS4263264000000,"Radnor township, PA",0,T,6319
+G,CS4264800000000,"Ridley township, PA",0,T,6321
+G,CS4266264000000,"Ross township (Allegheny County), PA",0,T,6322
+G,CS4269584000000,"Shaler township, PA",0,T,6324
+G,CS4272824000000,"Spring township (Berks County), PA",0,T,6325
+G,CS4272992000000,"Springettsbury township, PA",0,T,6326
+G,CS4273032000000,"Springfield township (Delaware County), PA",0,T,6327
+G,CS4275528000000,"Susquehanna township (Dauphin County), PA",0,T,6329
+G,CS4275672000000,"Swatara township (Dauphin County), PA",0,T,6330
+G,CS4277344000000,"Tredyffrin township, PA",0,T,6331
+G,CS4279000000000,"Upper Darby township, PA",0,T,6332
+G,CS4279008000000,"Upper Dublin township, PA",0,T,6333
+G,CS4279104000000,"Upper Macungie township, PA",0,T,6334
+G,CS4279136000000,"Upper Merion township, PA",0,T,6335
+G,CS4279176000000,"Upper Moreland township, PA",0,T,6336
+G,CS4280952000000,"Warminster township, PA",0,T,6337
+G,CS4281048000000,"Warrington township (Bucks County), PA",0,T,6338
+G,CS4284528000000,"Whitehall township, PA",0,T,6340
+G,CS4287056000000,"York township, PA",0,T,6344
+G,CS4418640000000,"Coventry town, RI",0,T,6362
+G,CS4420080000000,"Cumberland town, RI",0,T,6364
+G,CS4437720000000,"Johnston town, RI",0,T,6372
+G,CS4451580000000,"North Kingstown town, RI",0,T,6379
+G,CS4451760000000,"North Providence town, RI",0,T,6380
+G,CS4467460000000,"South Kingstown town, RI",0,T,6388
+G,CS4478440000000,"West Warwick town, RI",0,T,6394
+G,CT0100820000000,"Alabaster city, AL",0,T,98
+G,CT0101852000000,"Anniston city, AL",0,T,99
+G,CT0102956000000,"Athens city, AL",0,T,100
+G,CT0103076000000,"Auburn city, AL",0,T,101
+G,CT0105980000000,"Bessemer city, AL",0,T,102
+G,CT0107000000000,"Birmingham city, AL",0,T,103
+G,CT0119648000000,"Daphne city, AL",0,T,104
+G,CT0120104000000,"Decatur city, AL",0,T,105
+G,CT0121184000000,"Dothan city, AL",0,T,106
+G,CT0124184000000,"Enterprise city, AL",0,T,107
+G,CT0126896000000,"Florence city, AL",0,T,108
+G,CT0128696000000,"Gadsden city, AL",0,T,109
+G,CT0135800000000,"Homewood city, AL",0,T,110
+G,CT0135896000000,"Hoover city, AL",0,T,111
+G,CT0137000000000,"Huntsville city, AL",0,T,112
+G,CT0145784000000,"Madison city, AL",0,T,113
+G,CT0150000000000,"Mobile city, AL",0,T,114
+G,CT0151000000000,"Montgomery city, AL",0,T,115
+G,CT0155200000000,"Northport city, AL",0,T,116
+G,CT0157048000000,"Opelika city, AL",0,T,117
+G,CT0159472000000,"Phenix City city, AL",0,T,118
+G,CT0162328000000,"Prattville city, AL",0,T,119
+G,CT0162496000000,"Prichard city, AL",0,T,120
+G,CT0169120000000,"Selma city, AL",0,T,121
+G,CT0176944000000,"Trussville city, AL",0,T,122
+G,CT0177256000000,"Tuscaloosa city, AL",0,T,123
+G,CT0178552000000,"Vestavia Hills city, AL",0,T,124
+G,CT0203000000000,"Anchorage Borough/municipality, AK",0,T,188
+G,CT0224230000000,"Fairbanks city, AK",0,T,189
+G,CT0236400000000,"Juneau Borough/city, AK",0,T,190
+G,CT0270540000000,"Sitka Borough/city, AK",0,T,191
+G,CT0286380000000,"Wrangell Borough/city, AK",0,T,192
+G,CT0402830000000,"Apache Junction city, AZ",0,T,221
+G,CT0404720000000,"Avondale city, AZ",0,T,222
+G,CT0407940000000,"Buckeye city, AZ",0,T,223
+G,CT0408220000000,"Bullhead City city, AZ",0,T,224
+G,CT0410530000000,"Casa Grande city, AZ",0,T,225
+G,CT0412000000000,"Chandler city, AZ",0,T,226
+G,CT0422220000000,"El Mirage city, AZ",0,T,227
+G,CT0423620000000,"Flagstaff city, AZ",0,T,228
+G,CT0423760000000,"Florence town, AZ",0,T,229
+G,CT0425300000000,"Fountain Hills town, AZ",0,T,230
+G,CT0427400000000,"Gilbert town, AZ",0,T,231
+G,CT0427820000000,"Glendale city, AZ",0,T,232
+G,CT0428380000000,"Goodyear city, AZ",0,T,233
+G,CT0437620000000,"Kingman city, AZ",0,T,234
+G,CT0439370000000,"Lake Havasu City city, AZ",0,T,235
+G,CT0444270000000,"Marana town, AZ",0,T,236
+G,CT0444410000000,"Maricopa city, AZ",0,T,237
+G,CT0446000000000,"Mesa city, AZ",0,T,238
+G,CT0451600000000,"Oro Valley town, AZ",0,T,239
+G,CT0454050000000,"Peoria city, AZ",0,T,240
+G,CT0455000000000,"Phoenix city, AZ",0,T,241
+G,CT0457380000000,"Prescott city, AZ",0,T,242
+G,CT0457450000000,"Prescott Valley town, AZ",0,T,243
+G,CT0458150000000,"Queen Creek town, AZ",0,T,244
+G,CT0462140000000,"Sahuarita town, AZ",0,T,245
+G,CT0463470000000,"San Luis city, AZ",0,T,246
+G,CT0465000000000,"Scottsdale city, AZ",0,T,247
+G,CT0466820000000,"Sierra Vista city, AZ",0,T,248
+G,CT0471510000000,"Surprise city, AZ",0,T,249
+G,CT0473000000000,"Tempe city, AZ",0,T,250
+G,CT0477000000000,"Tucson city, AZ",0,T,251
+G,CT0485540000000,"Yuma city, AZ",0,T,252
+G,CT0504840000000,"Bella Vista city, AR",0,T,357
+G,CT0505290000000,"Benton city, AR",0,T,358
+G,CT0505320000000,"Bentonville city, AR",0,T,359
+G,CT0510300000000,"Cabot city, AR",0,T,360
+G,CT0515190000000,"Conway city, AR",0,T,361
+G,CT0523290000000,"Fayetteville city, AR",0,T,362
+G,CT0524550000000,"Fort Smith city, AR",0,T,363
+G,CT0533400000000,"Hot Springs city, AR",0,T,364
+G,CT0534750000000,"Jacksonville city, AR",0,T,365
+G,CT0535710000000,"Jonesboro city, AR",0,T,366
+G,CT0541000000000,"Little Rock city, AR",0,T,367
+G,CT0550450000000,"North Little Rock city, AR",0,T,368
+G,CT0553390000000,"Paragould city, AR",0,T,369
+G,CT0555310000000,"Pine Bluff city, AR",0,T,370
+G,CT0560410000000,"Rogers city, AR",0,T,371
+G,CT0561670000000,"Russellville city, AR",0,T,372
+G,CT0563800000000,"Sherwood city, AR",0,T,373
+G,CT0566080000000,"Springdale city, AR",0,T,374
+G,CT0568810000000,"Texarkana city, AR",0,T,375
+G,CT0574540000000,"West Memphis city, AR",0,T,376
+G,CT0600296000000,"Adelanto city, CA",0,T,488
+G,CT0600394000000,"Agoura Hills city, CA",0,T,489
+G,CT0600562000000,"Alameda city, CA",0,T,490
+G,CT0600884000000,"Alhambra city, CA",0,T,491
+G,CT0600947000000,"Aliso Viejo city, CA",0,T,492
+G,CT0602000000000,"Anaheim city, CA",0,T,493
+G,CT0602252000000,"Antioch city, CA",0,T,494
+G,CT0602364000000,"Apple Valley town, CA",0,T,495
+G,CT0602462000000,"Arcadia city, CA",0,T,496
+G,CT0603064000000,"Atascadero city, CA",0,T,497
+G,CT0603162000000,"Atwater city, CA",0,T,498
+G,CT0603386000000,"Azusa city, CA",0,T,499
+G,CT0603526000000,"Bakersfield city, CA",0,T,500
+G,CT0603666000000,"Baldwin Park city, CA",0,T,501
+G,CT0603820000000,"Banning city, CA",0,T,502
+G,CT0604030000000,"Barstow city, CA",0,T,503
+G,CT0604758000000,"Beaumont city, CA",0,T,504
+G,CT0604870000000,"Bell city, CA",0,T,505
+G,CT0604982000000,"Bellflower city, CA",0,T,506
+G,CT0604996000000,"Bell Gardens city, CA",0,T,507
+G,CT0605108000000,"Belmont city, CA",0,T,508
+G,CT0605290000000,"Benicia city, CA",0,T,509
+G,CT0606000000000,"Berkeley city, CA",0,T,510
+G,CT0606308000000,"Beverly Hills city, CA",0,T,511
+G,CT0608058000000,"Brawley city, CA",0,T,512
+G,CT0608100000000,"Brea city, CA",0,T,513
+G,CT0608142000000,"Brentwood city, CA",0,T,514
+G,CT0608786000000,"Buena Park city, CA",0,T,515
+G,CT0608954000000,"Burbank city, CA",0,T,516
+G,CT0609066000000,"Burlingame city, CA",0,T,517
+G,CT0609710000000,"Calexico city, CA",0,T,518
+G,CT0610046000000,"Camarillo city, CA",0,T,519
+G,CT0610345000000,"Campbell city, CA",0,T,520
+G,CT0611194000000,"Carlsbad city, CA",0,T,521
+G,CT0611530000000,"Carson city, CA",0,T,522
+G,CT0612048000000,"Cathedral City city, CA",0,T,523
+G,CT0612524000000,"Ceres city, CA",0,T,524
+G,CT0612552000000,"Cerritos city, CA",0,T,525
+G,CT0613014000000,"Chico city, CA",0,T,526
+G,CT0613210000000,"Chino city, CA",0,T,527
+G,CT0613214000000,"Chino Hills city, CA",0,T,528
+G,CT0613392000000,"Chula Vista city, CA",0,T,529
+G,CT0613588000000,"Citrus Heights city, CA",0,T,530
+G,CT0613756000000,"Claremont city, CA",0,T,531
+G,CT0614218000000,"Clovis city, CA",0,T,532
+G,CT0614260000000,"Coachella city, CA",0,T,533
+G,CT0614890000000,"Colton city, CA",0,T,534
+G,CT0615044000000,"Compton city, CA",0,T,535
+G,CT0616000000000,"Concord city, CA",0,T,536
+G,CT0616224000000,"Corcoran city, CA",0,T,537
+G,CT0616350000000,"Corona city, CA",0,T,538
+G,CT0616378000000,"Coronado city, CA",0,T,539
+G,CT0616532000000,"Costa Mesa city, CA",0,T,540
+G,CT0616742000000,"Covina city, CA",0,T,541
+G,CT0617498000000,"Cudahy city, CA",0,T,542
+G,CT0617568000000,"Culver City city, CA",0,T,543
+G,CT0617610000000,"Cupertino city, CA",0,T,544
+G,CT0617750000000,"Cypress city, CA",0,T,545
+G,CT0617918000000,"Daly City city, CA",0,T,546
+G,CT0617946000000,"Dana Point city, CA",0,T,547
+G,CT0617988000000,"Danville town, CA",0,T,548
+G,CT0618100000000,"Davis city, CA",0,T,549
+G,CT0618394000000,"Delano city, CA",0,T,550
+G,CT0618996000000,"Desert Hot Springs city, CA",0,T,551
+G,CT0619192000000,"Diamond Bar city, CA",0,T,552
+G,CT0619318000000,"Dinuba city, CA",0,T,553
+G,CT0619766000000,"Downey city, CA",0,T,554
+G,CT0620018000000,"Dublin city, CA",0,T,555
+G,CT0620956000000,"East Palo Alto city, CA",0,T,556
+G,CT0621230000000,"Eastvale city, CA",0,T,557
+G,CT0621712000000,"El Cajon city, CA",0,T,558
+G,CT0621782000000,"El Centro city, CA",0,T,559
+G,CT0621796000000,"El Cerrito city, CA",0,T,560
+G,CT0622020000000,"Elk Grove city, CA",0,T,561
+G,CT0622230000000,"El Monte city, CA",0,T,562
+G,CT0622300000000,"El Paso de Robles (Paso Robles) city, CA",0,T,563
+G,CT0622678000000,"Encinitas city, CA",0,T,564
+G,CT0622804000000,"Escondido city, CA",0,T,565
+G,CT0623042000000,"Eureka city, CA",0,T,566
+G,CT0623182000000,"Fairfield city, CA",0,T,567
+G,CT0624638000000,"Folsom city, CA",0,T,568
+G,CT0624680000000,"Fontana city, CA",0,T,569
+G,CT0625338000000,"Foster City city, CA",0,T,570
+G,CT0625380000000,"Fountain Valley city, CA",0,T,571
+G,CT0626000000000,"Fremont city, CA",0,T,572
+G,CT0627000000000,"Fresno city, CA",0,T,573
+G,CT0628000000000,"Fullerton city, CA",0,T,574
+G,CT0628112000000,"Galt city, CA",0,T,575
+G,CT0628168000000,"Gardena city, CA",0,T,576
+G,CT0629000000000,"Garden Grove city, CA",0,T,577
+G,CT0629504000000,"Gilroy city, CA",0,T,578
+G,CT0630000000000,"Glendale city, CA",0,T,579
+G,CT0630014000000,"Glendora city, CA",0,T,580
+G,CT0630378000000,"Goleta city, CA",0,T,581
+G,CT0631960000000,"Hanford city, CA",0,T,582
+G,CT0632548000000,"Hawthorne city, CA",0,T,583
+G,CT0633000000000,"Hayward city, CA",0,T,584
+G,CT0633182000000,"Hemet city, CA",0,T,585
+G,CT0633308000000,"Hercules city, CA",0,T,586
+G,CT0633434000000,"Hesperia city, CA",0,T,587
+G,CT0633588000000,"Highland city, CA",0,T,588
+G,CT0634120000000,"Hollister city, CA",0,T,589
+G,CT0636000000000,"Huntington Beach city, CA",0,T,590
+G,CT0636056000000,"Huntington Park city, CA",0,T,591
+G,CT0636294000000,"Imperial Beach city, CA",0,T,592
+G,CT0636448000000,"Indio city, CA",0,T,593
+G,CT0636546000000,"Inglewood city, CA",0,T,594
+G,CT0636770000000,"Irvine city, CA",0,T,595
+G,CT0637692000000,"Jurupa Valley city, CA",0,T,596
+G,CT0639122000000,"Lafayette city, CA",0,T,597
+G,CT0639178000000,"Laguna Beach city, CA",0,T,598
+G,CT0639220000000,"Laguna Hills city, CA",0,T,599
+G,CT0639248000000,"Laguna Niguel city, CA",0,T,600
+G,CT0639290000000,"La Habra city, CA",0,T,601
+G,CT0639486000000,"Lake Elsinore city, CA",0,T,602
+G,CT0639496000000,"Lake Forest city, CA",0,T,603
+G,CT0639892000000,"Lakewood city, CA",0,T,604
+G,CT0640004000000,"La Mesa city, CA",0,T,605
+G,CT0640032000000,"La Mirada city, CA",0,T,606
+G,CT0640130000000,"Lancaster city, CA",0,T,607
+G,CT0640340000000,"La Puente city, CA",0,T,608
+G,CT0640354000000,"La Quinta city, CA",0,T,609
+G,CT0640704000000,"Lathrop city, CA",0,T,610
+G,CT0640830000000,"La Verne city, CA",0,T,611
+G,CT0640886000000,"Lawndale city, CA",0,T,612
+G,CT0641124000000,"Lemon Grove city, CA",0,T,613
+G,CT0641152000000,"Lemoore city, CA",0,T,614
+G,CT0641474000000,"Lincoln city, CA",0,T,615
+G,CT0641992000000,"Livermore city, CA",0,T,616
+G,CT0642202000000,"Lodi city, CA",0,T,617
+G,CT0642370000000,"Loma Linda city, CA",0,T,618
+G,CT0642524000000,"Lompoc city, CA",0,T,619
+G,CT0643000000000,"Long Beach city, CA",0,T,620
+G,CT0643280000000,"Los Altos city, CA",0,T,621
+G,CT0644000000000,"Los Angeles city, CA",0,T,622
+G,CT0644028000000,"Los Banos city, CA",0,T,623
+G,CT0644112000000,"Los Gatos town, CA",0,T,624
+G,CT0644574000000,"Lynwood city, CA",0,T,625
+G,CT0645022000000,"Madera city, CA",0,T,626
+G,CT0645400000000,"Manhattan Beach city, CA",0,T,627
+G,CT0645484000000,"Manteca city, CA",0,T,628
+G,CT0645778000000,"Marina city, CA",0,T,629
+G,CT0646114000000,"Martinez city, CA",0,T,630
+G,CT0646492000000,"Maywood city, CA",0,T,631
+G,CT0646842000000,"Menifee city, CA",0,T,632
+G,CT0646870000000,"Menlo Park city, CA",0,T,633
+G,CT0646898000000,"Merced city, CA",0,T,634
+G,CT0647766000000,"Milpitas city, CA",0,T,635
+G,CT0648256000000,"Mission Viejo city, CA",0,T,636
+G,CT0648354000000,"Modesto city, CA",0,T,637
+G,CT0648648000000,"Monrovia city, CA",0,T,638
+G,CT0648788000000,"Montclair city, CA",0,T,639
+G,CT0648816000000,"Montebello city, CA",0,T,640
+G,CT0648872000000,"Monterey city, CA",0,T,641
+G,CT0648914000000,"Monterey Park city, CA",0,T,642
+G,CT0649138000000,"Moorpark city, CA",0,T,643
+G,CT0649270000000,"Moreno Valley city, CA",0,T,644
+G,CT0649278000000,"Morgan Hill city, CA",0,T,645
+G,CT0649670000000,"Mountain View city, CA",0,T,646
+G,CT0650076000000,"Murrieta city, CA",0,T,647
+G,CT0650258000000,"Napa city, CA",0,T,648
+G,CT0650398000000,"National City city, CA",0,T,649
+G,CT0650916000000,"Newark city, CA",0,T,650
+G,CT0651182000000,"Newport Beach city, CA",0,T,651
+G,CT0651560000000,"Norco city, CA",0,T,652
+G,CT0652526000000,"Norwalk city, CA",0,T,653
+G,CT0652582000000,"Novato city, CA",0,T,654
+G,CT0653000000000,"Oakland city, CA",0,T,655
+G,CT0653070000000,"Oakley city, CA",0,T,656
+G,CT0653322000000,"Oceanside city, CA",0,T,657
+G,CT0653896000000,"Ontario city, CA",0,T,658
+G,CT0653980000000,"Orange city, CA",0,T,659
+G,CT0654652000000,"Oxnard city, CA",0,T,660
+G,CT0654806000000,"Pacifica city, CA",0,T,661
+G,CT0655156000000,"Palmdale city, CA",0,T,662
+G,CT0655184000000,"Palm Desert city, CA",0,T,663
+G,CT0655254000000,"Palm Springs city, CA",0,T,664
+G,CT0655282000000,"Palo Alto city, CA",0,T,665
+G,CT0655520000000,"Paradise town, CA",0,T,666
+G,CT0655618000000,"Paramount city, CA",0,T,667
+G,CT0656000000000,"Pasadena city, CA",0,T,668
+G,CT0656700000000,"Perris city, CA",0,T,669
+G,CT0656784000000,"Petaluma city, CA",0,T,670
+G,CT0656924000000,"Pico Rivera city, CA",0,T,671
+G,CT0657456000000,"Pittsburg city, CA",0,T,672
+G,CT0657526000000,"Placentia city, CA",0,T,673
+G,CT0657764000000,"Pleasant Hill city, CA",0,T,674
+G,CT0657792000000,"Pleasanton city, CA",0,T,675
+G,CT0658072000000,"Pomona city, CA",0,T,676
+G,CT0658240000000,"Porterville city, CA",0,T,677
+G,CT0658520000000,"Poway city, CA",0,T,678
+G,CT0659444000000,"Rancho Cordova city, CA",0,T,679
+G,CT0659451000000,"Rancho Cucamonga city, CA",0,T,680
+G,CT0659514000000,"Rancho Palos Verdes city, CA",0,T,681
+G,CT0659587000000,"Rancho Santa Margarita city, CA",0,T,682
+G,CT0659920000000,"Redding city, CA",0,T,683
+G,CT0659962000000,"Redlands city, CA",0,T,684
+G,CT0660018000000,"Redondo Beach city, CA",0,T,685
+G,CT0660102000000,"Redwood City city, CA",0,T,686
+G,CT0660242000000,"Reedley city, CA",0,T,687
+G,CT0660466000000,"Rialto city, CA",0,T,688
+G,CT0660620000000,"Richmond city, CA",0,T,689
+G,CT0660704000000,"Ridgecrest city, CA",0,T,690
+G,CT0662000000000,"Riverside city, CA",0,T,691
+G,CT0662364000000,"Rocklin city, CA",0,T,692
+G,CT0662546000000,"Rohnert Park city, CA",0,T,693
+G,CT0662896000000,"Rosemead city, CA",0,T,694
+G,CT0662938000000,"Roseville city, CA",0,T,695
+G,CT0664000000000,"Sacramento city, CA",0,T,696
+G,CT0664224000000,"Salinas city, CA",0,T,697
+G,CT0665000000000,"San Bernardino city, CA",0,T,698
+G,CT0665028000000,"San Bruno city, CA",0,T,699
+G,CT0665042000000,"San Buenaventura (Ventura) city, CA",0,T,700
+G,CT0665070000000,"San Carlos city, CA",0,T,701
+G,CT0665084000000,"San Clemente city, CA",0,T,702
+G,CT0666000000000,"San Diego city, CA",0,T,703
+G,CT0666070000000,"San Dimas city, CA",0,T,704
+G,CT0667000000000,"San Francisco County/city, CA",0,T,705
+G,CT0667042000000,"San Gabriel city, CA",0,T,706
+G,CT0667056000000,"Sanger city, CA",0,T,707
+G,CT0667112000000,"San Jacinto city, CA",0,T,708
+G,CT0668000000000,"San Jose city, CA",0,T,709
+G,CT0668028000000,"San Juan Capistrano city, CA",0,T,710
+G,CT0668084000000,"San Leandro city, CA",0,T,711
+G,CT0668154000000,"San Luis Obispo city, CA",0,T,712
+G,CT0668196000000,"San Marcos city, CA",0,T,713
+G,CT0668252000000,"San Mateo city, CA",0,T,714
+G,CT0668294000000,"San Pablo city, CA",0,T,715
+G,CT0668364000000,"San Rafael city, CA",0,T,716
+G,CT0668378000000,"San Ramon city, CA",0,T,717
+G,CT0669000000000,"Santa Ana city, CA",0,T,718
+G,CT0669070000000,"Santa Barbara city, CA",0,T,719
+G,CT0669084000000,"Santa Clara city, CA",0,T,720
+G,CT0669088000000,"Santa Clarita city, CA",0,T,721
+G,CT0669112000000,"Santa Cruz city, CA",0,T,722
+G,CT0669196000000,"Santa Maria city, CA",0,T,723
+G,CT0670000000000,"Santa Monica city, CA",0,T,724
+G,CT0670042000000,"Santa Paula city, CA",0,T,725
+G,CT0670098000000,"Santa Rosa city, CA",0,T,726
+G,CT0670224000000,"Santee city, CA",0,T,727
+G,CT0670280000000,"Saratoga city, CA",0,T,728
+G,CT0670686000000,"Seal Beach city, CA",0,T,729
+G,CT0670742000000,"Seaside city, CA",0,T,730
+G,CT0672016000000,"Simi Valley city, CA",0,T,731
+G,CT0672520000000,"Soledad city, CA",0,T,732
+G,CT0673080000000,"South Gate city, CA",0,T,733
+G,CT0673220000000,"South Pasadena city, CA",0,T,734
+G,CT0673262000000,"South San Francisco city, CA",0,T,735
+G,CT0673962000000,"Stanton city, CA",0,T,736
+G,CT0675000000000,"Stockton city, CA",0,T,737
+G,CT0675630000000,"Suisun City city, CA",0,T,738
+G,CT0677000000000,"Sunnyvale city, CA",0,T,739
+G,CT0678120000000,"Temecula city, CA",0,T,740
+G,CT0678148000000,"Temple City city, CA",0,T,741
+G,CT0678582000000,"Thousand Oaks city, CA",0,T,742
+G,CT0680000000000,"Torrance city, CA",0,T,743
+G,CT0680238000000,"Tracy city, CA",0,T,744
+G,CT0680644000000,"Tulare city, CA",0,T,745
+G,CT0680812000000,"Turlock city, CA",0,T,746
+G,CT0680854000000,"Tustin city, CA",0,T,747
+G,CT0680994000000,"Twentynine Palms city, CA",0,T,748
+G,CT0681204000000,"Union City city, CA",0,T,749
+G,CT0681344000000,"Upland city, CA",0,T,750
+G,CT0681554000000,"Vacaville city, CA",0,T,751
+G,CT0681666000000,"Vallejo city, CA",0,T,752
+G,CT0682590000000,"Victorville city, CA",0,T,753
+G,CT0682954000000,"Visalia city, CA",0,T,754
+G,CT0682996000000,"Vista city, CA",0,T,755
+G,CT0683332000000,"Walnut city, CA",0,T,756
+G,CT0683346000000,"Walnut Creek city, CA",0,T,757
+G,CT0683542000000,"Wasco city, CA",0,T,758
+G,CT0683668000000,"Watsonville city, CA",0,T,759
+G,CT0684200000000,"West Covina city, CA",0,T,760
+G,CT0684410000000,"West Hollywood city, CA",0,T,761
+G,CT0684550000000,"Westminster city, CA",0,T,762
+G,CT0684816000000,"West Sacramento city, CA",0,T,763
+G,CT0685292000000,"Whittier city, CA",0,T,764
+G,CT0685446000000,"Wildomar city, CA",0,T,765
+G,CT0685922000000,"Windsor town, CA",0,T,766
+G,CT0686328000000,"Woodland city, CA",0,T,767
+G,CT0686832000000,"Yorba Linda city, CA",0,T,768
+G,CT0686972000000,"Yuba City city, CA",0,T,769
+G,CT0687042000000,"Yucaipa city, CA",0,T,770
+G,CT0803455000000,"Arvada city, CO",0,T,858
+G,CT0804000000000,"Aurora city, CO",0,T,859
+G,CT0807850000000,"Boulder city, CO",0,T,860
+G,CT0808675000000,"Brighton city, CO",0,T,861
+G,CT0809280000000,"Broomfield County/city, CO",0,T,862
+G,CT0812415000000,"Castle Rock town, CO",0,T,863
+G,CT0812815000000,"Centennial city, CO",0,T,864
+G,CT0816000000000,"Colorado Springs city, CO",0,T,865
+G,CT0816495000000,"Commerce City city, CO",0,T,866
+G,CT0820000000000,"Denver County/city, CO",0,T,867
+G,CT0824785000000,"Englewood city, CO",0,T,868
+G,CT0824950000000,"Erie town, CO",0,T,869
+G,CT0827425000000,"Fort Collins city, CO",0,T,870
+G,CT0827865000000,"Fountain city, CO",0,T,871
+G,CT0831660000000,"Grand Junction city, CO",0,T,872
+G,CT0832155000000,"Greeley city, CO",0,T,873
+G,CT0841835000000,"Lafayette city, CO",0,T,874
+G,CT0843000000000,"Lakewood city, CO",0,T,875
+G,CT0845255000000,"Littleton city, CO",0,T,876
+G,CT0845970000000,"Longmont city, CO",0,T,877
+G,CT0846465000000,"Loveland city, CO",0,T,878
+G,CT0854330000000,"Northglenn city, CO",0,T,879
+G,CT0857630000000,"Parker town, CO",0,T,880
+G,CT0862000000000,"Pueblo city, CO",0,T,881
+G,CT0877290000000,"Thornton city, CO",0,T,882
+G,CT0883835000000,"Westminster city, CO",0,T,883
+G,CT0884440000000,"Wheat Ridge city, CO",0,T,884
+G,CT0885485000000,"Windsor town, CO",0,T,885
+G,CT0908000000000,"Bridgeport city/town, CT",0,T,940
+G,CT0908420000000,"Bristol city/town, CT",0,T,942
+G,CT0918430000000,"Danbury city/town, CT",0,T,959
+G,CT0937000000000,"Hartford city/town, CT",0,T,989
+G,CT0946450000000,"Meriden city/town, CT",0,T,1005
+G,CT0947290000000,"Middletown city/town, CT",0,T,1008
+G,CT0947500000000,"Milford (consolidated) city/town, CT",0,T,1009
+G,CT0949880000000,"Naugatuck borough/town, CT",0,T,1013
+G,CT0950370000000,"New Britain city/town, CT",0,T,1014
+G,CT0952000000000,"New Haven city/town, CT",0,T,1018
+G,CT0952280000000,"New London city/town, CT",0,T,1020
+G,CT0955990000000,"Norwalk city/town, CT",0,T,1028
+G,CT0956200000000,"Norwich city/town, CT",0,T,1029
+G,CT0968100000000,"Shelton city/town, CT",0,T,1051
+G,CT0973000000000,"Stamford city/town, CT",0,T,1060
+G,CT0976500000000,"Torrington city/town, CT",0,T,1068
+G,CT0980000000000,"Waterbury city/town, CT",0,T,1076
+G,CT0982800000000,"West Haven city/town, CT",0,T,1081
+G,CT1021200000000,"Dover city, DE",0,T,1107
+G,CT1050670000000,"Newark city, DE",0,T,1108
+G,CT1077580000000,"Wilmington city, DE",0,T,1109
+G,CT1150000000000,"Washington city, DC",0,T,1117
+G,CT1200950000000,"Altamonte Springs city, FL",0,T,1227
+G,CT1201700000000,"Apopka city, FL",0,T,1228
+G,CT1202681000000,"Aventura city, FL",0,T,1229
+G,CT1207300000000,"Boca Raton city, FL",0,T,1230
+G,CT1207525000000,"Bonita Springs city, FL",0,T,1231
+G,CT1207875000000,"Boynton Beach city, FL",0,T,1232
+G,CT1207950000000,"Bradenton city, FL",0,T,1233
+G,CT1210275000000,"Cape Coral city, FL",0,T,1234
+G,CT1211050000000,"Casselberry city, FL",0,T,1235
+G,CT1212875000000,"Clearwater city, FL",0,T,1236
+G,CT1212925000000,"Clermont city, FL",0,T,1237
+G,CT1213275000000,"Coconut Creek city, FL",0,T,1238
+G,CT1214125000000,"Cooper City city, FL",0,T,1239
+G,CT1214250000000,"Coral Gables city, FL",0,T,1240
+G,CT1214400000000,"Coral Springs city, FL",0,T,1241
+G,CT1215475000000,"Crestview city, FL",0,T,1242
+G,CT1215968000000,"Cutler Bay town, FL",0,T,1243
+G,CT1216335000000,"Dania Beach city, FL",0,T,1244
+G,CT1216475000000,"Davie town, FL",0,T,1245
+G,CT1216525000000,"Daytona Beach city, FL",0,T,1246
+G,CT1216725000000,"Deerfield Beach city, FL",0,T,1247
+G,CT1216875000000,"DeLand city, FL",0,T,1248
+G,CT1217100000000,"Delray Beach city, FL",0,T,1249
+G,CT1217200000000,"Deltona city, FL",0,T,1250
+G,CT1217935000000,"Doral city, FL",0,T,1251
+G,CT1218575000000,"Dunedin city, FL",0,T,1252
+G,CT1221150000000,"Estero village, FL",0,T,1253
+G,CT1224000000000,"Fort Lauderdale city, FL",0,T,1254
+G,CT1224125000000,"Fort Myers city, FL",0,T,1255
+G,CT1224300000000,"Fort Pierce city, FL",0,T,1256
+G,CT1225175000000,"Gainesville city, FL",0,T,1257
+G,CT1227322000000,"Greenacres city, FL",0,T,1258
+G,CT1228400000000,"Haines City city, FL",0,T,1259
+G,CT1228452000000,"Hallandale Beach city, FL",0,T,1260
+G,CT1230000000000,"Hialeah city, FL",0,T,1261
+G,CT1232000000000,"Hollywood city, FL",0,T,1262
+G,CT1232275000000,"Homestead city, FL",0,T,1263
+G,CT1235000000000,"Jacksonville city, FL",0,T,1264
+G,CT1235875000000,"Jupiter town, FL",0,T,1265
+G,CT1236550000000,"Key West city, FL",0,T,1266
+G,CT1236950000000,"Kissimmee city, FL",0,T,1267
+G,CT1238250000000,"Lakeland city, FL",0,T,1268
+G,CT1239081000000,"Lake Worth Beach city, FL",0,T,1269
+G,CT1239425000000,"Largo city, FL",0,T,1270
+G,CT1239525000000,"Lauderdale Lakes city, FL",0,T,1271
+G,CT1239550000000,"Lauderhill city, FL",0,T,1272
+G,CT1239875000000,"Leesburg city, FL",0,T,1273
+G,CT1243125000000,"Margate city, FL",0,T,1274
+G,CT1243975000000,"Melbourne city, FL",0,T,1275
+G,CT1245000000000,"Miami city, FL",0,T,1276
+G,CT1245025000000,"Miami Beach city, FL",0,T,1277
+G,CT1245060000000,"Miami Gardens city, FL",0,T,1278
+G,CT1245100000000,"Miami Lakes town, FL",0,T,1279
+G,CT1245975000000,"Miramar city, FL",0,T,1280
+G,CT1248625000000,"New Smyrna Beach city, FL",0,T,1281
+G,CT1249425000000,"North Lauderdale city, FL",0,T,1282
+G,CT1249450000000,"North Miami city, FL",0,T,1283
+G,CT1249475000000,"North Miami Beach city, FL",0,T,1284
+G,CT1249675000000,"North Port city, FL",0,T,1285
+G,CT1250575000000,"Oakland Park city, FL",0,T,1286
+G,CT1250750000000,"Ocala city, FL",0,T,1287
+G,CT1251075000000,"Ocoee city, FL",0,T,1288
+G,CT1253000000000,"Orlando city, FL",0,T,1289
+G,CT1253150000000,"Ormond Beach city, FL",0,T,1290
+G,CT1253575000000,"Oviedo city, FL",0,T,1291
+G,CT1254000000000,"Palm Bay city, FL",0,T,1292
+G,CT1254075000000,"Palm Beach Gardens city, FL",0,T,1293
+G,CT1254200000000,"Palm Coast city, FL",0,T,1294
+G,CT1254450000000,"Palm Springs village, FL",0,T,1295
+G,CT1254700000000,"Panama City city, FL",0,T,1296
+G,CT1255125000000,"Parkland city, FL",0,T,1297
+G,CT1255775000000,"Pembroke Pines city, FL",0,T,1298
+G,CT1255925000000,"Pensacola city, FL",0,T,1299
+G,CT1256975000000,"Pinellas Park city, FL",0,T,1300
+G,CT1257425000000,"Plantation city, FL",0,T,1301
+G,CT1257550000000,"Plant City city, FL",0,T,1302
+G,CT1258050000000,"Pompano Beach city, FL",0,T,1303
+G,CT1258575000000,"Port Orange city, FL",0,T,1304
+G,CT1258715000000,"Port St. Lucie city, FL",0,T,1305
+G,CT1260975000000,"Riviera Beach city, FL",0,T,1306
+G,CT1261500000000,"Rockledge city, FL",0,T,1307
+G,CT1262100000000,"Royal Palm Beach village, FL",0,T,1308
+G,CT1262625000000,"St. Cloud city, FL",0,T,1309
+G,CT1263000000000,"St. Petersburg city, FL",0,T,1310
+G,CT1263650000000,"Sanford city, FL",0,T,1311
+G,CT1264175000000,"Sarasota city, FL",0,T,1312
+G,CT1264825000000,"Sebastian city, FL",0,T,1313
+G,CT1269700000000,"Sunrise city, FL",0,T,1314
+G,CT1270600000000,"Tallahassee city, FL",0,T,1315
+G,CT1270675000000,"Tamarac city, FL",0,T,1316
+G,CT1271000000000,"Tampa city, FL",0,T,1317
+G,CT1271150000000,"Tarpon Springs city, FL",0,T,1318
+G,CT1271400000000,"Temple Terrace city, FL",0,T,1319
+G,CT1271900000000,"Titusville city, FL",0,T,1320
+G,CT1273900000000,"Venice city, FL",0,T,1321
+G,CT1275812000000,"Wellington village, FL",0,T,1322
+G,CT1276500000000,"West Melbourne city, FL",0,T,1323
+G,CT1276582000000,"Weston city, FL",0,T,1324
+G,CT1276600000000,"West Palm Beach city, FL",0,T,1325
+G,CT1278250000000,"Winter Garden city, FL",0,T,1326
+G,CT1278275000000,"Winter Haven city, FL",0,T,1327
+G,CT1278300000000,"Winter Park city, FL",0,T,1328
+G,CT1278325000000,"Winter Springs city, FL",0,T,1329
+G,CT1301052000000,"Albany city, GA",0,T,1533
+G,CT1301696000000,"Alpharetta city, GA",0,T,1534
+G,CT1303436000000,"Athens-Clarke County (consolidated) city, GA",0,T,1535
+G,CT1304000000000,"Atlanta city, GA",0,T,1536
+G,CT1304200000000,"Augusta-Richmond County (consolidated) city, GA",0,T,1537
+G,CT1310944000000,"Brookhaven city, GA",0,T,1538
+G,CT1312988000000,"Canton city, GA",0,T,1539
+G,CT1313492000000,"Carrollton city, GA",0,T,1540
+G,CT1315172000000,"Chamblee city, GA",0,T,1541
+G,CT1319000000000,"Columbus (consolidated) city, GA",0,T,1542
+G,CT1321380000000,"Dalton city, GA",0,T,1543
+G,CT1322052000000,"Decatur city, GA",0,T,1544
+G,CT1323900000000,"Douglasville city, GA",0,T,1545
+G,CT1324600000000,"Duluth city, GA",0,T,1546
+G,CT1324768000000,"Dunwoody city, GA",0,T,1547
+G,CT1325720000000,"East Point city, GA",0,T,1548
+G,CT1331908000000,"Gainesville city, GA",0,T,1549
+G,CT1338964000000,"Hinesville city, GA",0,T,1550
+G,CT1342425000000,"Johns Creek city, GA",0,T,1551
+G,CT1343192000000,"Kennesaw city, GA",0,T,1552
+G,CT1344340000000,"LaGrange city, GA",0,T,1553
+G,CT1345488000000,"Lawrenceville city, GA",0,T,1554
+G,CT1348624000000,"McDonough city, GA",0,T,1555
+G,CT1349008000000,"Macon-Bibb County, GA",0,T,1556
+G,CT1349756000000,"Marietta city, GA",0,T,1557
+G,CT1351670000000,"Milton city, GA",0,T,1558
+G,CT1355020000000,"Newnan city, GA",0,T,1559
+G,CT1359724000000,"Peachtree City city, GA",0,T,1560
+G,CT1359735000000,"Peachtree Corners city, GA",0,T,1561
+G,CT1362104000000,"Pooler city, GA",0,T,1562
+G,CT1366668000000,"Rome city, GA",0,T,1563
+G,CT1367284000000,"Roswell city, GA",0,T,1564
+G,CT1368516000000,"Sandy Springs city, GA",0,T,1565
+G,CT1369000000000,"Savannah city, GA",0,T,1566
+G,CT1371492000000,"Smyrna city, GA",0,T,1567
+G,CT1373256000000,"Statesboro city, GA",0,T,1568
+G,CT1373704000000,"Stockbridge city, GA",0,T,1569
+G,CT1374180000000,"Sugar Hill city, GA",0,T,1570
+G,CT1377652000000,"Tucker city, GA",0,T,1571
+G,CT1378324000000,"Union City city, GA",0,T,1572
+G,CT1378800000000,"Valdosta city, GA",0,T,1573
+G,CT1380508000000,"Warner Robins city, GA",0,T,1574
+G,CT1384176000000,"Woodstock city, GA",0,T,1575
+G,CT1516999000000,"Honolulu County/city, HI",0,T,1594
+G,CT1608830000000,"Boise City city, ID",0,T,1655
+G,CT1612250000000,"Caldwell city, ID",0,T,1656
+G,CT1616750000000,"Coeur d'Alene city, ID",0,T,1657
+G,CT1623410000000,"Eagle city, ID",0,T,1658
+G,CT1639700000000,"Idaho Falls city, ID",0,T,1659
+G,CT1644290000000,"Kuna city, ID",0,T,1660
+G,CT1646540000000,"Lewiston city, ID",0,T,1661
+G,CT1652120000000,"Meridian city, ID",0,T,1662
+G,CT1654550000000,"Moscow city, ID",0,T,1663
+G,CT1656260000000,"Nampa city, ID",0,T,1664
+G,CT1664090000000,"Pocatello city, ID",0,T,1665
+G,CT1664810000000,"Post Falls city, ID",0,T,1666
+G,CT1667420000000,"Rexburg city, ID",0,T,1667
+G,CT1682810000000,"Twin Falls city, ID",0,T,1668
+G,CT1700243000000,"Addison village, IL",0,T,1817
+G,CT1700685000000,"Algonquin village, IL",0,T,1818
+G,CT1701114000000,"Alton city, IL",0,T,1819
+G,CT1702154000000,"Arlington Heights village, IL",0,T,1820
+G,CT1703012000000,"Aurora city, IL",0,T,1821
+G,CT1704013000000,"Bartlett village, IL",0,T,1822
+G,CT1704078000000,"Batavia city, IL",0,T,1823
+G,CT1704845000000,"Belleville city, IL",0,T,1824
+G,CT1705092000000,"Belvidere city, IL",0,T,1825
+G,CT1705573000000,"Berwyn city, IL",0,T,1826
+G,CT1706613000000,"Bloomington city, IL",0,T,1827
+G,CT1707133000000,"Bolingbrook village, IL",0,T,1828
+G,CT1709447000000,"Buffalo Grove village, IL",0,T,1829
+G,CT1709642000000,"Burbank city, IL",0,T,1830
+G,CT1710487000000,"Calumet City city, IL",0,T,1831
+G,CT1711163000000,"Carbondale city, IL",0,T,1832
+G,CT1711332000000,"Carol Stream village, IL",0,T,1833
+G,CT1711358000000,"Carpentersville village, IL",0,T,1834
+G,CT1712385000000,"Champaign city, IL",0,T,1835
+G,CT1714000000000,"Chicago city, IL",0,T,1836
+G,CT1714026000000,"Chicago Heights city, IL",0,T,1837
+G,CT1714351000000,"Cicero town, IL",0,T,1838
+G,CT1715599000000,"Collinsville city, IL",0,T,1839
+G,CT1717887000000,"Crystal Lake city, IL",0,T,1840
+G,CT1718563000000,"Danville city, IL",0,T,1841
+G,CT1718823000000,"Decatur city, IL",0,T,1842
+G,CT1719161000000,"DeKalb city, IL",0,T,1843
+G,CT1719642000000,"Des Plaines city, IL",0,T,1844
+G,CT1720292000000,"Dolton village, IL",0,T,1845
+G,CT1720591000000,"Downers Grove village, IL",0,T,1846
+G,CT1722255000000,"East St. Louis city, IL",0,T,1847
+G,CT1722697000000,"Edwardsville city, IL",0,T,1848
+G,CT1723074000000,"Elgin city, IL",0,T,1849
+G,CT1723256000000,"Elk Grove Village village, IL",0,T,1850
+G,CT1723620000000,"Elmhurst city, IL",0,T,1851
+G,CT1723724000000,"Elmwood Park village, IL",0,T,1852
+G,CT1724582000000,"Evanston city, IL",0,T,1853
+G,CT1727884000000,"Freeport city, IL",0,T,1854
+G,CT1728326000000,"Galesburg city, IL",0,T,1855
+G,CT1729730000000,"Glendale Heights village, IL",0,T,1856
+G,CT1729756000000,"Glen Ellyn village, IL",0,T,1857
+G,CT1729938000000,"Glenview village, IL",0,T,1858
+G,CT1730926000000,"Granite City city, IL",0,T,1859
+G,CT1732018000000,"Gurnee village, IL",0,T,1860
+G,CT1732746000000,"Hanover Park village, IL",0,T,1861
+G,CT1733383000000,"Harvey city, IL",0,T,1862
+G,CT1734722000000,"Highland Park city, IL",0,T,1863
+G,CT1735411000000,"Hoffman Estates village, IL",0,T,1864
+G,CT1735835000000,"Homer Glen village, IL",0,T,1865
+G,CT1736750000000,"Huntley village, IL",0,T,1866
+G,CT1738570000000,"Joliet city, IL",0,T,1867
+G,CT1738934000000,"Kankakee city, IL",0,T,1868
+G,CT1741183000000,"Lake in the Hills village, IL",0,T,1869
+G,CT1742028000000,"Lansing village, IL",0,T,1870
+G,CT1744225000000,"Lockport city, IL",0,T,1871
+G,CT1744407000000,"Lombard village, IL",0,T,1872
+G,CT1745694000000,"McHenry city, IL",0,T,1873
+G,CT1747774000000,"Maywood village, IL",0,T,1874
+G,CT1748242000000,"Melrose Park village, IL",0,T,1875
+G,CT1749867000000,"Moline city, IL",0,T,1876
+G,CT1750647000000,"Morton Grove village, IL",0,T,1877
+G,CT1751089000000,"Mount Prospect village, IL",0,T,1878
+G,CT1751349000000,"Mundelein village, IL",0,T,1879
+G,CT1751622000000,"Naperville city, IL",0,T,1880
+G,CT1752584000000,"New Lenox village, IL",0,T,1881
+G,CT1753000000000,"Niles village, IL",0,T,1882
+G,CT1753234000000,"Normal town, IL",0,T,1883
+G,CT1753481000000,"Northbrook village, IL",0,T,1884
+G,CT1753559000000,"North Chicago city, IL",0,T,1885
+G,CT1754638000000,"Oak Forest city, IL",0,T,1886
+G,CT1754820000000,"Oak Lawn village, IL",0,T,1887
+G,CT1754885000000,"Oak Park village, IL",0,T,1888
+G,CT1755249000000,"O'Fallon city, IL",0,T,1889
+G,CT1756640000000,"Orland Park village, IL",0,T,1890
+G,CT1756887000000,"Oswego village, IL",0,T,1891
+G,CT1757225000000,"Palatine village, IL",0,T,1892
+G,CT1757732000000,"Park Forest village, IL",0,T,1893
+G,CT1757875000000,"Park Ridge city, IL",0,T,1894
+G,CT1758447000000,"Pekin city, IL",0,T,1895
+G,CT1759000000000,"Peoria city, IL",0,T,1896
+G,CT1760287000000,"Plainfield village, IL",0,T,1897
+G,CT1762367000000,"Quincy city, IL",0,T,1898
+G,CT1765000000000,"Rockford city, IL",0,T,1899
+G,CT1765078000000,"Rock Island city, IL",0,T,1900
+G,CT1765442000000,"Romeoville village, IL",0,T,1901
+G,CT1766040000000,"Round Lake Beach village, IL",0,T,1902
+G,CT1766703000000,"St. Charles city, IL",0,T,1903
+G,CT1768003000000,"Schaumburg village, IL",0,T,1904
+G,CT1770122000000,"Skokie village, IL",0,T,1905
+G,CT1772000000000,"Springfield city, IL",0,T,1906
+G,CT1773157000000,"Streamwood village, IL",0,T,1907
+G,CT1775484000000,"Tinley Park village, IL",0,T,1908
+G,CT1777005000000,"Urbana city, IL",0,T,1909
+G,CT1777694000000,"Vernon Hills village, IL",0,T,1910
+G,CT1779293000000,"Waukegan city, IL",0,T,1911
+G,CT1780060000000,"West Chicago city, IL",0,T,1912
+G,CT1780645000000,"Westmont village, IL",0,T,1913
+G,CT1781048000000,"Wheaton city, IL",0,T,1914
+G,CT1781087000000,"Wheeling village, IL",0,T,1915
+G,CT1782075000000,"Wilmette village, IL",0,T,1916
+G,CT1783245000000,"Woodridge village, IL",0,T,1917
+G,CT1783349000000,"Woodstock city, IL",0,T,1918
+G,CT1784220000000,"Zion city, IL",0,T,1919
+G,CT1801468000000,"Anderson city, IN",0,T,2098
+G,CT1805860000000,"Bloomington city, IN",0,T,2099
+G,CT1808416000000,"Brownsburg town, IN",0,T,2100
+G,CT1810342000000,"Carmel city, IN",0,T,2101
+G,CT1814734000000,"Columbus city, IN",0,T,2102
+G,CT1816138000000,"Crown Point city, IN",0,T,2103
+G,CT1819486000000,"East Chicago city, IN",0,T,2104
+G,CT1820728000000,"Elkhart city, IN",0,T,2105
+G,CT1822000000000,"Evansville city, IN",0,T,2106
+G,CT1823278000000,"Fishers city, IN",0,T,2107
+G,CT1825000000000,"Fort Wayne city, IN",0,T,2108
+G,CT1825450000000,"Franklin city, IN",0,T,2109
+G,CT1827000000000,"Gary city, IN",0,T,2110
+G,CT1828386000000,"Goshen city, IN",0,T,2111
+G,CT1829898000000,"Greenwood city, IN",0,T,2112
+G,CT1831000000000,"Hammond city, IN",0,T,2113
+G,CT1834114000000,"Hobart city, IN",0,T,2114
+G,CT1836000000000,"Indianapolis (consolidated) city, IN",0,T,2115
+G,CT1836003000000,"Indianapolis (incorporated) city, IN",0,T,2116
+G,CT1838358000000,"Jeffersonville city, IN",0,T,2117
+G,CT1840392000000,"Kokomo city, IN",0,T,2118
+G,CT1840788000000,"Lafayette city, IN",0,T,2119
+G,CT1842426000000,"Lawrence city, IN",0,T,2120
+G,CT1846908000000,"Marion city, IN",0,T,2121
+G,CT1848528000000,"Merrillville town, IN",0,T,2122
+G,CT1848798000000,"Michigan City city, IN",0,T,2123
+G,CT1849932000000,"Mishawaka city, IN",0,T,2124
+G,CT1851876000000,"Muncie city, IN",0,T,2125
+G,CT1852326000000,"New Albany city, IN",0,T,2126
+G,CT1854180000000,"Noblesville city, IN",0,T,2127
+G,CT1860246000000,"Plainfield town, IN",0,T,2128
+G,CT1861092000000,"Portage city, IN",0,T,2129
+G,CT1864260000000,"Richmond city, IN",0,T,2130
+G,CT1868220000000,"Schererville town, IN",0,T,2131
+G,CT1871000000000,"South Bend city, IN",0,T,2132
+G,CT1875428000000,"Terre Haute city, IN",0,T,2133
+G,CT1878326000000,"Valparaiso city, IN",0,T,2134
+G,CT1882700000000,"Westfield city, IN",0,T,2135
+G,CT1882862000000,"West Lafayette city, IN",0,T,2136
+G,CT1886372000000,"Zionsville town, IN",0,T,2137
+G,CT1901855000000,"Ames city, IA",0,T,2271
+G,CT1902305000000,"Ankeny city, IA",0,T,2272
+G,CT1906355000000,"Bettendorf city, IA",0,T,2273
+G,CT1909550000000,"Burlington city, IA",0,T,2274
+G,CT1911755000000,"Cedar Falls city, IA",0,T,2275
+G,CT1912000000000,"Cedar Rapids city, IA",0,T,2276
+G,CT1914430000000,"Clinton city, IA",0,T,2277
+G,CT1916860000000,"Council Bluffs city, IA",0,T,2278
+G,CT1919000000000,"Davenport city, IA",0,T,2279
+G,CT1921000000000,"Des Moines city, IA",0,T,2280
+G,CT1922395000000,"Dubuque city, IA",0,T,2281
+G,CT1928515000000,"Fort Dodge city, IA",0,T,2282
+G,CT1938595000000,"Iowa City city, IA",0,T,2283
+G,CT1949485000000,"Marion city, IA",0,T,2284
+G,CT1949755000000,"Marshalltown city, IA",0,T,2285
+G,CT1950160000000,"Mason City city, IA",0,T,2286
+G,CT1960465000000,"Ottumwa city, IA",0,T,2287
+G,CT1973335000000,"Sioux City city, IA",0,T,2288
+G,CT1979950000000,"Urbandale city, IA",0,T,2289
+G,CT1982425000000,"Waterloo city, IA",0,T,2290
+G,CT1982695000000,"Waukee city, IA",0,T,2291
+G,CT1983910000000,"West Des Moines city, IA",0,T,2292
+G,CT2017800000000,"Derby city, KS",0,T,2432
+G,CT2018250000000,"Dodge City city, KS",0,T,2433
+G,CT2021275000000,"Emporia city, KS",0,T,2434
+G,CT2025325000000,"Garden City city, KS",0,T,2435
+G,CT2033625000000,"Hutchinson city, KS",0,T,2436
+G,CT2035750000000,"Junction City city, KS",0,T,2437
+G,CT2036000000000,"Kansas City city, KS",0,T,2438
+G,CT2038900000000,"Lawrence city, KS",0,T,2439
+G,CT2039000000000,"Leavenworth city, KS",0,T,2440
+G,CT2039075000000,"Leawood city, KS",0,T,2441
+G,CT2039350000000,"Lenexa city, KS",0,T,2442
+G,CT2044250000000,"Manhattan city, KS",0,T,2443
+G,CT2052575000000,"Olathe city, KS",0,T,2444
+G,CT2053775000000,"Overland Park city, KS",0,T,2445
+G,CT2062700000000,"Salina city, KS",0,T,2446
+G,CT2064500000000,"Shawnee city, KS",0,T,2447
+G,CT2071000000000,"Topeka city, KS",0,T,2448
+G,CT2079000000000,"Wichita city, KS",0,T,2449
+G,CT2102368000000,"Ashland city, KY",0,T,2600
+G,CT2108902000000,"Bowling Green city, KY",0,T,2601
+G,CT2117848000000,"Covington city, KY",0,T,2602
+G,CT2124274000000,"Elizabethtown city, KY",0,T,2603
+G,CT2127982000000,"Florence city, KY",0,T,2604
+G,CT2128900000000,"Frankfort city, KY",0,T,2605
+G,CT2130700000000,"Georgetown city, KY",0,T,2606
+G,CT2135866000000,"Henderson city, KY",0,T,2607
+G,CT2137918000000,"Hopkinsville city, KY",0,T,2608
+G,CT2139142000000,"Independence city, KY",0,T,2609
+G,CT2140222000000,"Jeffersontown city, KY",0,T,2610
+G,CT2146027000000,"Lexington-Fayette city, KY",0,T,2611
+G,CT2148003000000,"Louisville-Jefferson County (consolidated) city, KY",0,T,2612
+G,CT2156136000000,"Nicholasville city, KY",0,T,2613
+G,CT2158620000000,"Owensboro city, KY",0,T,2614
+G,CT2158836000000,"Paducah city, KY",0,T,2615
+G,CT2165226000000,"Richmond city, KY",0,T,2616
+G,CT2200975000000,"Alexandria city, LA",0,T,2714
+G,CT2205000000000,"Baton Rouge city, LA",0,T,2715
+G,CT2208920000000,"Bossier City city, LA",0,T,2716
+G,CT2213960000000,"Central city, LA",0,T,2717
+G,CT2236255000000,"Houma city, LA",0,T,2718
+G,CT2239475000000,"Kenner city, LA",0,T,2719
+G,CT2240735000000,"Lafayette city, LA",0,T,2720
+G,CT2241155000000,"Lake Charles city, LA",0,T,2721
+G,CT2251410000000,"Monroe city, LA",0,T,2722
+G,CT2254035000000,"New Iberia city, LA",0,T,2723
+G,CT2255000000000,"New Orleans city, LA",0,T,2724
+G,CT2270000000000,"Shreveport city, LA",0,T,2725
+G,CT2270805000000,"Slidell city, LA",0,T,2726
+G,CT2302795000000,"Bangor city, ME",0,T,2783
+G,CT2338740000000,"Lewiston city, ME",0,T,2999
+G,CT2360545000000,"Portland city, ME",0,T,3130
+G,CT2371990000000,"South Portland city, ME",0,T,3186
+G,CT2401600000000,"Annapolis city, MD",0,T,3334
+G,CT2404000000000,"Baltimore city, MD",0,T,3335
+G,CT2408775000000,"Bowie city, MD",0,T,3336
+G,CT2418750000000,"College Park city, MD",0,T,3337
+G,CT2430325000000,"Frederick city, MD",0,T,3338
+G,CT2431175000000,"Gaithersburg city, MD",0,T,3339
+G,CT2436075000000,"Hagerstown city, MD",0,T,3340
+G,CT2445900000000,"Laurel city, MD",0,T,3341
+G,CT2467675000000,"Rockville city, MD",0,T,3342
+G,CT2469925000000,"Salisbury city, MD",0,T,3343
+G,CT2500840000000,"Agawam Town city, MA",0,T,3390
+G,CT2501370000000,"Amherst Town city, MA",0,T,3393
+G,CT2502690000000,"Attleboro city, MA",0,T,3402
+G,CT2503690000000,"Barnstable Town city, MA",0,T,3406
+G,CT2505595000000,"Beverly city, MA",0,T,3416
+G,CT2507000000000,"Boston city, MA",0,T,3421
+G,CT2507740000000,"Braintree Town city, MA",0,T,3426
+G,CT2508130000000,"Bridgewater Town city, MA",0,T,3428
+G,CT2509000000000,"Brockton city, MA",0,T,3430
+G,CT2511000000000,"Cambridge city, MA",0,T,3435
+G,CT2513205000000,"Chelsea city, MA",0,T,3443
+G,CT2513660000000,"Chicopee city, MA",0,T,3447
+G,CT2521990000000,"Everett city, MA",0,T,3479
+G,CT2523000000000,"Fall River city, MA",0,T,3481
+G,CT2523875000000,"Fitchburg city, MA",0,T,3483
+G,CT2524960000000,"Framingham city, MA",0,T,3486
+G,CT2525172000000,"Franklin Town city, MA",0,T,3487
+G,CT2526150000000,"Gloucester city, MA",0,T,3492
+G,CT2529405000000,"Haverhill city, MA",0,T,3513
+G,CT2530840000000,"Holyoke city, MA",0,T,3522
+G,CT2534550000000,"Lawrence city, MA",0,T,3534
+G,CT2535075000000,"Leominster city, MA",0,T,3538
+G,CT2537000000000,"Lowell city, MA",0,T,3545
+G,CT2537490000000,"Lynn city, MA",0,T,3548
+G,CT2537875000000,"Malden city, MA",0,T,3550
+G,CT2538715000000,"Marlborough city, MA",0,T,3555
+G,CT2539835000000,"Medford city, MA",0,T,3561
+G,CT2540115000000,"Melrose city, MA",0,T,3563
+G,CT2540710000000,"Methuen Town city, MA",0,T,3566
+G,CT2545000000000,"New Bedford city, MA",0,T,3586
+G,CT2545560000000,"Newton city, MA",0,T,3592
+G,CT2546330000000,"Northampton city, MA",0,T,3595
+G,CT2546598000000,"North Attleborough Town city, MA",0,T,3597
+G,CT2552490000000,"Peabody city, MA",0,T,3614
+G,CT2553960000000,"Pittsfield city, MA",0,T,3621
+G,CT2555745000000,"Quincy city, MA",0,T,3628
+G,CT2556000000000,"Randolph Town city, MA",0,T,3629
+G,CT2556585000000,"Revere city, MA",0,T,3633
+G,CT2559105000000,"Salem city, MA",0,T,3643
+G,CT2562535000000,"Somerville city, MA",0,T,3659
+G,CT2567000000000,"Springfield city, MA",0,T,3666
+G,CT2569170000000,"Taunton city, MA",0,T,3678
+G,CT2572600000000,"Waltham city, MA",0,T,3693
+G,CT2573440000000,"Watertown Town city, MA",0,T,3699
+G,CT2576030000000,"Westfield city, MA",0,T,3710
+G,CT2577890000000,"West Springfield Town city, MA",0,T,3717
+G,CT2578972000000,"Weymouth Town city, MA",0,T,3721
+G,CT2581035000000,"Woburn city, MA",0,T,3732
+G,CT2582000000000,"Worcester city, MA",0,T,3733
+G,CT2601380000000,"Allen Park city, MI",0,T,3873
+G,CT2603000000000,"Ann Arbor city, MI",0,T,3874
+G,CT2605920000000,"Battle Creek city, MI",0,T,3875
+G,CT2606020000000,"Bay City city, MI",0,T,3876
+G,CT2612060000000,"Burton city, MI",0,T,3881
+G,CT2621000000000,"Dearborn city, MI",0,T,3887
+G,CT2621020000000,"Dearborn Heights city, MI",0,T,3888
+G,CT2622000000000,"Detroit city, MI",0,T,3891
+G,CT2624120000000,"East Lansing city, MI",0,T,3892
+G,CT2624290000000,"Eastpointe city, MI",0,T,3893
+G,CT2627440000000,"Farmington Hills city, MI",0,T,3894
+G,CT2627880000000,"Ferndale city, MI",0,T,3895
+G,CT2629000000000,"Flint city, MI",0,T,3896
+G,CT2631420000000,"Garden City city, MI",0,T,3899
+G,CT2634000000000,"Grand Rapids city, MI",0,T,3902
+G,CT2636280000000,"Hamtramck city, MI",0,T,3903
+G,CT2638640000000,"Holland city, MI",0,T,3905
+G,CT2640680000000,"Inkster city, MI",0,T,3908
+G,CT2641420000000,"Jackson city, MI",0,T,3909
+G,CT2642160000000,"Kalamazoo city, MI",0,T,3910
+G,CT2642820000000,"Kentwood city, MI",0,T,3911
+G,CT2646000000000,"Lansing city, MI",0,T,3912
+G,CT2647800000000,"Lincoln Park city, MI",0,T,3913
+G,CT2649000000000,"Livonia city, MI",0,T,3914
+G,CT2650560000000,"Madison Heights city, MI",0,T,3916
+G,CT2653780000000,"Midland city, MI",0,T,3918
+G,CT2656020000000,"Mount Pleasant city, MI",0,T,3920
+G,CT2656320000000,"Muskegon city, MI",0,T,3921
+G,CT2659140000000,"Norton Shores city, MI",0,T,3923
+G,CT2659440000000,"Novi city, MI",0,T,3924
+G,CT2659920000000,"Oak Park city, MI",0,T,3925
+G,CT2665440000000,"Pontiac city, MI",0,T,3930
+G,CT2665560000000,"Portage city, MI",0,T,3931
+G,CT2665820000000,"Port Huron city, MI",0,T,3932
+G,CT2669035000000,"Rochester Hills city, MI",0,T,3934
+G,CT2669420000000,"Romulus city, MI",0,T,3935
+G,CT2669800000000,"Roseville city, MI",0,T,3936
+G,CT2670040000000,"Royal Oak city, MI",0,T,3937
+G,CT2670520000000,"Saginaw city, MI",0,T,3938
+G,CT2670760000000,"St. Clair Shores city, MI",0,T,3940
+G,CT2674900000000,"Southfield city, MI",0,T,3942
+G,CT2674960000000,"Southgate city, MI",0,T,3943
+G,CT2676460000000,"Sterling Heights city, MI",0,T,3944
+G,CT2679000000000,"Taylor city, MI",0,T,3945
+G,CT2680700000000,"Troy city, MI",0,T,3946
+G,CT2682960000000,"Walker city, MI",0,T,3948
+G,CT2684000000000,"Warren city, MI",0,T,3949
+G,CT2686000000000,"Westland city, MI",0,T,3953
+G,CT2688900000000,"Wyandotte city, MI",0,T,3955
+G,CT2688940000000,"Wyoming city, MI",0,T,3956
+G,CT2701486000000,"Andover city, MN",0,T,4085
+G,CT2701900000000,"Apple Valley city, MN",0,T,4086
+G,CT2702908000000,"Austin city, MN",0,T,4087
+G,CT2706382000000,"Blaine city, MN",0,T,4088
+G,CT2706616000000,"Bloomington city, MN",0,T,4089
+G,CT2707948000000,"Brooklyn Center city, MN",0,T,4090
+G,CT2707966000000,"Brooklyn Park city, MN",0,T,4091
+G,CT2708794000000,"Burnsville city, MN",0,T,4092
+G,CT2710846000000,"Champlin city, MN",0,T,4093
+G,CT2710918000000,"Chanhassen city, MN",0,T,4094
+G,CT2710972000000,"Chaska city, MN",0,T,4095
+G,CT2713114000000,"Coon Rapids city, MN",0,T,4096
+G,CT2713456000000,"Cottage Grove city, MN",0,T,4097
+G,CT2717000000000,"Duluth city, MN",0,T,4098
+G,CT2717288000000,"Eagan city, MN",0,T,4099
+G,CT2718116000000,"Eden Prairie city, MN",0,T,4100
+G,CT2718188000000,"Edina city, MN",0,T,4101
+G,CT2718674000000,"Elk River city, MN",0,T,4102
+G,CT2722814000000,"Fridley city, MN",0,T,4103
+G,CT2731076000000,"Inver Grove Heights city, MN",0,T,4104
+G,CT2735180000000,"Lakeville city, MN",0,T,4105
+G,CT2739878000000,"Mankato city, MN",0,T,4106
+G,CT2740166000000,"Maple Grove city, MN",0,T,4107
+G,CT2740382000000,"Maplewood city, MN",0,T,4108
+G,CT2743000000000,"Minneapolis city, MN",0,T,4109
+G,CT2743252000000,"Minnetonka city, MN",0,T,4110
+G,CT2743864000000,"Moorhead city, MN",0,T,4111
+G,CT2747680000000,"Oakdale city, MN",0,T,4112
+G,CT2749300000000,"Owatonna city, MN",0,T,4113
+G,CT2751730000000,"Plymouth city, MN",0,T,4114
+G,CT2752594000000,"Prior Lake city, MN",0,T,4115
+G,CT2753026000000,"Ramsey city, MN",0,T,4116
+G,CT2754214000000,"Richfield city, MN",0,T,4117
+G,CT2754880000000,"Rochester city, MN",0,T,4118
+G,CT2755726000000,"Rosemount city, MN",0,T,4119
+G,CT2755852000000,"Roseville city, MN",0,T,4120
+G,CT2756896000000,"St. Cloud city, MN",0,T,4121
+G,CT2757220000000,"St. Louis Park city, MN",0,T,4122
+G,CT2758000000000,"St. Paul city, MN",0,T,4123
+G,CT2758738000000,"Savage city, MN",0,T,4124
+G,CT2759350000000,"Shakopee city, MN",0,T,4125
+G,CT2759998000000,"Shoreview city, MN",0,T,4126
+G,CT2769970000000,"White Bear Lake city, MN",0,T,4127
+G,CT2771032000000,"Winona city, MN",0,T,4128
+G,CT2771428000000,"Woodbury city, MN",0,T,4129
+G,CT2806220000000,"Biloxi city, MS",0,T,4252
+G,CT2808300000000,"Brandon city, MS",0,T,4253
+G,CT2814420000000,"Clinton city, MS",0,T,4254
+G,CT2815380000000,"Columbus city, MS",0,T,4255
+G,CT2829180000000,"Greenville city, MS",0,T,4256
+G,CT2829700000000,"Gulfport city, MS",0,T,4257
+G,CT2831020000000,"Hattiesburg city, MS",0,T,4258
+G,CT2833700000000,"Horn Lake city, MS",0,T,4259
+G,CT2836000000000,"Jackson city, MS",0,T,4260
+G,CT2844520000000,"Madison city, MS",0,T,4261
+G,CT2846640000000,"Meridian city, MS",0,T,4262
+G,CT2854040000000,"Olive Branch city, MS",0,T,4263
+G,CT2854840000000,"Oxford city, MS",0,T,4264
+G,CT2855360000000,"Pascagoula city, MS",0,T,4265
+G,CT2855760000000,"Pearl city, MS",0,T,4266
+G,CT2869280000000,"Southaven city, MS",0,T,4267
+G,CT2870240000000,"Starkville city, MS",0,T,4268
+G,CT2874840000000,"Tupelo city, MS",0,T,4269
+G,CT2876720000000,"Vicksburg city, MS",0,T,4270
+G,CT2903160000000,"Ballwin city, MO",0,T,4425
+G,CT2906652000000,"Blue Springs city, MO",0,T,4426
+G,CT2911242000000,"Cape Girardeau city, MO",0,T,4427
+G,CT2913600000000,"Chesterfield city, MO",0,T,4428
+G,CT2915670000000,"Columbia city, MO",0,T,4429
+G,CT2924778000000,"Florissant city, MO",0,T,4430
+G,CT2927190000000,"Gladstone city, MO",0,T,4431
+G,CT2928324000000,"Grandview city, MO",0,T,4432
+G,CT2931276000000,"Hazelwood city, MO",0,T,4433
+G,CT2935000000000,"Independence city, MO",0,T,4434
+G,CT2937000000000,"Jefferson City city, MO",0,T,4435
+G,CT2937592000000,"Joplin city, MO",0,T,4436
+G,CT2938000000000,"Kansas City city, MO",0,T,4437
+G,CT2939044000000,"Kirkwood city, MO",0,T,4438
+G,CT2941348000000,"Lee's Summit city, MO",0,T,4439
+G,CT2942032000000,"Liberty city, MO",0,T,4440
+G,CT2946586000000,"Maryland Heights city, MO",0,T,4441
+G,CT2954074000000,"O'Fallon city, MO",0,T,4442
+G,CT2960788000000,"Raytown city, MO",0,T,4443
+G,CT2964082000000,"St. Charles city, MO",0,T,4444
+G,CT2964550000000,"St. Joseph city, MO",0,T,4445
+G,CT2965000000000,"St. Louis city, MO",0,T,4446
+G,CT2965126000000,"St. Peters city, MO",0,T,4447
+G,CT2970000000000,"Springfield city, MO",0,T,4448
+G,CT2975220000000,"University City city, MO",0,T,4449
+G,CT2978442000000,"Wentzville city, MO",0,T,4450
+G,CT2979820000000,"Wildwood city, MO",0,T,4451
+G,CT3001675000000,"Anaconda-Deer Lodge County city, MT",0,T,4533
+G,CT3006550000000,"Billings city, MT",0,T,4534
+G,CT3008950000000,"Bozeman city, MT",0,T,4535
+G,CT3011390000000,"Butte-Silver Bow (consolidated) city, MT",0,T,4536
+G,CT3032800000000,"Great Falls city, MT",0,T,4537
+G,CT3035600000000,"Helena city, MT",0,T,4538
+G,CT3040075000000,"Kalispell city, MT",0,T,4539
+G,CT3050200000000,"Missoula city, MT",0,T,4540
+G,CT3103950000000,"Bellevue city, NE",0,T,4650
+G,CT3117670000000,"Fremont city, NE",0,T,4651
+G,CT3119595000000,"Grand Island city, NE",0,T,4652
+G,CT3121415000000,"Hastings city, NE",0,T,4653
+G,CT3125055000000,"Kearney city, NE",0,T,4654
+G,CT3128000000000,"Lincoln city, NE",0,T,4655
+G,CT3137000000000,"Omaha city, NE",0,T,4656
+G,CT3209700000000,"Carson City, NV",0,T,4689
+G,CT3231900000000,"Henderson city, NV",0,T,4690
+G,CT3240000000000,"Las Vegas city, NV",0,T,4691
+G,CT3251800000000,"North Las Vegas city, NV",0,T,4692
+G,CT3260600000000,"Reno city, NV",0,T,4693
+G,CT3268400000000,"Sparks city, NV",0,T,4694
+G,CT3314200000000,"Concord city, NH",0,T,4763
+G,CT3318820000000,"Dover city, NH",0,T,4775
+G,CT3345140000000,"Manchester city, NH",0,T,4852
+G,CT3350260000000,"Nashua city, NH",0,T,4866
+G,CT3365140000000,"Rochester city, NH",0,T,4903
+G,CT3402080000000,"Atlantic City city, NJ",0,T,5011
+G,CT3403580000000,"Bayonne city, NJ",0,T,5012
+G,CT3405170000000,"Bergenfield borough, NJ",0,T,5014
+G,CT3407600000000,"Bridgeton city, NJ",0,T,5019
+G,CT3410000000000,"Camden city, NJ",0,T,5021
+G,CT3410750000000,"Carteret borough, NJ",0,T,5022
+G,CT3413570000000,"Cliffside Park borough, NJ",0,T,5025
+G,CT3413690000000,"Clifton city, NJ",0,T,5026
+G,CT3419390000000,"East Orange city, NJ",0,T,5029
+G,CT3421000000000,"Elizabeth city, NJ",0,T,5033
+G,CT3421480000000,"Englewood city, NJ",0,T,5034
+G,CT3422470000000,"Fair Lawn borough, NJ",0,T,5037
+G,CT3424420000000,"Fort Lee borough, NJ",0,T,5038
+G,CT3425770000000,"Garfield city, NJ",0,T,5042
+G,CT3428680000000,"Hackensack city, NJ",0,T,5044
+G,CT3432250000000,"Hoboken city, NJ",0,T,5048
+G,CT3436000000000,"Jersey City city, NJ",0,T,5052
+G,CT3436510000000,"Kearny town, NJ",0,T,5053
+G,CT3440350000000,"Linden city, NJ",0,T,5057
+G,CT3441100000000,"Lodi borough, NJ",0,T,5059
+G,CT3441310000000,"Long Branch city, NJ",0,T,5060
+G,CT3446680000000,"Millville city, NJ",0,T,5067
+G,CT3451000000000,"Newark city, NJ",0,T,5074
+G,CT3451210000000,"New Brunswick city, NJ",0,T,5075
+G,CT3455950000000,"Paramus borough, NJ",0,T,5081
+G,CT3456550000000,"Passaic city, NJ",0,T,5083
+G,CT3457000000000,"Paterson city, NJ",0,T,5084
+G,CT3458200000000,"Perth Amboy city, NJ",0,T,5087
+G,CT3459190000000,"Plainfield city, NJ",0,T,5089
+G,CT3460900000000,"Princeton, NJ",0,T,5090
+G,CT3461530000000,"Rahway city, NJ",0,T,5091
+G,CT3463000000000,"Ridgewood village, NJ",0,T,5093
+G,CT3465790000000,"Sayreville borough, NJ",0,T,5095
+G,CT3474000000000,"Trenton city, NJ",0,T,5100
+G,CT3474630000000,"Union City city, NJ",0,T,5102
+G,CT3476070000000,"Vineland city, NJ",0,T,5104
+G,CT3479040000000,"Westfield town, NJ",0,T,5109
+G,CT3479610000000,"West New York town, NJ",0,T,5111
+G,CT3501780000000,"Alamogordo city, NM",0,T,5176
+G,CT3502000000000,"Albuquerque city, NM",0,T,5177
+G,CT3512150000000,"Carlsbad city, NM",0,T,5178
+G,CT3516420000000,"Clovis city, NM",0,T,5179
+G,CT3525800000000,"Farmington city, NM",0,T,5180
+G,CT3532520000000,"Hobbs city, NM",0,T,5181
+G,CT3539380000000,"Las Cruces city, NM",0,T,5182
+G,CT3563460000000,"Rio Rancho city, NM",0,T,5183
+G,CT3564930000000,"Roswell city, NM",0,T,5184
+G,CT3570500000000,"Santa Fe city, NM",0,T,5185
+G,CT3601000000000,"Albany city, NY",0,T,5285
+G,CT3603078000000,"Auburn city, NY",0,T,5287
+G,CT3606607000000,"Binghamton city, NY",0,T,5290
+G,CT3611000000000,"Buffalo city, NY",0,T,5293
+G,CT3624229000000,"Elmira city, NY",0,T,5309
+G,CT3627485000000,"Freeport village, NY",0,T,5310
+G,CT3629113000000,"Glen Cove city, NY",0,T,5312
+G,CT3632402000000,"Harrison village/town, NY",0,T,5319
+G,CT3633139000000,"Hempstead village, NY",0,T,5321
+G,CT3638077000000,"Ithaca city, NY",0,T,5327
+G,CT3638264000000,"Jamestown city, NY",0,T,5328
+G,CT3639853000000,"Kiryas Joel village, NY",0,T,5329
+G,CT3642554000000,"Lindenhurst village, NY",0,T,5332
+G,CT3643082000000,"Lockport city, NY",0,T,5333
+G,CT3643335000000,"Long Beach city, NY",0,T,5334
+G,CT3647042000000,"Middletown city, NY",0,T,5337
+G,CT3649121000000,"Mount Vernon city, NY",0,T,5340
+G,CT3650034000000,"Newburgh city, NY",0,T,5341
+G,CT3650617000000,"New Rochelle city, NY",0,T,5343
+G,CT3651000000000,"New York city, NY",0,T,5345
+G,CT3651055000000,"Niagara Falls city, NY",0,T,5346
+G,CT3653682000000,"North Tonawanda city, NY",0,T,5348
+G,CT3655530000000,"Ossining village, NY",0,T,5351
+G,CT3656979000000,"Peekskill city, NY",0,T,5354
+G,CT3659223000000,"Port Chester village, NY",0,T,5358
+G,CT3659641000000,"Poughkeepsie city, NY",0,T,5359
+G,CT3663000000000,"Rochester city, NY",0,T,5364
+G,CT3663264000000,"Rockville Centre village, NY",0,T,5365
+G,CT3663418000000,"Rome city, NY",0,T,5366
+G,CT3665255000000,"Saratoga Springs city, NY",0,T,5370
+G,CT3665508000000,"Schenectady city, NY",0,T,5371
+G,CT3670420000000,"Spring Valley village, NY",0,T,5374
+G,CT3673000000000,"Syracuse city, NY",0,T,5375
+G,CT3675484000000,"Troy city, NY",0,T,5377
+G,CT3676540000000,"Utica city, NY",0,T,5379
+G,CT3676705000000,"Valley Stream village, NY",0,T,5380
+G,CT3678608000000,"Watertown city, NY",0,T,5385
+G,CT3681677000000,"White Plains city, NY",0,T,5388
+G,CT3684000000000,"Yonkers city, NY",0,T,5389
+G,CT3701520000000,"Apex town, NC",0,T,5542
+G,CT3702080000000,"Asheboro city, NC",0,T,5543
+G,CT3702140000000,"Asheville city, NC",0,T,5544
+G,CT3709060000000,"Burlington city, NC",0,T,5545
+G,CT3710740000000,"Cary town, NC",0,T,5546
+G,CT3711800000000,"Chapel Hill town, NC",0,T,5547
+G,CT3712000000000,"Charlotte city, NC",0,T,5548
+G,CT3712860000000,"Clayton town, NC",0,T,5549
+G,CT3714100000000,"Concord city, NC",0,T,5550
+G,CT3714700000000,"Cornelius town, NC",0,T,5551
+G,CT3719000000000,"Durham city, NC",0,T,5552
+G,CT3722920000000,"Fayetteville city, NC",0,T,5553
+G,CT3725300000000,"Fuquay-Varina town, NC",0,T,5554
+G,CT3725480000000,"Garner town, NC",0,T,5555
+G,CT3725580000000,"Gastonia city, NC",0,T,5556
+G,CT3726880000000,"Goldsboro city, NC",0,T,5557
+G,CT3728000000000,"Greensboro city, NC",0,T,5558
+G,CT3728080000000,"Greenville city, NC",0,T,5559
+G,CT3731060000000,"Hickory city, NC",0,T,5560
+G,CT3731400000000,"High Point city, NC",0,T,5561
+G,CT3732260000000,"Holly Springs town, NC",0,T,5562
+G,CT3733120000000,"Huntersville town, NC",0,T,5563
+G,CT3733560000000,"Indian Trail town, NC",0,T,5564
+G,CT3734200000000,"Jacksonville city, NC",0,T,5565
+G,CT3735200000000,"Kannapolis city, NC",0,T,5566
+G,CT3735600000000,"Kernersville town, NC",0,T,5567
+G,CT3735920000000,"Kinston city, NC",0,T,5568
+G,CT3737680000000,"Leland town, NC",0,T,5569
+G,CT3741960000000,"Matthews town, NC",0,T,5570
+G,CT3743480000000,"Mint Hill town, NC",0,T,5571
+G,CT3743920000000,"Monroe city, NC",0,T,5572
+G,CT3744220000000,"Mooresville town, NC",0,T,5573
+G,CT3744520000000,"Morrisville town, NC",0,T,5574
+G,CT3746340000000,"New Bern city, NC",0,T,5575
+G,CT3755000000000,"Raleigh city, NC",0,T,5576
+G,CT3757500000000,"Rocky Mount city, NC",0,T,5577
+G,CT3758860000000,"Salisbury city, NC",0,T,5578
+G,CT3759280000000,"Sanford city, NC",0,T,5579
+G,CT3764740000000,"Statesville city, NC",0,T,5580
+G,CT3767420000000,"Thomasville city, NC",0,T,5581
+G,CT3770540000000,"Wake Forest town, NC",0,T,5582
+G,CT3774440000000,"Wilmington city, NC",0,T,5583
+G,CT3774540000000,"Wilson city, NC",0,T,5584
+G,CT3775000000000,"Winston-Salem city, NC",0,T,5585
+G,CT3807200000000,"Bismarck city, ND",0,T,5678
+G,CT3819620000000,"Dickinson city, ND",0,T,5679
+G,CT3825700000000,"Fargo city, ND",0,T,5680
+G,CT3832060000000,"Grand Forks city, ND",0,T,5681
+G,CT3853380000000,"Minot city, ND",0,T,5682
+G,CT3884780000000,"West Fargo city, ND",0,T,5683
+G,CT3886220000000,"Williston city, ND",0,T,5684
+G,CT3901000000000,"Akron city, OH",0,T,5831
+G,CT3902736000000,"Athens city, OH",0,T,5832
+G,CT3903352000000,"Avon city, OH",0,T,5833
+G,CT3903464000000,"Avon Lake city, OH",0,T,5834
+G,CT3903828000000,"Barberton city, OH",0,T,5835
+G,CT3904720000000,"Beavercreek city, OH",0,T,5836
+G,CT3907972000000,"Bowling Green city, OH",0,T,5837
+G,CT3909680000000,"Brunswick city, OH",0,T,5838
+G,CT3912000000000,"Canton city, OH",0,T,5839
+G,CT3915000000000,"Cincinnati city, OH",0,T,5840
+G,CT3916000000000,"Cleveland city, OH",0,T,5841
+G,CT3916014000000,"Cleveland Heights city, OH",0,T,5842
+G,CT3918000000000,"Columbus city, OH",0,T,5843
+G,CT3919778000000,"Cuyahoga Falls city, OH",0,T,5844
+G,CT3921000000000,"Dayton city, OH",0,T,5845
+G,CT3921434000000,"Delaware city, OH",0,T,5846
+G,CT3922694000000,"Dublin city, OH",0,T,5847
+G,CT3925256000000,"Elyria city, OH",0,T,5848
+G,CT3925704000000,"Euclid city, OH",0,T,5849
+G,CT3925914000000,"Fairborn city, OH",0,T,5850
+G,CT3925970000000,"Fairfield city, OH",0,T,5851
+G,CT3927048000000,"Findlay city, OH",0,T,5852
+G,CT3929106000000,"Gahanna city, OH",0,T,5853
+G,CT3929428000000,"Garfield Heights city, OH",0,T,5854
+G,CT3931860000000,"Green city, OH",0,T,5855
+G,CT3932592000000,"Grove City city, OH",0,T,5856
+G,CT3933012000000,"Hamilton city, OH",0,T,5857
+G,CT3935476000000,"Hilliard city, OH",0,T,5858
+G,CT3936610000000,"Huber Heights city, OH",0,T,5859
+G,CT3939872000000,"Kent city, OH",0,T,5860
+G,CT3940040000000,"Kettering city, OH",0,T,5861
+G,CT3941664000000,"Lakewood city, OH",0,T,5862
+G,CT3941720000000,"Lancaster city, OH",0,T,5863
+G,CT3943554000000,"Lima city, OH",0,T,5864
+G,CT3944856000000,"Lorain city, OH",0,T,5865
+G,CT3947138000000,"Mansfield city, OH",0,T,5866
+G,CT3947306000000,"Maple Heights city, OH",0,T,5867
+G,CT3947754000000,"Marion city, OH",0,T,5868
+G,CT3948160000000,"Marysville city, OH",0,T,5869
+G,CT3948188000000,"Mason city, OH",0,T,5870
+G,CT3948244000000,"Massillon city, OH",0,T,5871
+G,CT3948790000000,"Medina city, OH",0,T,5872
+G,CT3949056000000,"Mentor city, OH",0,T,5873
+G,CT3949840000000,"Middletown city, OH",0,T,5874
+G,CT3954040000000,"Newark city, OH",0,T,5875
+G,CT3956882000000,"North Olmsted city, OH",0,T,5876
+G,CT3956966000000,"North Ridgeville city, OH",0,T,5877
+G,CT3957008000000,"North Royalton city, OH",0,T,5878
+G,CT3961000000000,"Parma city, OH",0,T,5879
+G,CT3962148000000,"Perrysburg city, OH",0,T,5880
+G,CT3966390000000,"Reynoldsburg city, OH",0,T,5881
+G,CT3967468000000,"Riverside city, OH",0,T,5882
+G,CT3970380000000,"Sandusky city, OH",0,T,5883
+G,CT3971682000000,"Shaker Heights city, OH",0,T,5884
+G,CT3973264000000,"South Euclid city, OH",0,T,5885
+G,CT3974118000000,"Springfield city, OH",0,T,5886
+G,CT3974944000000,"Stow city, OH",0,T,5887
+G,CT3975098000000,"Strongsville city, OH",0,T,5888
+G,CT3977000000000,"Toledo city, OH",0,T,5889
+G,CT3977504000000,"Trotwood city, OH",0,T,5890
+G,CT3977588000000,"Troy city, OH",0,T,5891
+G,CT3979002000000,"Upper Arlington city, OH",0,T,5892
+G,CT3980892000000,"Warren city, OH",0,T,5893
+G,CT3983342000000,"Westerville city, OH",0,T,5894
+G,CT3983622000000,"Westlake city, OH",0,T,5895
+G,CT3986548000000,"Wooster city, OH",0,T,5896
+G,CT3986772000000,"Xenia city, OH",0,T,5897
+G,CT3988000000000,"Youngstown city, OH",0,T,5898
+G,CT3988084000000,"Zanesville city, OH",0,T,5899
+G,CT4002600000000,"Ardmore city, OK",0,T,6025
+G,CT4004450000000,"Bartlesville city, OK",0,T,6026
+G,CT4006400000000,"Bixby city, OK",0,T,6027
+G,CT4009050000000,"Broken Arrow city, OK",0,T,6028
+G,CT4019900000000,"Del City city, OK",0,T,6029
+G,CT4023200000000,"Edmond city, OK",0,T,6030
+G,CT4023950000000,"Enid city, OK",0,T,6031
+G,CT4037800000000,"Jenks city, OK",0,T,6032
+G,CT4041850000000,"Lawton city, OK",0,T,6033
+G,CT4048350000000,"Midwest City city, OK",0,T,6034
+G,CT4049200000000,"Moore city, OK",0,T,6035
+G,CT4050050000000,"Muskogee city, OK",0,T,6036
+G,CT4052500000000,"Norman city, OK",0,T,6037
+G,CT4055000000000,"Oklahoma City city, OK",0,T,6038
+G,CT4056650000000,"Owasso city, OK",0,T,6039
+G,CT4059850000000,"Ponca City city, OK",0,T,6040
+G,CT4066800000000,"Shawnee city, OK",0,T,6041
+G,CT4070300000000,"Stillwater city, OK",0,T,6042
+G,CT4075000000000,"Tulsa city, OK",0,T,6043
+G,CT4082950000000,"Yukon city, OK",0,T,6044
+G,CT4101000000000,"Albany city, OR",0,T,6119
+G,CT4105350000000,"Beaverton city, OR",0,T,6120
+G,CT4105800000000,"Bend city, OR",0,T,6121
+G,CT4115800000000,"Corvallis city, OR",0,T,6122
+G,CT4123850000000,"Eugene city, OR",0,T,6123
+G,CT4126200000000,"Forest Grove city, OR",0,T,6124
+G,CT4130550000000,"Grants Pass city, OR",0,T,6125
+G,CT4131250000000,"Gresham city, OR",0,T,6126
+G,CT4132050000000,"Happy Valley city, OR",0,T,6127
+G,CT4134100000000,"Hillsboro city, OR",0,T,6128
+G,CT4138500000000,"Keizer city, OR",0,T,6129
+G,CT4140550000000,"Lake Oswego city, OR",0,T,6130
+G,CT4145000000000,"McMinnville city, OR",0,T,6131
+G,CT4147000000000,"Medford city, OR",0,T,6132
+G,CT4152100000000,"Newberg city, OR",0,T,6133
+G,CT4155200000000,"Oregon City city, OR",0,T,6134
+G,CT4159000000000,"Portland city, OR",0,T,6135
+G,CT4161200000000,"Redmond city, OR",0,T,6136
+G,CT4164900000000,"Salem city, OR",0,T,6137
+G,CT4169600000000,"Springfield city, OR",0,T,6138
+G,CT4173650000000,"Tigard city, OR",0,T,6139
+G,CT4174950000000,"Tualatin city, OR",0,T,6140
+G,CT4180150000000,"West Linn city, OR",0,T,6141
+G,CT4182800000000,"Wilsonville city, OR",0,T,6142
+G,CT4183750000000,"Woodburn city, OR",0,T,6143
+G,CT4202000000000,"Allentown city, PA",0,T,6273
+G,CT4202184000000,"Altoona city, PA",0,T,6274
+G,CT4206064000000,"Bethel Park municipality, PA",0,T,6276
+G,CT4206088000000,"Bethlehem city, PA",0,T,6277
+G,CT4213208000000,"Chester city, PA",0,T,6281
+G,CT4221648000000,"Easton city, PA",0,T,6285
+G,CT4224000000000,"Erie city, PA",0,T,6286
+G,CT4232800000000,"Harrisburg city, PA",0,T,6290
+G,CT4233408000000,"Hazleton city, PA",0,T,6292
+G,CT4238288000000,"Johnstown city, PA",0,T,6295
+G,CT4241216000000,"Lancaster city, PA",0,T,6296
+G,CT4242168000000,"Lebanon city, PA",0,T,6297
+G,CT4250528000000,"Monroeville municipality, PA",0,T,6307
+G,CT4253368000000,"New Castle city, PA",0,T,6311
+G,CT4254656000000,"Norristown borough, PA",0,T,6312
+G,CT4260000000000,"Philadelphia County/city, PA",0,T,6316
+G,CT4261000000000,"Pittsburgh city, PA",0,T,6317
+G,CT4261536000000,"Plum borough, PA",0,T,6318
+G,CT4263624000000,"Reading city, PA",0,T,6320
+G,CT4269000000000,"Scranton city, PA",0,T,6323
+G,CT4273808000000,"State College borough, PA",0,T,6328
+G,CT4283512000000,"West Mifflin borough, PA",0,T,6339
+G,CT4285152000000,"Wilkes-Barre city, PA",0,T,6341
+G,CT4285312000000,"Williamsport city, PA",0,T,6342
+G,CT4287048000000,"York city, PA",0,T,6343
+G,CT4419180000000,"Cranston city, RI",0,T,6363
+G,CT4422960000000,"East Providence city, RI",0,T,6366
+G,CT4449960000000,"Newport city, RI",0,T,6377
+G,CT4454640000000,"Pawtucket city, RI",0,T,6382
+G,CT4459000000000,"Providence city, RI",0,T,6384
+G,CT4474300000000,"Warwick city, RI",0,T,6391
+G,CT4480780000000,"Woonsocket city, RI",0,T,6395
+G,CT4500550000000,"Aiken city, SC",0,T,6463
+G,CT4501360000000,"Anderson city, SC",0,T,6464
+G,CT4507210000000,"Bluffton town, SC",0,T,6465
+G,CT4513330000000,"Charleston city, SC",0,T,6466
+G,CT4516000000000,"Columbia city, SC",0,T,6467
+G,CT4516405000000,"Conway city, SC",0,T,6468
+G,CT4525810000000,"Florence city, SC",0,T,6469
+G,CT4526890000000,"Fort Mill town, SC",0,T,6470
+G,CT4529815000000,"Goose Creek city, SC",0,T,6471
+G,CT4530850000000,"Greenville city, SC",0,T,6472
+G,CT4530985000000,"Greer city, SC",0,T,6473
+G,CT4532065000000,"Hanahan city, SC",0,T,6474
+G,CT4534045000000,"Hilton Head Island town, SC",0,T,6475
+G,CT4545115000000,"Mauldin city, SC",0,T,6476
+G,CT4548535000000,"Mount Pleasant town, SC",0,T,6477
+G,CT4549075000000,"Myrtle Beach city, SC",0,T,6478
+G,CT4550875000000,"North Charleston city, SC",0,T,6479
+G,CT4561405000000,"Rock Hill city, SC",0,T,6480
+G,CT4568290000000,"Spartanburg city, SC",0,T,6481
+G,CT4570270000000,"Summerville town, SC",0,T,6482
+G,CT4570405000000,"Sumter city, SC",0,T,6483
+G,CT4600100000000,"Aberdeen city, SD",0,T,6577
+G,CT4652980000000,"Rapid City city, SD",0,T,6578
+G,CT4659020000000,"Sioux Falls city, SD",0,T,6579
+G,CT4703440000000,"Bartlett city, TN",0,T,6714
+G,CT4708280000000,"Brentwood city, TN",0,T,6715
+G,CT4708540000000,"Bristol city, TN",0,T,6716
+G,CT4714000000000,"Chattanooga city, TN",0,T,6717
+G,CT4715160000000,"Clarksville city, TN",0,T,6718
+G,CT4715400000000,"Cleveland city, TN",0,T,6719
+G,CT4716420000000,"Collierville town, TN",0,T,6720
+G,CT4716540000000,"Columbia city, TN",0,T,6721
+G,CT4716920000000,"Cookeville city, TN",0,T,6722
+G,CT4727740000000,"Franklin city, TN",0,T,6723
+G,CT4728540000000,"Gallatin city, TN",0,T,6724
+G,CT4728960000000,"Germantown city, TN",0,T,6725
+G,CT4733280000000,"Hendersonville city, TN",0,T,6726
+G,CT4737640000000,"Jackson city, TN",0,T,6727
+G,CT4738320000000,"Johnson City city, TN",0,T,6728
+G,CT4739560000000,"Kingsport city, TN",0,T,6729
+G,CT4740000000000,"Knoxville city, TN",0,T,6730
+G,CT4741200000000,"La Vergne city, TN",0,T,6731
+G,CT4741520000000,"Lebanon city, TN",0,T,6732
+G,CT4746380000000,"Maryville city, TN",0,T,6733
+G,CT4748000000000,"Memphis city, TN",0,T,6734
+G,CT4750280000000,"Morristown city, TN",0,T,6735
+G,CT4750780000000,"Mount Juliet city, TN",0,T,6736
+G,CT4751560000000,"Murfreesboro city, TN",0,T,6737
+G,CT4752004000000,"Nashville-Davidson (consolidated) city, TN",0,T,6738
+G,CT4755120000000,"Oak Ridge city, TN",0,T,6739
+G,CT4769420000000,"Smyrna town, TN",0,T,6740
+G,CT4770580000000,"Spring Hill city, TN",0,T,6741
+G,CT4801000000000,"Abilene city, TX",0,T,7096
+G,CT4801924000000,"Allen city, TX",0,T,7097
+G,CT4802272000000,"Alvin city, TX",0,T,7098
+G,CT4803000000000,"Amarillo city, TX",0,T,7099
+G,CT4804000000000,"Arlington city, TX",0,T,7100
+G,CT4805000000000,"Austin city, TX",0,T,7101
+G,CT4805372000000,"Balch Springs city, TX",0,T,7102
+G,CT4806128000000,"Baytown city, TX",0,T,7103
+G,CT4807000000000,"Beaumont city, TX",0,T,7104
+G,CT4807132000000,"Bedford city, TX",0,T,7105
+G,CT4808236000000,"Big Spring city, TX",0,T,7106
+G,CT4810768000000,"Brownsville city, TX",0,T,7107
+G,CT4810912000000,"Bryan city, TX",0,T,7108
+G,CT4811428000000,"Burleson city, TX",0,T,7109
+G,CT4813024000000,"Carrollton city, TX",0,T,7110
+G,CT4813492000000,"Cedar Hill city, TX",0,T,7111
+G,CT4813552000000,"Cedar Park city, TX",0,T,7112
+G,CT4814920000000,"Cibolo city, TX",0,T,7113
+G,CT4815364000000,"Cleburne city, TX",0,T,7114
+G,CT4815976000000,"College Station city, TX",0,T,7115
+G,CT4815988000000,"Colleyville city, TX",0,T,7116
+G,CT4816432000000,"Conroe city, TX",0,T,7117
+G,CT4816468000000,"Converse city, TX",0,T,7118
+G,CT4816612000000,"Coppell city, TX",0,T,7119
+G,CT4816624000000,"Copperas Cove city, TX",0,T,7120
+G,CT4817000000000,"Corpus Christi city, TX",0,T,7121
+G,CT4817060000000,"Corsicana city, TX",0,T,7122
+G,CT4819000000000,"Dallas city, TX",0,T,7123
+G,CT4819624000000,"Deer Park city, TX",0,T,7124
+G,CT4819792000000,"Del Rio city, TX",0,T,7125
+G,CT4819900000000,"Denison city, TX",0,T,7126
+G,CT4819972000000,"Denton city, TX",0,T,7127
+G,CT4820092000000,"DeSoto city, TX",0,T,7128
+G,CT4821628000000,"Duncanville city, TX",0,T,7129
+G,CT4821892000000,"Eagle Pass city, TX",0,T,7130
+G,CT4822660000000,"Edinburg city, TX",0,T,7131
+G,CT4824000000000,"El Paso city, TX",0,T,7132
+G,CT4824768000000,"Euless city, TX",0,T,7133
+G,CT4825452000000,"Farmers Branch city, TX",0,T,7134
+G,CT4826232000000,"Flower Mound town, TX",0,T,7135
+G,CT4826604000000,"Forney city, TX",0,T,7136
+G,CT4827000000000,"Fort Worth city, TX",0,T,7137
+G,CT4827648000000,"Friendswood city, TX",0,T,7138
+G,CT4827684000000,"Frisco city, TX",0,T,7139
+G,CT4827876000000,"Fulshear city, TX",0,T,7140
+G,CT4828068000000,"Galveston city, TX",0,T,7141
+G,CT4829000000000,"Garland city, TX",0,T,7142
+G,CT4829336000000,"Georgetown city, TX",0,T,7143
+G,CT4830464000000,"Grand Prairie city, TX",0,T,7144
+G,CT4830644000000,"Grapevine city, TX",0,T,7145
+G,CT4830920000000,"Greenville city, TX",0,T,7146
+G,CT4831928000000,"Haltom City city, TX",0,T,7147
+G,CT4832312000000,"Harker Heights city, TX",0,T,7148
+G,CT4832372000000,"Harlingen city, TX",0,T,7149
+G,CT4835000000000,"Houston city, TX",0,T,7150
+G,CT4835528000000,"Huntsville city, TX",0,T,7151
+G,CT4835576000000,"Hurst city, TX",0,T,7152
+G,CT4835624000000,"Hutto city, TX",0,T,7153
+G,CT4837000000000,"Irving city, TX",0,T,7154
+G,CT4838632000000,"Keller city, TX",0,T,7155
+G,CT4839148000000,"Killeen city, TX",0,T,7156
+G,CT4839352000000,"Kingsville city, TX",0,T,7157
+G,CT4839952000000,"Kyle city, TX",0,T,7158
+G,CT4840588000000,"Lake Jackson city, TX",0,T,7159
+G,CT4841212000000,"Lancaster city, TX",0,T,7160
+G,CT4841440000000,"La Porte city, TX",0,T,7161
+G,CT4841464000000,"Laredo city, TX",0,T,7162
+G,CT4841980000000,"League City city, TX",0,T,7163
+G,CT4842016000000,"Leander city, TX",0,T,7164
+G,CT4842508000000,"Lewisville city, TX",0,T,7165
+G,CT4843012000000,"Little Elm city, TX",0,T,7166
+G,CT4843888000000,"Longview city, TX",0,T,7167
+G,CT4845000000000,"Lubbock city, TX",0,T,7168
+G,CT4845072000000,"Lufkin city, TX",0,T,7169
+G,CT4845384000000,"McAllen city, TX",0,T,7170
+G,CT4845744000000,"McKinney city, TX",0,T,7171
+G,CT4846452000000,"Mansfield city, TX",0,T,7172
+G,CT4847892000000,"Mesquite city, TX",0,T,7173
+G,CT4848072000000,"Midland city, TX",0,T,7174
+G,CT4848096000000,"Midlothian city, TX",0,T,7175
+G,CT4848768000000,"Mission city, TX",0,T,7176
+G,CT4848804000000,"Missouri City city, TX",0,T,7177
+G,CT4850256000000,"Nacogdoches city, TX",0,T,7178
+G,CT4850820000000,"New Braunfels city, TX",0,T,7179
+G,CT4852356000000,"North Richland Hills city, TX",0,T,7180
+G,CT4853388000000,"Odessa city, TX",0,T,7181
+G,CT4855080000000,"Paris city, TX",0,T,7182
+G,CT4856000000000,"Pasadena city, TX",0,T,7183
+G,CT4856348000000,"Pearland city, TX",0,T,7184
+G,CT4857176000000,"Pflugerville city, TX",0,T,7185
+G,CT4857200000000,"Pharr city, TX",0,T,7186
+G,CT4858016000000,"Plano city, TX",0,T,7187
+G,CT4858820000000,"Port Arthur city, TX",0,T,7188
+G,CT4859696000000,"Prosper town, TX",0,T,7189
+G,CT4861796000000,"Richardson city, TX",0,T,7190
+G,CT4862828000000,"Rockwall city, TX",0,T,7191
+G,CT4863284000000,"Rosenberg city, TX",0,T,7192
+G,CT4863500000000,"Round Rock city, TX",0,T,7193
+G,CT4863572000000,"Rowlett city, TX",0,T,7194
+G,CT4864064000000,"Sachse city, TX",0,T,7195
+G,CT4864472000000,"San Angelo city, TX",0,T,7196
+G,CT4865000000000,"San Antonio city, TX",0,T,7197
+G,CT4865036000000,"San Benito city, TX",0,T,7198
+G,CT4865516000000,"San Juan city, TX",0,T,7199
+G,CT4865600000000,"San Marcos city, TX",0,T,7200
+G,CT4866128000000,"Schertz city, TX",0,T,7201
+G,CT4866644000000,"Seguin city, TX",0,T,7202
+G,CT4867496000000,"Sherman city, TX",0,T,7203
+G,CT4868636000000,"Socorro city, TX",0,T,7204
+G,CT4869032000000,"Southlake city, TX",0,T,7205
+G,CT4870808000000,"Sugar Land city, TX",0,T,7206
+G,CT4872176000000,"Temple city, TX",0,T,7207
+G,CT4872368000000,"Texarkana city, TX",0,T,7208
+G,CT4872392000000,"Texas City city, TX",0,T,7209
+G,CT4872530000000,"The Colony city, TX",0,T,7210
+G,CT4874144000000,"Tyler city, TX",0,T,7211
+G,CT4874492000000,"University Park city, TX",0,T,7212
+G,CT4875428000000,"Victoria city, TX",0,T,7213
+G,CT4876000000000,"Waco city, TX",0,T,7214
+G,CT4876816000000,"Waxahachie city, TX",0,T,7215
+G,CT4876864000000,"Weatherford city, TX",0,T,7216
+G,CT4877272000000,"Weslaco city, TX",0,T,7217
+G,CT4879000000000,"Wichita Falls city, TX",0,T,7218
+G,CT4880356000000,"Wylie city, TX",0,T,7219
+G,CT4901310000000,"American Fork city, UT",0,T,7351
+G,CT4907690000000,"Bountiful city, UT",0,T,7352
+G,CT4911320000000,"Cedar City city, UT",0,T,7353
+G,CT4913850000000,"Clearfield city, UT",0,T,7354
+G,CT4916270000000,"Cottonwood Heights city, UT",0,T,7355
+G,CT4920120000000,"Draper city, UT",0,T,7356
+G,CT4920810000000,"Eagle Mountain city, UT",0,T,7357
+G,CT4924740000000,"Farmington city, UT",0,T,7358
+G,CT4934970000000,"Herriman city, UT",0,T,7359
+G,CT4936070000000,"Holladay city, UT",0,T,7360
+G,CT4940360000000,"Kaysville city, UT",0,T,7361
+G,CT4940470000000,"Kearns metro township, UT",0,T,7362
+G,CT4943660000000,"Layton city, UT",0,T,7363
+G,CT4944320000000,"Lehi city, UT",0,T,7364
+G,CT4945860000000,"Logan city, UT",0,T,7365
+G,CT4947290000000,"Magna metro township, UT",0,T,7366
+G,CT4949710000000,"Midvale city, UT",0,T,7367
+G,CT4950150000000,"Millcreek city, UT",0,T,7368
+G,CT4953230000000,"Murray city, UT",0,T,7369
+G,CT4955980000000,"Ogden city, UT",0,T,7370
+G,CT4957300000000,"Orem city, UT",0,T,7371
+G,CT4960930000000,"Pleasant Grove city, UT",0,T,7372
+G,CT4962470000000,"Provo city, UT",0,T,7373
+G,CT4964340000000,"Riverton city, UT",0,T,7374
+G,CT4965110000000,"Roy city, UT",0,T,7375
+G,CT4965330000000,"St. George city, UT",0,T,7376
+G,CT4967000000000,"Salt Lake City city, UT",0,T,7377
+G,CT4967440000000,"Sandy city, UT",0,T,7378
+G,CT4967825000000,"Saratoga Springs city, UT",0,T,7379
+G,CT4970850000000,"South Jordan city, UT",0,T,7380
+G,CT4971070000000,"South Salt Lake city, UT",0,T,7381
+G,CT4971290000000,"Spanish Fork city, UT",0,T,7382
+G,CT4972280000000,"Springville city, UT",0,T,7383
+G,CT4974810000000,"Syracuse city, UT",0,T,7384
+G,CT4975360000000,"Taylorsville city, UT",0,T,7385
+G,CT4976680000000,"Tooele city, UT",0,T,7386
+G,CT4981960000000,"Washington city, UT",0,T,7387
+G,CT4982950000000,"West Jordan city, UT",0,T,7388
+G,CT4983470000000,"West Valley City city, UT",0,T,7389
+G,CT5010675000000,"Burlington city, VT",0,T,7448
+G,CT5101000000000,"Alexandria city, VA",0,T,7828
+G,CT5107784000000,"Blacksburg town, VA",0,T,7829
+G,CT5109816000000,"Bristol city, VA",0,T,7830
+G,CT5111032000000,"Buena Vista city, VA",0,T,7831
+G,CT5114968000000,"Charlottesville city, VA",0,T,7832
+G,CT5116000000000,"Chesapeake city, VA",0,T,7833
+G,CT5118448000000,"Colonial Heights city, VA",0,T,7834
+G,CT5119728000000,"Covington city, VA",0,T,7835
+G,CT5121344000000,"Danville city, VA",0,T,7836
+G,CT5125808000000,"Emporia city, VA",0,T,7837
+G,CT5126496000000,"Fairfax city, VA",0,T,7838
+G,CT5127200000000,"Falls Church city, VA",0,T,7839
+G,CT5129600000000,"Franklin city, VA",0,T,7840
+G,CT5129744000000,"Fredericksburg city, VA",0,T,7841
+G,CT5130208000000,"Galax city, VA",0,T,7842
+G,CT5135000000000,"Hampton city, VA",0,T,7843
+G,CT5135624000000,"Harrisonburg city, VA",0,T,7844
+G,CT5138424000000,"Hopewell city, VA",0,T,7845
+G,CT5144984000000,"Leesburg town, VA",0,T,7846
+G,CT5145512000000,"Lexington city, VA",0,T,7847
+G,CT5147672000000,"Lynchburg city, VA",0,T,7848
+G,CT5148952000000,"Manassas city, VA",0,T,7849
+G,CT5148968000000,"Manassas Park city, VA",0,T,7850
+G,CT5149784000000,"Martinsville city, VA",0,T,7851
+G,CT5156000000000,"Newport News city, VA",0,T,7852
+G,CT5157000000000,"Norfolk city, VA",0,T,7853
+G,CT5157688000000,"Norton city, VA",0,T,7854
+G,CT5161832000000,"Petersburg city, VA",0,T,7855
+G,CT5163768000000,"Poquoson city, VA",0,T,7856
+G,CT5164000000000,"Portsmouth city, VA",0,T,7857
+G,CT5165392000000,"Radford city, VA",0,T,7858
+G,CT5167000000000,"Richmond city, VA",0,T,7859
+G,CT5168000000000,"Roanoke city, VA",0,T,7860
+G,CT5170000000000,"Salem city, VA",0,T,7861
+G,CT5175216000000,"Staunton city, VA",0,T,7862
+G,CT5176432000000,"Suffolk city, VA",0,T,7863
+G,CT5182000000000,"Virginia Beach city, VA",0,T,7864
+G,CT5183680000000,"Waynesboro city, VA",0,T,7865
+G,CT5186160000000,"Williamsburg city, VA",0,T,7866
+G,CT5186720000000,"Winchester city, VA",0,T,7867
+G,CT5303180000000,"Auburn city, WA",0,T,7945
+G,CT5303736000000,"Bainbridge Island city, WA",0,T,7946
+G,CT5305210000000,"Bellevue city, WA",0,T,7947
+G,CT5305280000000,"Bellingham city, WA",0,T,7948
+G,CT5307380000000,"Bothell city, WA",0,T,7949
+G,CT5307695000000,"Bremerton city, WA",0,T,7950
+G,CT5308850000000,"Burien city, WA",0,T,7951
+G,CT5309480000000,"Camas city, WA",0,T,7952
+G,CT5317635000000,"Des Moines city, WA",0,T,7953
+G,CT5320750000000,"Edmonds city, WA",0,T,7954
+G,CT5322640000000,"Everett city, WA",0,T,7955
+G,CT5323515000000,"Federal Way city, WA",0,T,7956
+G,CT5333805000000,"Issaquah city, WA",0,T,7957
+G,CT5335275000000,"Kennewick city, WA",0,T,7958
+G,CT5335415000000,"Kent city, WA",0,T,7959
+G,CT5335940000000,"Kirkland city, WA",0,T,7960
+G,CT5336745000000,"Lacey city, WA",0,T,7961
+G,CT5337900000000,"Lake Stevens city, WA",0,T,7962
+G,CT5338038000000,"Lakewood city, WA",0,T,7963
+G,CT5340245000000,"Longview city, WA",0,T,7964
+G,CT5340840000000,"Lynnwood city, WA",0,T,7965
+G,CT5343150000000,"Maple Valley city, WA",0,T,7966
+G,CT5343955000000,"Marysville city, WA",0,T,7967
+G,CT5345005000000,"Mercer Island city, WA",0,T,7968
+G,CT5347245000000,"Moses Lake city, WA",0,T,7969
+G,CT5347560000000,"Mount Vernon city, WA",0,T,7970
+G,CT5351300000000,"Olympia city, WA",0,T,7971
+G,CT5353545000000,"Pasco city, WA",0,T,7972
+G,CT5356625000000,"Pullman city, WA",0,T,7973
+G,CT5356695000000,"Puyallup city, WA",0,T,7974
+G,CT5357535000000,"Redmond city, WA",0,T,7975
+G,CT5357745000000,"Renton city, WA",0,T,7976
+G,CT5358235000000,"Richland city, WA",0,T,7977
+G,CT5361115000000,"Sammamish city, WA",0,T,7978
+G,CT5362288000000,"SeaTac city, WA",0,T,7979
+G,CT5363000000000,"Seattle city, WA",0,T,7980
+G,CT5363960000000,"Shoreline city, WA",0,T,7981
+G,CT5367000000000,"Spokane city, WA",0,T,7982
+G,CT5367167000000,"Spokane Valley city, WA",0,T,7983
+G,CT5370000000000,"Tacoma city, WA",0,T,7984
+G,CT5372905000000,"Tumwater city, WA",0,T,7985
+G,CT5373465000000,"University Place city, WA",0,T,7986
+G,CT5374060000000,"Vancouver city, WA",0,T,7987
+G,CT5375775000000,"Walla Walla city, WA",0,T,7988
+G,CT5377105000000,"Wenatchee city, WA",0,T,7989
+G,CT5380010000000,"Yakima city, WA",0,T,7990
+G,CT5414600000000,"Charleston city, WV",0,T,8068
+G,CT5439460000000,"Huntington city, WV",0,T,8069
+G,CT5455756000000,"Morgantown city, WV",0,T,8070
+G,CT5462140000000,"Parkersburg city, WV",0,T,8071
+G,CT5486452000000,"Wheeling city, WV",0,T,8072
+G,CT5502375000000,"Appleton city, WI",0,T,8189
+G,CT5506500000000,"Beloit city, WI",0,T,8190
+G,CT5510025000000,"Brookfield city, WI",0,T,8191
+G,CT5511950000000,"Caledonia village, WI",0,T,8192
+G,CT5519775000000,"De Pere city, WI",0,T,8193
+G,CT5522300000000,"Eau Claire city, WI",0,T,8194
+G,CT5525950000000,"Fitchburg city, WI",0,T,8195
+G,CT5526275000000,"Fond du Lac city, WI",0,T,8196
+G,CT5527300000000,"Franklin city, WI",0,T,8197
+G,CT5531000000000,"Green Bay city, WI",0,T,8198
+G,CT5531175000000,"Greenfield city, WI",0,T,8199
+G,CT5537825000000,"Janesville city, WI",0,T,8200
+G,CT5539225000000,"Kenosha city, WI",0,T,8201
+G,CT5540775000000,"La Crosse city, WI",0,T,8202
+G,CT5548000000000,"Madison city, WI",0,T,8203
+G,CT5548500000000,"Manitowoc city, WI",0,T,8204
+G,CT5551000000000,"Menomonee Falls village, WI",0,T,8205
+G,CT5551150000000,"Mequon city, WI",0,T,8206
+G,CT5553000000000,"Milwaukee city, WI",0,T,8207
+G,CT5554875000000,"Mount Pleasant village, WI",0,T,8208
+G,CT5555275000000,"Muskego city, WI",0,T,8209
+G,CT5555750000000,"Neenah city, WI",0,T,8210
+G,CT5556375000000,"New Berlin city, WI",0,T,8211
+G,CT5558800000000,"Oak Creek city, WI",0,T,8212
+G,CT5560500000000,"Oshkosh city, WI",0,T,8213
+G,CT5566000000000,"Racine city, WI",0,T,8214
+G,CT5572975000000,"Sheboygan city, WI",0,T,8215
+G,CT5577200000000,"Stevens Point city, WI",0,T,8216
+G,CT5578600000000,"Sun Prairie city, WI",0,T,8217
+G,CT5578650000000,"Superior city, WI",0,T,8218
+G,CT5584250000000,"Waukesha city, WI",0,T,8219
+G,CT5584475000000,"Wausau city, WI",0,T,8220
+G,CT5584675000000,"Wauwatosa city, WI",0,T,8221
+G,CT5585300000000,"West Allis city, WI",0,T,8222
+G,CT5585350000000,"West Bend city, WI",0,T,8223
+G,CT5613150000000,"Casper city, WY",0,T,8270
+G,CT5613900000000,"Cheyenne city, WY",0,T,8271
+G,CT5631855000000,"Gillette city, WY",0,T,8272
+G,CT5645050000000,"Laramie city, WY",0,T,8273
+H,CS0901080000000,"Andover town, CT",0,T,926
+H,CS0901430000000,"Ashford town, CT",0,T,928
+H,CS0902060000000,"Avon town, CT",0,T,929
+H,CS0902760000000,"Barkhamsted town, CT",0,T,930
+H,CS0903250000000,"Beacon Falls town, CT",0,T,931
+H,CS0904300000000,"Berlin town, CT",0,T,932
+H,CS0904580000000,"Bethany town, CT",0,T,933
+H,CS0904720000000,"Bethel town, CT",0,T,934
+H,CS0904930000000,"Bethlehem town, CT",0,T,935
+H,CS0905910000000,"Bloomfield town, CT",0,T,936
+H,CS0906260000000,"Bolton town, CT",0,T,937
+H,CS0906820000000,"Bozrah town, CT",0,T,938
+H,CS0908210000000,"Bridgewater town, CT",0,T,941
+H,CS0908980000000,"Brookfield town, CT",0,T,943
+H,CS0909190000000,"Brooklyn town, CT",0,T,944
+H,CS0910100000000,"Burlington town, CT",0,T,945
+H,CS0910940000000,"Canaan town, CT",0,T,946
+H,CS0912130000000,"Canterbury town, CT",0,T,947
+H,CS0912270000000,"Canton town, CT",0,T,948
+H,CS0913810000000,"Chaplin town, CT",0,T,949
+H,CS0914300000000,"Chester town, CT",0,T,951
+H,CS0915350000000,"Clinton town, CT",0,T,952
+H,CS0915910000000,"Colchester town, CT",0,T,953
+H,CS0916050000000,"Colebrook town, CT",0,T,954
+H,CS0916400000000,"Columbia town, CT",0,T,955
+H,CS0917240000000,"Cornwall town, CT",0,T,956
+H,CS0917800000000,"Coventry town, CT",0,T,957
+H,CS0918080000000,"Cromwell town, CT",0,T,958
+H,CS0918850000000,"Darien town, CT",0,T,960
+H,CS0919130000000,"Deep River town, CT",0,T,961
+H,CS0920810000000,"Durham town, CT",0,T,963
+H,CS0921860000000,"Eastford town, CT",0,T,964
+H,CS0922070000000,"East Granby town, CT",0,T,965
+H,CS0922280000000,"East Haddam town, CT",0,T,966
+H,CS0922490000000,"East Hampton town, CT",0,T,967
+H,CS0923400000000,"East Lyme town, CT",0,T,970
+H,CS0923890000000,"Easton town, CT",0,T,971
+H,CS0924800000000,"East Windsor town, CT",0,T,972
+H,CS0925360000000,"Ellington town, CT",0,T,973
+H,CS0926270000000,"Essex town, CT",0,T,975
+H,CS0929910000000,"Franklin town, CT",0,T,978
+H,CS0932290000000,"Goshen town, CT",0,T,980
+H,CS0932640000000,"Granby town, CT",0,T,981
+H,CS0933900000000,"Griswold town, CT",0,T,983
+H,CS0934950000000,"Guilford town, CT",0,T,985
+H,CS0935230000000,"Haddam town, CT",0,T,986
+H,CS0936000000000,"Hampton town, CT",0,T,988
+H,CS0937140000000,"Hartland town, CT",0,T,990
+H,CS0937280000000,"Harwinton town, CT",0,T,991
+H,CS0937910000000,"Hebron town, CT",0,T,992
+H,CS0940290000000,"Kent town, CT",0,T,993
+H,CS0940500000000,"Killingly town, CT",0,T,994
+H,CS0940710000000,"Killingworth town, CT",0,T,995
+H,CS0942390000000,"Lebanon town, CT",0,T,996
+H,CS0942600000000,"Ledyard town, CT",0,T,997
+H,CS0943230000000,"Lisbon town, CT",0,T,998
+H,CS0943370000000,"Litchfield town, CT",0,T,999
+H,CS0944210000000,"Lyme town, CT",0,T,1000
+H,CS0944560000000,"Madison town, CT",0,T,1001
+H,CS0945820000000,"Marlborough town, CT",0,T,1004
+H,CS0946940000000,"Middlebury town, CT",0,T,1006
+H,CS0947080000000,"Middlefield town, CT",0,T,1007
+H,CS0948620000000,"Monroe town, CT",0,T,1010
+H,CS0948900000000,"Montville town, CT",0,T,1011
+H,CS0949460000000,"Morris town, CT",0,T,1012
+H,CS0950580000000,"New Canaan town, CT",0,T,1015
+H,CS0950860000000,"New Fairfield town, CT",0,T,1016
+H,CS0951350000000,"New Hartford town, CT",0,T,1017
+H,CS0953470000000,"Norfolk town, CT",0,T,1023
+H,CS0953890000000,"North Branford town, CT",0,T,1024
+H,CS0954030000000,"North Canaan town, CT",0,T,1025
+H,CS0954870000000,"North Haven town, CT",0,T,1026
+H,CS0955500000000,"North Stonington town, CT",0,T,1027
+H,CS0957040000000,"Old Lyme town, CT",0,T,1030
+H,CS0957320000000,"Old Saybrook town, CT",0,T,1031
+H,CS0957600000000,"Orange town, CT",0,T,1032
+H,CS0958300000000,"Oxford town, CT",0,T,1033
+H,CS0959980000000,"Plainfield town, CT",0,T,1034
+H,CS0960120000000,"Plainville town, CT",0,T,1035
+H,CS0960750000000,"Plymouth town, CT",0,T,1036
+H,CS0961030000000,"Pomfret town, CT",0,T,1037
+H,CS0961800000000,"Portland town, CT",0,T,1038
+H,CS0962150000000,"Preston town, CT",0,T,1039
+H,CS0962290000000,"Prospect town, CT",0,T,1040
+H,CS0962710000000,"Putnam town, CT",0,T,1041
+H,CS0963480000000,"Redding town, CT",0,T,1042
+H,CS0965370000000,"Rocky Hill town, CT",0,T,1044
+H,CS0965930000000,"Roxbury town, CT",0,T,1045
+H,CS0966210000000,"Salem town, CT",0,T,1046
+H,CS0966420000000,"Salisbury town, CT",0,T,1047
+H,CS0967400000000,"Scotland town, CT",0,T,1048
+H,CS0967610000000,"Seymour town, CT",0,T,1049
+H,CS0967960000000,"Sharon town, CT",0,T,1050
+H,CS0968310000000,"Sherman town, CT",0,T,1052
+H,CS0968940000000,"Simsbury town, CT",0,T,1053
+H,CS0969220000000,"Somers town, CT",0,T,1054
+H,CS0969640000000,"Southbury town, CT",0,T,1055
+H,CS0971670000000,"Sprague town, CT",0,T,1058
+H,CS0972090000000,"Stafford town, CT",0,T,1059
+H,CS0973420000000,"Sterling town, CT",0,T,1061
+H,CS0973770000000,"Stonington town, CT",0,T,1062
+H,CS0974540000000,"Suffield town, CT",0,T,1064
+H,CS0975730000000,"Thomaston town, CT",0,T,1065
+H,CS0975870000000,"Thompson town, CT",0,T,1066
+H,CS0976290000000,"Tolland town, CT",0,T,1067
+H,CS0977830000000,"Union town, CT",0,T,1070
+H,CS0978600000000,"Voluntown town, CT",0,T,1072
+H,CS0979510000000,"Warren town, CT",0,T,1074
+H,CS0979720000000,"Washington town, CT",0,T,1075
+H,CS0980280000000,"Waterford town, CT",0,T,1077
+H,CS0980490000000,"Watertown town, CT",0,T,1078
+H,CS0981680000000,"Westbrook town, CT",0,T,1079
+H,CS0983430000000,"Weston town, CT",0,T,1082
+H,CS0985950000000,"Willington town, CT",0,T,1085
+H,CS0986370000000,"Wilton town, CT",0,T,1086
+H,CS0986440000000,"Winchester town, CT",0,T,1087
+H,CS0986790000000,"Windham town, CT",0,T,1088
+H,CS0987070000000,"Windsor Locks town, CT",0,T,1090
+H,CS0987560000000,"Wolcott town, CT",0,T,1091
+H,CS0987700000000,"Woodbridge town, CT",0,T,1092
+H,CS0987910000000,"Woodbury town, CT",0,T,1093
+H,CS0988190000000,"Woodstock town, CT",0,T,1094
+H,CS2300100000000,"Abbot town, ME",0,T,2756
+H,CS2300275000000,"Acton town, ME",0,T,2757
+H,CS2300380000000,"Addison town, ME",0,T,2758
+H,CS2300590000000,"Albion town, ME",0,T,2759
+H,CS2300660000000,"Alexander town, ME",0,T,2760
+H,CS2300730000000,"Alfred town, ME",0,T,2761
+H,CS2300800000000,"Allagash town, ME",0,T,2762
+H,CS2301010000000,"Alna town, ME",0,T,2763
+H,CS2301115000000,"Alton town, ME",0,T,2764
+H,CS2301185000000,"Amherst town, ME",0,T,2765
+H,CS2301220000000,"Amity town, ME",0,T,2766
+H,CS2301325000000,"Andover town, ME",0,T,2767
+H,CS2301395000000,"Anson town, ME",0,T,2768
+H,CS2301465000000,"Appleton town, ME",0,T,2769
+H,CS2301500000000,"Argyle unorganized, ME",0,T,2770
+H,CS2301570000000,"Arrowsic town, ME",0,T,2771
+H,CS2301605000000,"Arundel town, ME",0,T,2772
+H,CS2301710000000,"Ashland town, ME",0,T,2773
+H,CS2301885000000,"Athens town, ME",0,T,2774
+H,CS2301920000000,"Atkinson town, ME",0,T,2775
+H,CS2302165000000,"Aurora town, ME",0,T,2778
+H,CS2302235000000,"Avon town, ME",0,T,2779
+H,CS2302480000000,"Baileyville town, ME",0,T,2780
+H,CS2302655000000,"Baldwin town, ME",0,T,2781
+H,CS2302762000000,"Bancroft unorganized, ME",0,T,2782
+H,CS2302865000000,"Bar Harbor town, ME",0,T,2784
+H,CS2302970000000,"Baring plantation, ME",0,T,2785
+H,CS2303670000000,"Beals town, ME",0,T,2787
+H,CS2303740000000,"Beaver Cove town, ME",0,T,2788
+H,CS2303810000000,"Beddington town, ME",0,T,2789
+H,CS2304020000000,"Belgrade town, ME",0,T,2791
+H,CS2304125000000,"Belmont town, ME",0,T,2792
+H,CS2304475000000,"Benton town, ME",0,T,2793
+H,CS2304720000000,"Berwick town, ME",0,T,2794
+H,CS2304825000000,"Bethel town, ME",0,T,2795
+H,CS2305000000000,"Bingham town, ME",0,T,2797
+H,CS2305385000000,"Blaine town, ME",0,T,2798
+H,CS2305560000000,"Blanchard unorganized, ME",0,T,2799
+H,CS2305700000000,"Blue Hill town, ME",0,T,2800
+H,CS2306050000000,"Boothbay town, ME",0,T,2801
+H,CS2306120000000,"Boothbay Harbor town, ME",0,T,2802
+H,CS2306260000000,"Bowdoin town, ME",0,T,2803
+H,CS2306365000000,"Bowdoinham town, ME",0,T,2804
+H,CS2306400000000,"Bowerbank town, ME",0,T,2805
+H,CS2306575000000,"Bradford town, ME",0,T,2806
+H,CS2306680000000,"Bradley town, ME",0,T,2807
+H,CS2306855000000,"Bremen town, ME",0,T,2808
+H,CS2307065000000,"Bridgewater town, ME",0,T,2810
+H,CS2307170000000,"Bridgton town, ME",0,T,2811
+H,CS2307380000000,"Brighton plantation, ME",0,T,2812
+H,CS2307485000000,"Bristol town, ME",0,T,2813
+H,CS2307800000000,"Brooklin town, ME",0,T,2814
+H,CS2307870000000,"Brooks town, ME",0,T,2815
+H,CS2307975000000,"Brooksville town, ME",0,T,2816
+H,CS2308150000000,"Brownfield town, ME",0,T,2817
+H,CS2308325000000,"Brownville town, ME",0,T,2818
+H,CS2308430000000,"Brunswick town, ME",0,T,2819
+H,CS2308710000000,"Buckfield town, ME",0,T,2820
+H,CS2308815000000,"Bucksport town, ME",0,T,2821
+H,CS2309200000000,"Burlington town, ME",0,T,2822
+H,CS2309270000000,"Burnham town, ME",0,T,2823
+H,CS2309410000000,"Buxton town, ME",0,T,2824
+H,CS2309550000000,"Byron town, ME",0,T,2825
+H,CS2309655000000,"Cambridge town, ME",0,T,2827
+H,CS2309725000000,"Camden town, ME",0,T,2828
+H,CS2309935000000,"Canaan town, ME",0,T,2829
+H,CS2310005000000,"Canton town, ME",0,T,2830
+H,CS2310180000000,"Cape Elizabeth town, ME",0,T,2831
+H,CS2310495000000,"Caratunk town, ME",0,T,2832
+H,CS2310670000000,"Carmel town, ME",0,T,2834
+H,CS2310740000000,"Carrabassett Valley town, ME",0,T,2835
+H,CS2310810000000,"Carroll plantation, ME",0,T,2836
+H,CS2310915000000,"Carthage town, ME",0,T,2837
+H,CS2311020000000,"Cary plantation, ME",0,T,2838
+H,CS2311125000000,"Casco town, ME",0,T,2839
+H,CS2311265000000,"Castine town, ME",0,T,2840
+H,CS2311300000000,"Castle Hill town, ME",0,T,2841
+H,CS2311335000000,"Caswell town, ME",0,T,2842
+H,CS2311785000000,"Central Aroostook unorganized, ME",0,T,2843
+H,CS2311800000000,"Central Hancock unorganized, ME",0,T,2844
+H,CS2311820000000,"Central Somerset unorganized, ME",0,T,2845
+H,CS2312000000000,"Chapman town, ME",0,T,2846
+H,CS2312105000000,"Charleston town, ME",0,T,2847
+H,CS2312175000000,"Charlotte town, ME",0,T,2848
+H,CS2312300000000,"Chebeague Island town, ME",0,T,2849
+H,CS2312350000000,"Chelsea town, ME",0,T,2850
+H,CS2312455000000,"Cherryfield town, ME",0,T,2851
+H,CS2312525000000,"Chester town, ME",0,T,2852
+H,CS2312595000000,"Chesterville town, ME",0,T,2853
+H,CS2312735000000,"China town, ME",0,T,2854
+H,CS2313365000000,"Clifton town, ME",0,T,2855
+H,CS2313470000000,"Clinton town, ME",0,T,2856
+H,CS2313610000000,"Codyville plantation, ME",0,T,2857
+H,CS2313750000000,"Columbia town, ME",0,T,2858
+H,CS2313820000000,"Columbia Falls town, ME",0,T,2859
+H,CS2313900000000,"Connor unorganized, ME",0,T,2860
+H,CS2314100000000,"Cooper town, ME",0,T,2861
+H,CS2314205000000,"Coplin plantation, ME",0,T,2862
+H,CS2314310000000,"Corinna town, ME",0,T,2863
+H,CS2314380000000,"Corinth town, ME",0,T,2864
+H,CS2314485000000,"Cornish town, ME",0,T,2865
+H,CS2314555000000,"Cornville town, ME",0,T,2866
+H,CS2314905000000,"Cranberry Isles town, ME",0,T,2867
+H,CS2314940000000,"Crawford town, ME",0,T,2868
+H,CS2315395000000,"Crystal town, ME",0,T,2869
+H,CS2315430000000,"Cumberland town, ME",0,T,2870
+H,CS2315780000000,"Cushing town, ME",0,T,2871
+H,CS2315920000000,"Cutler town, ME",0,T,2872
+H,CS2315990000000,"Cyr plantation, ME",0,T,2873
+H,CS2316165000000,"Dallas plantation, ME",0,T,2874
+H,CS2316235000000,"Damariscotta town, ME",0,T,2875
+H,CS2316410000000,"Danforth town, ME",0,T,2876
+H,CS2316725000000,"Dayton town, ME",0,T,2877
+H,CS2316865000000,"Deblois town, ME",0,T,2878
+H,CS2316935000000,"Dedham town, ME",0,T,2879
+H,CS2317145000000,"Deer Isle town, ME",0,T,2880
+H,CS2317250000000,"Denmark town, ME",0,T,2881
+H,CS2317285000000,"Dennistown plantation, ME",0,T,2882
+H,CS2317355000000,"Dennysville town, ME",0,T,2883
+H,CS2317460000000,"Detroit town, ME",0,T,2884
+H,CS2317530000000,"Dexter town, ME",0,T,2885
+H,CS2317740000000,"Dixfield town, ME",0,T,2886
+H,CS2317950000000,"Dixmont town, ME",0,T,2887
+H,CS2318195000000,"Dover-Foxcroft town, ME",0,T,2888
+H,CS2318475000000,"Dresden town, ME",0,T,2889
+H,CS2318580000000,"Drew plantation, ME",0,T,2890
+H,CS2319105000000,"Durham town, ME",0,T,2891
+H,CS2319210000000,"Dyer Brook town, ME",0,T,2892
+H,CS2319420000000,"Eagle Lake town, ME",0,T,2893
+H,CS2319770000000,"Eastbrook town, ME",0,T,2894
+H,CS2319865000000,"East Central Franklin unorganized, ME",0,T,2895
+H,CS2319868000000,"East Central Penobscot unorganized, ME",0,T,2896
+H,CS2319870000000,"East Central Washington unorganized, ME",0,T,2897
+H,CS2320405000000,"East Hancock unorganized, ME",0,T,2898
+H,CS2320960000000,"East Machias town, ME",0,T,2899
+H,CS2321030000000,"East Millinocket town, ME",0,T,2900
+H,CS2321380000000,"Easton town, ME",0,T,2901
+H,CS2322535000000,"Eddington town, ME",0,T,2903
+H,CS2322675000000,"Edgecomb town, ME",0,T,2904
+H,CS2322710000000,"Edinburg town, ME",0,T,2905
+H,CS2322955000000,"Eliot town, ME",0,T,2906
+H,CS2323410000000,"Embden town, ME",0,T,2908
+H,CS2323620000000,"Enfield town, ME",0,T,2909
+H,CS2323865000000,"Etna town, ME",0,T,2910
+H,CS2324005000000,"Eustis town, ME",0,T,2911
+H,CS2324110000000,"Exeter town, ME",0,T,2912
+H,CS2324320000000,"Fairfield town, ME",0,T,2913
+H,CS2324495000000,"Falmouth town, ME",0,T,2914
+H,CS2324670000000,"Farmingdale town, ME",0,T,2915
+H,CS2324775000000,"Farmington town, ME",0,T,2916
+H,CS2324950000000,"Fayette town, ME",0,T,2917
+H,CS2325615000000,"Fort Fairfield town, ME",0,T,2918
+H,CS2325755000000,"Fort Kent town, ME",0,T,2919
+H,CS2326280000000,"Frankfort town, ME",0,T,2920
+H,CS2326350000000,"Franklin town, ME",0,T,2921
+H,CS2326420000000,"Freedom town, ME",0,T,2922
+H,CS2326525000000,"Freeport town, ME",0,T,2923
+H,CS2326595000000,"Frenchboro town, ME",0,T,2924
+H,CS2326735000000,"Frenchville town, ME",0,T,2925
+H,CS2326805000000,"Friendship town, ME",0,T,2926
+H,CS2326910000000,"Fryeburg town, ME",0,T,2927
+H,CS2327025000000,"Frye Island town, ME",0,T,2928
+H,CS2327120000000,"Garfield plantation, ME",0,T,2930
+H,CS2327190000000,"Garland town, ME",0,T,2931
+H,CS2327295000000,"Georgetown town, ME",0,T,2932
+H,CS2327505000000,"Gilead town, ME",0,T,2933
+H,CS2327645000000,"Glenburn town, ME",0,T,2934
+H,CS2327855000000,"Glenwood plantation, ME",0,T,2935
+H,CS2328240000000,"Gorham town, ME",0,T,2936
+H,CS2328450000000,"Gouldsboro town, ME",0,T,2937
+H,CS2328590000000,"Grand Isle town, ME",0,T,2938
+H,CS2328660000000,"Grand Lake Stream plantation, ME",0,T,2939
+H,CS2328870000000,"Gray town, ME",0,T,2940
+H,CS2328975000000,"Great Pond town, ME",0,T,2941
+H,CS2329185000000,"Greenbush town, ME",0,T,2942
+H,CS2329255000000,"Greene town, ME",0,T,2943
+H,CS2329535000000,"Greenville town, ME",0,T,2944
+H,CS2329710000000,"Greenwood town, ME",0,T,2945
+H,CS2330095000000,"Guilford town, ME",0,T,2946
+H,CS2330690000000,"Hamlin town, ME",0,T,2948
+H,CS2330725000000,"Hammond town, ME",0,T,2949
+H,CS2330795000000,"Hampden town, ME",0,T,2950
+H,CS2330970000000,"Hancock town, ME",0,T,2951
+H,CS2331110000000,"Hanover town, ME",0,T,2952
+H,CS2331355000000,"Harmony town, ME",0,T,2953
+H,CS2331390000000,"Harpswell town, ME",0,T,2954
+H,CS2331530000000,"Harrington town, ME",0,T,2955
+H,CS2331600000000,"Harrison town, ME",0,T,2956
+H,CS2331670000000,"Hartford town, ME",0,T,2957
+H,CS2331740000000,"Hartland town, ME",0,T,2958
+H,CS2332195000000,"Haynesville town, ME",0,T,2959
+H,CS2332370000000,"Hebron town, ME",0,T,2960
+H,CS2332510000000,"Hermon town, ME",0,T,2961
+H,CS2332685000000,"Hersey town, ME",0,T,2962
+H,CS2332715000000,"Hibberts gore, ME",0,T,2963
+H,CS2332895000000,"Highland plantation, ME",0,T,2964
+H,CS2333315000000,"Hiram town, ME",0,T,2965
+H,CS2333385000000,"Hodgdon town, ME",0,T,2966
+H,CS2333490000000,"Holden town, ME",0,T,2967
+H,CS2333665000000,"Hollis town, ME",0,T,2968
+H,CS2333840000000,"Hope town, ME",0,T,2969
+H,CS2333980000000,"Houlton town, ME",0,T,2970
+H,CS2334190000000,"Howland town, ME",0,T,2971
+H,CS2334365000000,"Hudson town, ME",0,T,2972
+H,CS2334820000000,"Industry town, ME",0,T,2973
+H,CS2335065000000,"Island Falls town, ME",0,T,2974
+H,CS2335135000000,"Isle au Haut town, ME",0,T,2975
+H,CS2335240000000,"Islesboro town, ME",0,T,2976
+H,CS2335345000000,"Jackman town, ME",0,T,2977
+H,CS2335450000000,"Jackson town, ME",0,T,2978
+H,CS2335625000000,"Jay town, ME",0,T,2979
+H,CS2335695000000,"Jefferson town, ME",0,T,2980
+H,CS2335905000000,"Jonesboro town, ME",0,T,2981
+H,CS2336010000000,"Jonesport town, ME",0,T,2982
+H,CS2336325000000,"Kenduskeag town, ME",0,T,2983
+H,CS2336535000000,"Kennebunk town, ME",0,T,2984
+H,CS2336745000000,"Kennebunkport town, ME",0,T,2985
+H,CS2337025000000,"Kingfield town, ME",0,T,2986
+H,CS2337075000000,"Kingman unorganized, ME",0,T,2987
+H,CS2337095000000,"Kingsbury plantation, ME",0,T,2988
+H,CS2337270000000,"Kittery town, ME",0,T,2989
+H,CS2337585000000,"Knox town, ME",0,T,2990
+H,CS2337760000000,"Lagrange town, ME",0,T,2991
+H,CS2337970000000,"Lake View plantation, ME",0,T,2992
+H,CS2338005000000,"Lakeville town, ME",0,T,2993
+H,CS2338180000000,"Lamoine town, ME",0,T,2994
+H,CS2338425000000,"Lebanon town, ME",0,T,2995
+H,CS2338530000000,"Lee town, ME",0,T,2996
+H,CS2338565000000,"Leeds town, ME",0,T,2997
+H,CS2338705000000,"Levant town, ME",0,T,2998
+H,CS2339055000000,"Liberty town, ME",0,T,3000
+H,CS2339195000000,"Limerick town, ME",0,T,3001
+H,CS2339300000000,"Limestone town, ME",0,T,3002
+H,CS2339405000000,"Limington town, ME",0,T,3003
+H,CS2339422000000,"Lincoln plantation, ME",0,T,3004
+H,CS2339475000000,"Lincoln town, ME",0,T,3005
+H,CS2339755000000,"Lincolnville town, ME",0,T,3006
+H,CS2339965000000,"Linneus town, ME",0,T,3007
+H,CS2340035000000,"Lisbon town, ME",0,T,3008
+H,CS2340175000000,"Litchfield town, ME",0,T,3009
+H,CS2340595000000,"Littleton town, ME",0,T,3010
+H,CS2340665000000,"Livermore town, ME",0,T,3011
+H,CS2340770000000,"Livermore Falls town, ME",0,T,3012
+H,CS2341067000000,"Long Island town, ME",0,T,3013
+H,CS2341365000000,"Lovell town, ME",0,T,3014
+H,CS2341435000000,"Lowell town, ME",0,T,3015
+H,CS2341610000000,"Lubec town, ME",0,T,3016
+H,CS2341715000000,"Ludlow town, ME",0,T,3017
+H,CS2341750000000,"Lyman town, ME",0,T,3018
+H,CS2341960000000,"Machias town, ME",0,T,3019
+H,CS2342100000000,"Machiasport town, ME",0,T,3020
+H,CS2342450000000,"Macwahoc plantation, ME",0,T,3021
+H,CS2342520000000,"Madawaska town, ME",0,T,3022
+H,CS2342660000000,"Madison town, ME",0,T,3023
+H,CS2342835000000,"Magalloway plantation, ME",0,T,3024
+H,CS2343080000000,"Manchester town, ME",0,T,3025
+H,CS2343255000000,"Mapleton town, ME",0,T,3026
+H,CS2343430000000,"Mariaville town, ME",0,T,3027
+H,CS2343640000000,"Marshfield town, ME",0,T,3028
+H,CS2343710000000,"Mars Hill town, ME",0,T,3029
+H,CS2343990000000,"Masardis town, ME",0,T,3030
+H,CS2344165000000,"Matinicus Isle plantation, ME",0,T,3031
+H,CS2344270000000,"Mattawamkeag town, ME",0,T,3032
+H,CS2344340000000,"Maxfield town, ME",0,T,3033
+H,CS2344585000000,"Mechanic Falls town, ME",0,T,3034
+H,CS2344760000000,"Meddybemps town, ME",0,T,3035
+H,CS2344830000000,"Medford town, ME",0,T,3036
+H,CS2345005000000,"Medway town, ME",0,T,3037
+H,CS2345110000000,"Mercer town, ME",0,T,3038
+H,CS2345180000000,"Merrill town, ME",0,T,3039
+H,CS2345285000000,"Mexico town, ME",0,T,3040
+H,CS2345600000000,"Milbridge town, ME",0,T,3041
+H,CS2345670000000,"Milford town, ME",0,T,3042
+H,CS2345810000000,"Millinocket town, ME",0,T,3043
+H,CS2346020000000,"Milo town, ME",0,T,3044
+H,CS2346105000000,"Milton unorganized, ME",0,T,3045
+H,CS2346160000000,"Minot town, ME",0,T,3046
+H,CS2346335000000,"Monhegan plantation, ME",0,T,3047
+H,CS2346405000000,"Monmouth town, ME",0,T,3048
+H,CS2346475000000,"Monroe town, ME",0,T,3049
+H,CS2346580000000,"Monson town, ME",0,T,3050
+H,CS2346685000000,"Monticello town, ME",0,T,3051
+H,CS2346790000000,"Montville town, ME",0,T,3052
+H,CS2347140000000,"Moose River town, ME",0,T,3053
+H,CS2347175000000,"Moro plantation, ME",0,T,3054
+H,CS2347245000000,"Morrill town, ME",0,T,3055
+H,CS2347455000000,"Moscow town, ME",0,T,3056
+H,CS2347560000000,"Mount Chase town, ME",0,T,3057
+H,CS2347630000000,"Mount Desert town, ME",0,T,3058
+H,CS2347770000000,"Mount Vernon town, ME",0,T,3059
+H,CS2348085000000,"Naples town, ME",0,T,3060
+H,CS2348120000000,"Nashville plantation, ME",0,T,3061
+H,CS2348505000000,"Newburgh town, ME",0,T,3062
+H,CS2348575000000,"New Canada town, ME",0,T,3063
+H,CS2348645000000,"Newcastle town, ME",0,T,3064
+H,CS2348750000000,"Newfield town, ME",0,T,3065
+H,CS2348820000000,"New Gloucester town, ME",0,T,3066
+H,CS2348960000000,"New Limerick town, ME",0,T,3067
+H,CS2349065000000,"Newport town, ME",0,T,3068
+H,CS2349205000000,"New Portland town, ME",0,T,3069
+H,CS2349275000000,"Newry town, ME",0,T,3070
+H,CS2349345000000,"New Sharon town, ME",0,T,3071
+H,CS2349415000000,"New Sweden town, ME",0,T,3072
+H,CS2349520000000,"New Vineyard town, ME",0,T,3073
+H,CS2349660000000,"Nobleboro town, ME",0,T,3074
+H,CS2349835000000,"Norridgewock town, ME",0,T,3075
+H,CS2350325000000,"North Berwick town, ME",0,T,3076
+H,CS2351105000000,"Northeast Piscataquis unorganized, ME",0,T,3077
+H,CS2351114000000,"Northeast Somerset unorganized, ME",0,T,3078
+H,CS2351375000000,"Northfield town, ME",0,T,3079
+H,CS2351400000000,"North Franklin unorganized, ME",0,T,3080
+H,CS2351620000000,"North Haven town, ME",0,T,3081
+H,CS2352575000000,"North Oxford unorganized, ME",0,T,3082
+H,CS2352710000000,"North Penobscot unorganized, ME",0,T,3083
+H,CS2352845000000,"Northport town, ME",0,T,3084
+H,CS2353500000000,"North Washington unorganized, ME",0,T,3085
+H,CS2353602000000,"Northwest Aroostook unorganized, ME",0,T,3086
+H,CS2353620000000,"Northwest Hancock unorganized, ME",0,T,3087
+H,CS2353628000000,"Northwest Piscataquis unorganized, ME",0,T,3088
+H,CS2353636000000,"Northwest Somerset unorganized, ME",0,T,3089
+H,CS2353860000000,"North Yarmouth town, ME",0,T,3090
+H,CS2354000000000,"Norway town, ME",0,T,3091
+H,CS2354385000000,"Oakfield town, ME",0,T,3092
+H,CS2354560000000,"Oakland town, ME",0,T,3093
+H,CS2354980000000,"Ogunquit town, ME",0,T,3094
+H,CS2355085000000,"Old Orchard Beach town, ME",0,T,3095
+H,CS2355435000000,"Orient town, ME",0,T,3097
+H,CS2355505000000,"Orland town, ME",0,T,3098
+H,CS2355565000000,"Orono town, ME",0,T,3099
+H,CS2355680000000,"Orrington town, ME",0,T,3100
+H,CS2355855000000,"Osborn town, ME",0,T,3101
+H,CS2355890000000,"Otis town, ME",0,T,3102
+H,CS2355960000000,"Otisfield town, ME",0,T,3103
+H,CS2356135000000,"Owls Head town, ME",0,T,3104
+H,CS2356310000000,"Oxford town, ME",0,T,3105
+H,CS2356450000000,"Palermo town, ME",0,T,3106
+H,CS2356520000000,"Palmyra town, ME",0,T,3107
+H,CS2356625000000,"Paris town, ME",0,T,3108
+H,CS2356765000000,"Parkman town, ME",0,T,3109
+H,CS2356870000000,"Parsonsfield town, ME",0,T,3110
+H,CS2357045000000,"Passadumkeag town, ME",0,T,3111
+H,CS2357082000000,"Passamaquoddy Indian Township Reservation, ME",0,T,3112
+H,CS2357090000000,"Passamaquoddy Pleasant Point Reservation, ME",0,T,3113
+H,CS2357150000000,"Patten town, ME",0,T,3114
+H,CS2357780000000,"Pembroke town, ME",0,T,3115
+H,CS2357920000000,"Penobscot town, ME",0,T,3116
+H,CS2357936000000,"Penobscot Indian Island Reservation, ME",0,T,3117
+H,CS2358060000000,"Perham town, ME",0,T,3118
+H,CS2358165000000,"Perry town, ME",0,T,3119
+H,CS2358270000000,"Peru town, ME",0,T,3120
+H,CS2358445000000,"Phillips town, ME",0,T,3121
+H,CS2358515000000,"Phippsburg town, ME",0,T,3122
+H,CS2359005000000,"Pittsfield town, ME",0,T,3123
+H,CS2359110000000,"Pittston town, ME",0,T,3124
+H,CS2359705000000,"Pleasant Ridge plantation, ME",0,T,3125
+H,CS2359950000000,"Plymouth town, ME",0,T,3126
+H,CS2360020000000,"Poland town, ME",0,T,3127
+H,CS2360300000000,"Portage Lake town, ME",0,T,3128
+H,CS2360405000000,"Porter town, ME",0,T,3129
+H,CS2360685000000,"Pownal town, ME",0,T,3131
+H,CS2360790000000,"Prentiss unorganized, ME",0,T,3132
+H,CS2361035000000,"Princeton town, ME",0,T,3134
+H,CS2361210000000,"Prospect town, ME",0,T,3135
+H,CS2361700000000,"Randolph town, ME",0,T,3136
+H,CS2361840000000,"Rangeley town, ME",0,T,3137
+H,CS2361875000000,"Rangeley plantation, ME",0,T,3138
+H,CS2361945000000,"Raymond town, ME",0,T,3139
+H,CS2362190000000,"Readfield town, ME",0,T,3140
+H,CS2362400000000,"Reed plantation, ME",0,T,3141
+H,CS2362645000000,"Richmond town, ME",0,T,3142
+H,CS2362995000000,"Ripley town, ME",0,T,3143
+H,CS2363275000000,"Robbinston town, ME",0,T,3144
+H,CS2363660000000,"Rockport town, ME",0,T,3146
+H,CS2363835000000,"Rome town, ME",0,T,3147
+H,CS2363940000000,"Roque Bluffs town, ME",0,T,3148
+H,CS2364185000000,"Roxbury town, ME",0,T,3149
+H,CS2364290000000,"Rumford town, ME",0,T,3150
+H,CS2364570000000,"Sabattus town, ME",0,T,3151
+H,CS2364780000000,"St. Agatha town, ME",0,T,3153
+H,CS2364850000000,"St. Albans town, ME",0,T,3154
+H,CS2365025000000,"St. Francis town, ME",0,T,3155
+H,CS2365130000000,"St. George town, ME",0,T,3156
+H,CS2365200000000,"St. John plantation, ME",0,T,3157
+H,CS2365655000000,"Sandy River plantation, ME",0,T,3158
+H,CS2365865000000,"Sangerville town, ME",0,T,3160
+H,CS2366145000000,"Scarborough town, ME",0,T,3161
+H,CS2366565000000,"Searsmont town, ME",0,T,3162
+H,CS2366635000000,"Searsport town, ME",0,T,3163
+H,CS2366775000000,"Sebago town, ME",0,T,3164
+H,CS2366950000000,"Sebec town, ME",0,T,3165
+H,CS2367160000000,"Seboeis plantation, ME",0,T,3166
+H,CS2367238000000,"Seboomook Lake unorganized, ME",0,T,3167
+H,CS2367300000000,"Sedgwick town, ME",0,T,3168
+H,CS2367475000000,"Shapleigh town, ME",0,T,3169
+H,CS2367790000000,"Sherman town, ME",0,T,3170
+H,CS2368140000000,"Shirley town, ME",0,T,3171
+H,CS2368385000000,"Sidney town, ME",0,T,3172
+H,CS2368910000000,"Skowhegan town, ME",0,T,3173
+H,CS2369155000000,"Smithfield town, ME",0,T,3174
+H,CS2369260000000,"Smyrna town, ME",0,T,3175
+H,CS2369505000000,"Solon town, ME",0,T,3176
+H,CS2369645000000,"Somerville town, ME",0,T,3177
+H,CS2369750000000,"Sorrento town, ME",0,T,3178
+H,CS2369930000000,"South Aroostook unorganized, ME",0,T,3179
+H,CS2370030000000,"South Berwick town, ME",0,T,3180
+H,CS2370240000000,"South Bristol town, ME",0,T,3181
+H,CS2370655000000,"Southeast Piscataquis unorganized, ME",0,T,3182
+H,CS2370760000000,"South Franklin unorganized, ME",0,T,3183
+H,CS2371755000000,"South Oxford unorganized, ME",0,T,3184
+H,CS2371955000000,"Southport town, ME",0,T,3185
+H,CS2372585000000,"South Thomaston town, ME",0,T,3187
+H,CS2372865000000,"Southwest Harbor town, ME",0,T,3188
+H,CS2373250000000,"Springfield town, ME",0,T,3189
+H,CS2373472000000,"Square Lake unorganized, ME",0,T,3190
+H,CS2373600000000,"Stacyville town, ME",0,T,3191
+H,CS2373670000000,"Standish town, ME",0,T,3192
+H,CS2373845000000,"Starks town, ME",0,T,3193
+H,CS2374055000000,"Stetson town, ME",0,T,3194
+H,CS2374125000000,"Steuben town, ME",0,T,3195
+H,CS2374405000000,"Stockholm town, ME",0,T,3196
+H,CS2374475000000,"Stockton Springs town, ME",0,T,3197
+H,CS2374510000000,"Stoneham town, ME",0,T,3198
+H,CS2374580000000,"Stonington town, ME",0,T,3199
+H,CS2374685000000,"Stow town, ME",0,T,3200
+H,CS2374825000000,"Strong town, ME",0,T,3201
+H,CS2374965000000,"Sullivan town, ME",0,T,3202
+H,CS2375035000000,"Sumner town, ME",0,T,3203
+H,CS2375280000000,"Surry town, ME",0,T,3204
+H,CS2375455000000,"Swans Island town, ME",0,T,3205
+H,CS2375525000000,"Swanville town, ME",0,T,3206
+H,CS2375595000000,"Sweden town, ME",0,T,3207
+H,CS2375770000000,"Talmadge town, ME",0,T,3208
+H,CS2375980000000,"Temple town, ME",0,T,3209
+H,CS2376190000000,"The Forks plantation, ME",0,T,3210
+H,CS2376365000000,"Thomaston town, ME",0,T,3211
+H,CS2376610000000,"Thorndike town, ME",0,T,3212
+H,CS2376895000000,"Topsfield town, ME",0,T,3213
+H,CS2376960000000,"Topsham town, ME",0,T,3214
+H,CS2377345000000,"Tremont town, ME",0,T,3215
+H,CS2377415000000,"Trenton town, ME",0,T,3216
+H,CS2377625000000,"Troy town, ME",0,T,3217
+H,CS2377800000000,"Turner town, ME",0,T,3218
+H,CS2378115000000,"Union town, ME",0,T,3219
+H,CS2378190000000,"Unity unorganized, ME",0,T,3220
+H,CS2378255000000,"Unity town, ME",0,T,3221
+H,CS2378465000000,"Upton town, ME",0,T,3222
+H,CS2378570000000,"Van Buren town, ME",0,T,3223
+H,CS2378675000000,"Vanceboro town, ME",0,T,3224
+H,CS2378745000000,"Vassalboro town, ME",0,T,3225
+H,CS2378780000000,"Veazie town, ME",0,T,3226
+H,CS2378925000000,"Verona Island town, ME",0,T,3227
+H,CS2379025000000,"Vienna town, ME",0,T,3228
+H,CS2379130000000,"Vinalhaven town, ME",0,T,3229
+H,CS2379270000000,"Wade town, ME",0,T,3230
+H,CS2379375000000,"Waite town, ME",0,T,3231
+H,CS2379480000000,"Waldo town, ME",0,T,3232
+H,CS2379550000000,"Waldoboro town, ME",0,T,3233
+H,CS2379585000000,"Wales town, ME",0,T,3234
+H,CS2379865000000,"Wallagrass town, ME",0,T,3235
+H,CS2380040000000,"Waltham town, ME",0,T,3236
+H,CS2380215000000,"Warren town, ME",0,T,3237
+H,CS2380285000000,"Washburn town, ME",0,T,3238
+H,CS2380425000000,"Washington town, ME",0,T,3239
+H,CS2380530000000,"Waterboro town, ME",0,T,3240
+H,CS2380635000000,"Waterford town, ME",0,T,3241
+H,CS2380880000000,"Wayne town, ME",0,T,3243
+H,CS2381055000000,"Webster plantation, ME",0,T,3244
+H,CS2381300000000,"Weld town, ME",0,T,3245
+H,CS2381405000000,"Wellington town, ME",0,T,3246
+H,CS2381475000000,"Wells town, ME",0,T,3247
+H,CS2381685000000,"Wesley town, ME",0,T,3248
+H,CS2381930000000,"West Bath town, ME",0,T,3249
+H,CS2382770000000,"Westfield town, ME",0,T,3251
+H,CS2382840000000,"West Forks plantation, ME",0,T,3252
+H,CS2382945000000,"West Gardiner town, ME",0,T,3253
+H,CS2383540000000,"Westmanland town, ME",0,T,3254
+H,CS2383785000000,"Weston town, ME",0,T,3255
+H,CS2383890000000,"West Paris town, ME",0,T,3256
+H,CS2384140000000,"Westport Island town, ME",0,T,3257
+H,CS2385010000000,"Whitefield town, ME",0,T,3258
+H,CS2385185000000,"Whiting town, ME",0,T,3259
+H,CS2385290000000,"Whitneyville town, ME",0,T,3260
+H,CS2385710000000,"Willimantic town, ME",0,T,3261
+H,CS2385850000000,"Wilton town, ME",0,T,3262
+H,CS2386025000000,"Windham town, ME",0,T,3263
+H,CS2386165000000,"Windsor town, ME",0,T,3264
+H,CS2386305000000,"Winn town, ME",0,T,3265
+H,CS2386515000000,"Winslow town, ME",0,T,3266
+H,CS2386655000000,"Winter Harbor town, ME",0,T,3267
+H,CS2386760000000,"Winterport town, ME",0,T,3268
+H,CS2386865000000,"Winterville plantation, ME",0,T,3269
+H,CS2386970000000,"Winthrop town, ME",0,T,3270
+H,CS2387075000000,"Wiscasset town, ME",0,T,3271
+H,CS2387215000000,"Woodland town, ME",0,T,3272
+H,CS2387355000000,"Woodstock town, ME",0,T,3273
+H,CS2387390000000,"Woodville town, ME",0,T,3274
+H,CS2387460000000,"Woolwich town, ME",0,T,3275
+H,CS2387680000000,"Wyman unorganized, ME",0,T,3276
+H,CS2387845000000,"Yarmouth town, ME",0,T,3277
+H,CS2387985000000,"York town, ME",0,T,3278
+H,CS2500170000000,"Abington town, MA",0,T,3386
+H,CS2500380000000,"Acton town, MA",0,T,3387
+H,CS2500520000000,"Acushnet town, MA",0,T,3388
+H,CS2500555000000,"Adams town, MA",0,T,3389
+H,CS2500975000000,"Alford town, MA",0,T,3391
+H,CS2501585000000,"Aquinnah town, MA",0,T,3395
+H,CS2501885000000,"Ashburnham town, MA",0,T,3397
+H,CS2501955000000,"Ashby town, MA",0,T,3398
+H,CS2502095000000,"Ashfield town, MA",0,T,3399
+H,CS2502130000000,"Ashland town, MA",0,T,3400
+H,CS2502480000000,"Athol town, MA",0,T,3401
+H,CS2502760000000,"Auburn town, MA",0,T,3403
+H,CS2502935000000,"Avon town, MA",0,T,3404
+H,CS2503005000000,"Ayer town, MA",0,T,3405
+H,CS2503740000000,"Barre town, MA",0,T,3407
+H,CS2504545000000,"Becket town, MA",0,T,3408
+H,CS2504615000000,"Bedford town, MA",0,T,3409
+H,CS2504825000000,"Belchertown town, MA",0,T,3410
+H,CS2504930000000,"Bellingham town, MA",0,T,3411
+H,CS2505280000000,"Berkley town, MA",0,T,3413
+H,CS2505490000000,"Berlin town, MA",0,T,3414
+H,CS2505560000000,"Bernardston town, MA",0,T,3415
+H,CS2506015000000,"Blackstone town, MA",0,T,3418
+H,CS2506085000000,"Blandford town, MA",0,T,3419
+H,CS2506365000000,"Bolton town, MA",0,T,3420
+H,CS2507175000000,"Bourne town, MA",0,T,3422
+H,CS2507350000000,"Boxborough town, MA",0,T,3423
+H,CS2507420000000,"Boxford town, MA",0,T,3424
+H,CS2507525000000,"Boylston town, MA",0,T,3425
+H,CS2507980000000,"Brewster town, MA",0,T,3427
+H,CS2508470000000,"Brimfield town, MA",0,T,3429
+H,CS2509105000000,"Brookfield town, MA",0,T,3431
+H,CS2509595000000,"Buckland town, MA",0,T,3433
+H,CS2511315000000,"Canton town, MA",0,T,3436
+H,CS2511525000000,"Carlisle town, MA",0,T,3437
+H,CS2511665000000,"Carver town, MA",0,T,3438
+H,CS2512505000000,"Charlemont town, MA",0,T,3439
+H,CS2512715000000,"Charlton town, MA",0,T,3440
+H,CS2512995000000,"Chatham town, MA",0,T,3441
+H,CS2513345000000,"Cheshire town, MA",0,T,3444
+H,CS2513485000000,"Chester town, MA",0,T,3445
+H,CS2513590000000,"Chesterfield town, MA",0,T,3446
+H,CS2513800000000,"Chilmark town, MA",0,T,3448
+H,CS2514010000000,"Clarksburg town, MA",0,T,3449
+H,CS2514395000000,"Clinton town, MA",0,T,3450
+H,CS2514640000000,"Cohasset town, MA",0,T,3451
+H,CS2514885000000,"Colrain town, MA",0,T,3452
+H,CS2515060000000,"Concord town, MA",0,T,3453
+H,CS2515200000000,"Conway town, MA",0,T,3454
+H,CS2516040000000,"Cummington town, MA",0,T,3455
+H,CS2516180000000,"Dalton town, MA",0,T,3456
+H,CS2516670000000,"Deerfield town, MA",0,T,3460
+H,CS2516775000000,"Dennis town, MA",0,T,3461
+H,CS2516950000000,"Dighton town, MA",0,T,3462
+H,CS2517300000000,"Douglas town, MA",0,T,3463
+H,CS2517405000000,"Dover town, MA",0,T,3464
+H,CS2517685000000,"Dudley town, MA",0,T,3466
+H,CS2517825000000,"Dunstable town, MA",0,T,3467
+H,CS2517895000000,"Duxbury town, MA",0,T,3468
+H,CS2518455000000,"East Bridgewater town, MA",0,T,3469
+H,CS2518560000000,"East Brookfield town, MA",0,T,3470
+H,CS2519295000000,"Eastham town, MA",0,T,3471
+H,CS2519645000000,"East Longmeadow town, MA",0,T,3473
+H,CS2521150000000,"Edgartown town, MA",0,T,3475
+H,CS2521360000000,"Egremont town, MA",0,T,3476
+H,CS2521780000000,"Erving town, MA",0,T,3477
+H,CS2521850000000,"Essex town, MA",0,T,3478
+H,CS2522130000000,"Fairhaven town, MA",0,T,3480
+H,CS2524120000000,"Florida town, MA",0,T,3484
+H,CS2524820000000,"Foxborough town, MA",0,T,3485
+H,CS2525240000000,"Freetown town, MA",0,T,3488
+H,CS2525625000000,"Georgetown town, MA",0,T,3490
+H,CS2525730000000,"Gill town, MA",0,T,3491
+H,CS2526290000000,"Goshen town, MA",0,T,3493
+H,CS2526325000000,"Gosnold town, MA",0,T,3494
+H,CS2526430000000,"Grafton town, MA",0,T,3495
+H,CS2526535000000,"Granby town, MA",0,T,3496
+H,CS2526675000000,"Granville town, MA",0,T,3497
+H,CS2526815000000,"Great Barrington town, MA",0,T,3498
+H,CS2527480000000,"Groton town, MA",0,T,3500
+H,CS2527620000000,"Groveland town, MA",0,T,3501
+H,CS2527690000000,"Hadley town, MA",0,T,3502
+H,CS2527795000000,"Halifax town, MA",0,T,3503
+H,CS2527900000000,"Hamilton town, MA",0,T,3504
+H,CS2528075000000,"Hampden town, MA",0,T,3505
+H,CS2528180000000,"Hancock town, MA",0,T,3506
+H,CS2528285000000,"Hanover town, MA",0,T,3507
+H,CS2528495000000,"Hanson town, MA",0,T,3508
+H,CS2528740000000,"Hardwick town, MA",0,T,3509
+H,CS2528950000000,"Harvard town, MA",0,T,3510
+H,CS2529020000000,"Harwich town, MA",0,T,3511
+H,CS2529265000000,"Hatfield town, MA",0,T,3512
+H,CS2529475000000,"Hawley town, MA",0,T,3514
+H,CS2529650000000,"Heath town, MA",0,T,3515
+H,CS2530210000000,"Hingham town, MA",0,T,3516
+H,CS2530315000000,"Hinsdale town, MA",0,T,3517
+H,CS2530455000000,"Holbrook town, MA",0,T,3518
+H,CS2530560000000,"Holden town, MA",0,T,3519
+H,CS2530665000000,"Holland town, MA",0,T,3520
+H,CS2530700000000,"Holliston town, MA",0,T,3521
+H,CS2530945000000,"Hopedale town, MA",0,T,3523
+H,CS2531085000000,"Hopkinton town, MA",0,T,3524
+H,CS2531435000000,"Hubbardston town, MA",0,T,3525
+H,CS2531540000000,"Hudson town, MA",0,T,3526
+H,CS2531645000000,"Hull town, MA",0,T,3527
+H,CS2531785000000,"Huntington town, MA",0,T,3528
+H,CS2532310000000,"Ipswich town, MA",0,T,3529
+H,CS2533220000000,"Kingston town, MA",0,T,3530
+H,CS2533920000000,"Lakeville town, MA",0,T,3531
+H,CS2534165000000,"Lancaster town, MA",0,T,3532
+H,CS2534340000000,"Lanesborough town, MA",0,T,3533
+H,CS2534655000000,"Lee town, MA",0,T,3535
+H,CS2534795000000,"Leicester town, MA",0,T,3536
+H,CS2534970000000,"Lenox town, MA",0,T,3537
+H,CS2535180000000,"Leverett town, MA",0,T,3539
+H,CS2535285000000,"Leyden town, MA",0,T,3541
+H,CS2535425000000,"Lincoln town, MA",0,T,3542
+H,CS2535950000000,"Littleton town, MA",0,T,3543
+H,CS2536300000000,"Longmeadow town, MA",0,T,3544
+H,CS2537175000000,"Ludlow town, MA",0,T,3546
+H,CS2537420000000,"Lunenburg town, MA",0,T,3547
+H,CS2537560000000,"Lynnfield town, MA",0,T,3549
+H,CS2537995000000,"Manchester-by-the-Sea town, MA",0,T,3551
+H,CS2538225000000,"Mansfield town, MA",0,T,3552
+H,CS2538400000000,"Marblehead town, MA",0,T,3553
+H,CS2538540000000,"Marion town, MA",0,T,3554
+H,CS2539100000000,"Mashpee town, MA",0,T,3557
+H,CS2539450000000,"Mattapoisett town, MA",0,T,3558
+H,CS2539625000000,"Maynard town, MA",0,T,3559
+H,CS2539765000000,"Medfield town, MA",0,T,3560
+H,CS2539975000000,"Medway town, MA",0,T,3562
+H,CS2540255000000,"Mendon town, MA",0,T,3564
+H,CS2540430000000,"Merrimac town, MA",0,T,3565
+H,CS2540850000000,"Middleborough town, MA",0,T,3567
+H,CS2540990000000,"Middlefield town, MA",0,T,3568
+H,CS2541095000000,"Middleton town, MA",0,T,3569
+H,CS2541340000000,"Millbury town, MA",0,T,3571
+H,CS2541515000000,"Millis town, MA",0,T,3572
+H,CS2541585000000,"Millville town, MA",0,T,3573
+H,CS2542040000000,"Monroe town, MA",0,T,3575
+H,CS2542145000000,"Monson town, MA",0,T,3576
+H,CS2542285000000,"Montague town, MA",0,T,3577
+H,CS2542460000000,"Monterey town, MA",0,T,3578
+H,CS2542530000000,"Montgomery town, MA",0,T,3579
+H,CS2543300000000,"Mount Washington town, MA",0,T,3580
+H,CS2543580000000,"Nahant town, MA",0,T,3581
+H,CS2543790000000,"Nantucket County/town, MA",0,T,3582
+H,CS2544385000000,"New Ashford town, MA",0,T,3585
+H,CS2545105000000,"New Braintree town, MA",0,T,3587
+H,CS2545175000000,"Newbury town, MA",0,T,3588
+H,CS2545420000000,"New Marlborough town, MA",0,T,3590
+H,CS2545490000000,"New Salem town, MA",0,T,3591
+H,CS2546050000000,"Norfolk town, MA",0,T,3593
+H,CS2546820000000,"Northborough town, MA",0,T,3598
+H,CS2546925000000,"Northbridge town, MA",0,T,3599
+H,CS2547135000000,"North Brookfield town, MA",0,T,3600
+H,CS2547835000000,"Northfield town, MA",0,T,3601
+H,CS2548955000000,"North Reading town, MA",0,T,3602
+H,CS2549970000000,"Norton town, MA",0,T,3603
+H,CS2550145000000,"Norwell town, MA",0,T,3604
+H,CS2550390000000,"Oak Bluffs town, MA",0,T,3606
+H,CS2550670000000,"Oakham town, MA",0,T,3607
+H,CS2551265000000,"Orange town, MA",0,T,3608
+H,CS2551440000000,"Orleans town, MA",0,T,3609
+H,CS2551580000000,"Otis town, MA",0,T,3610
+H,CS2551825000000,"Oxford town, MA",0,T,3611
+H,CS2552420000000,"Paxton town, MA",0,T,3613
+H,CS2552560000000,"Pelham town, MA",0,T,3615
+H,CS2552630000000,"Pembroke town, MA",0,T,3616
+H,CS2552805000000,"Pepperell town, MA",0,T,3617
+H,CS2553050000000,"Peru town, MA",0,T,3618
+H,CS2553120000000,"Petersham town, MA",0,T,3619
+H,CS2553225000000,"Phillipston town, MA",0,T,3620
+H,CS2554030000000,"Plainfield town, MA",0,T,3622
+H,CS2554100000000,"Plainville town, MA",0,T,3623
+H,CS2554415000000,"Plympton town, MA",0,T,3625
+H,CS2555395000000,"Princeton town, MA",0,T,3626
+H,CS2555500000000,"Provincetown town, MA",0,T,3627
+H,CS2556060000000,"Raynham town, MA",0,T,3630
+H,CS2556375000000,"Rehoboth town, MA",0,T,3632
+H,CS2556795000000,"Richmond town, MA",0,T,3634
+H,CS2557600000000,"Rochester town, MA",0,T,3635
+H,CS2557775000000,"Rockland town, MA",0,T,3636
+H,CS2557880000000,"Rockport town, MA",0,T,3637
+H,CS2558335000000,"Rowe town, MA",0,T,3638
+H,CS2558405000000,"Rowley town, MA",0,T,3639
+H,CS2558580000000,"Royalston town, MA",0,T,3640
+H,CS2558650000000,"Russell town, MA",0,T,3641
+H,CS2558825000000,"Rutland town, MA",0,T,3642
+H,CS2559245000000,"Salisbury town, MA",0,T,3644
+H,CS2559665000000,"Sandisfield town, MA",0,T,3645
+H,CS2559735000000,"Sandwich town, MA",0,T,3646
+H,CS2560225000000,"Savoy town, MA",0,T,3648
+H,CS2560330000000,"Scituate town, MA",0,T,3649
+H,CS2560645000000,"Seekonk town, MA",0,T,3650
+H,CS2560785000000,"Sharon town, MA",0,T,3651
+H,CS2561065000000,"Sheffield town, MA",0,T,3652
+H,CS2561135000000,"Shelburne town, MA",0,T,3653
+H,CS2561380000000,"Sherborn town, MA",0,T,3654
+H,CS2561590000000,"Shirley town, MA",0,T,3655
+H,CS2561905000000,"Shutesbury town, MA",0,T,3657
+H,CS2562430000000,"Somerset town, MA",0,T,3658
+H,CS2562745000000,"Southampton town, MA",0,T,3660
+H,CS2563165000000,"Southborough town, MA",0,T,3661
+H,CS2564145000000,"South Hadley town, MA",0,T,3663
+H,CS2565825000000,"Southwick town, MA",0,T,3664
+H,CS2566105000000,"Spencer town, MA",0,T,3665
+H,CS2567385000000,"Sterling town, MA",0,T,3667
+H,CS2567595000000,"Stockbridge town, MA",0,T,3668
+H,CS2567665000000,"Stoneham town, MA",0,T,3669
+H,CS2568050000000,"Stow town, MA",0,T,3671
+H,CS2568155000000,"Sturbridge town, MA",0,T,3672
+H,CS2568260000000,"Sudbury town, MA",0,T,3673
+H,CS2568400000000,"Sunderland town, MA",0,T,3674
+H,CS2568610000000,"Sutton town, MA",0,T,3675
+H,CS2568645000000,"Swampscott town, MA",0,T,3676
+H,CS2568750000000,"Swansea town, MA",0,T,3677
+H,CS2569275000000,"Templeton town, MA",0,T,3679
+H,CS2569940000000,"Tisbury town, MA",0,T,3681
+H,CS2570045000000,"Tolland town, MA",0,T,3682
+H,CS2570150000000,"Topsfield town, MA",0,T,3683
+H,CS2570360000000,"Townsend town, MA",0,T,3684
+H,CS2570605000000,"Truro town, MA",0,T,3685
+H,CS2571025000000,"Tyngsborough town, MA",0,T,3686
+H,CS2571095000000,"Tyringham town, MA",0,T,3687
+H,CS2571480000000,"Upton town, MA",0,T,3688
+H,CS2571620000000,"Uxbridge town, MA",0,T,3689
+H,CS2572390000000,"Wales town, MA",0,T,3691
+H,CS2572880000000,"Ware town, MA",0,T,3694
+H,CS2572985000000,"Wareham town, MA",0,T,3695
+H,CS2573090000000,"Warren town, MA",0,T,3696
+H,CS2573265000000,"Warwick town, MA",0,T,3697
+H,CS2573335000000,"Washington town, MA",0,T,3698
+H,CS2573790000000,"Wayland town, MA",0,T,3700
+H,CS2573895000000,"Webster town, MA",0,T,3701
+H,CS2574385000000,"Wellfleet town, MA",0,T,3703
+H,CS2574525000000,"Wendell town, MA",0,T,3704
+H,CS2574595000000,"Wenham town, MA",0,T,3705
+H,CS2575015000000,"Westborough town, MA",0,T,3706
+H,CS2575155000000,"West Boylston town, MA",0,T,3707
+H,CS2575260000000,"West Bridgewater town, MA",0,T,3708
+H,CS2575400000000,"West Brookfield town, MA",0,T,3709
+H,CS2576135000000,"Westford town, MA",0,T,3711
+H,CS2576380000000,"Westhampton town, MA",0,T,3712
+H,CS2577010000000,"Westminster town, MA",0,T,3713
+H,CS2577150000000,"West Newbury town, MA",0,T,3714
+H,CS2577255000000,"Weston town, MA",0,T,3715
+H,CS2577570000000,"Westport town, MA",0,T,3716
+H,CS2577990000000,"West Stockbridge town, MA",0,T,3718
+H,CS2578235000000,"West Tisbury town, MA",0,T,3719
+H,CS2578690000000,"Westwood town, MA",0,T,3720
+H,CS2579110000000,"Whately town, MA",0,T,3722
+H,CS2579530000000,"Whitman town, MA",0,T,3723
+H,CS2579740000000,"Wilbraham town, MA",0,T,3724
+H,CS2579915000000,"Williamsburg town, MA",0,T,3725
+H,CS2579985000000,"Williamstown town, MA",0,T,3726
+H,CS2580230000000,"Wilmington town, MA",0,T,3727
+H,CS2580405000000,"Winchendon town, MA",0,T,3728
+H,CS2580510000000,"Winchester town, MA",0,T,3729
+H,CS2580685000000,"Windsor town, MA",0,T,3730
+H,CS2582175000000,"Worthington town, MA",0,T,3734
+H,CS2582315000000,"Wrentham town, MA",0,T,3735
+H,CS3300260000000,"Acworth town, NH",0,T,4717
+H,CS3300420000000,"Albany town, NH",0,T,4718
+H,CS3300580000000,"Alexandria town, NH",0,T,4719
+H,CS3300660000000,"Allenstown town, NH",0,T,4720
+H,CS3300820000000,"Alstead town, NH",0,T,4721
+H,CS3301060000000,"Alton town, NH",0,T,4722
+H,CS3301300000000,"Amherst town, NH",0,T,4723
+H,CS3301460000000,"Andover town, NH",0,T,4724
+H,CS3301700000000,"Antrim town, NH",0,T,4725
+H,CS3302020000000,"Ashland town, NH",0,T,4726
+H,CS3302340000000,"Atkinson town, NH",0,T,4727
+H,CS3302820000000,"Auburn town, NH",0,T,4728
+H,CS3303220000000,"Barnstead town, NH",0,T,4729
+H,CS3303460000000,"Barrington town, NH",0,T,4730
+H,CS3303700000000,"Bartlett town, NH",0,T,4731
+H,CS3303940000000,"Bath town, NH",0,T,4732
+H,CS3304500000000,"Bedford town, NH",0,T,4733
+H,CS3304740000000,"Belmont town, NH",0,T,4734
+H,CS3304900000000,"Bennington town, NH",0,T,4735
+H,CS3305060000000,"Benton town, NH",0,T,4736
+H,CS3305460000000,"Bethlehem town, NH",0,T,4738
+H,CS3306260000000,"Boscawen town, NH",0,T,4739
+H,CS3306500000000,"Bow town, NH",0,T,4740
+H,CS3306980000000,"Bradford town, NH",0,T,4741
+H,CS3307220000000,"Brentwood town, NH",0,T,4742
+H,CS3307540000000,"Bridgewater town, NH",0,T,4743
+H,CS3307700000000,"Bristol town, NH",0,T,4744
+H,CS3307940000000,"Brookfield town, NH",0,T,4745
+H,CS3308100000000,"Brookline town, NH",0,T,4746
+H,CS3308420000000,"Cambridge township, NH",0,T,4747
+H,CS3308660000000,"Campton town, NH",0,T,4748
+H,CS3308980000000,"Canaan town, NH",0,T,4749
+H,CS3309300000000,"Candia town, NH",0,T,4750
+H,CS3309860000000,"Canterbury town, NH",0,T,4751
+H,CS3310100000000,"Carroll town, NH",0,T,4752
+H,CS3310660000000,"Center Harbor town, NH",0,T,4753
+H,CS3311380000000,"Charlestown town, NH",0,T,4754
+H,CS3311780000000,"Chatham town, NH",0,T,4755
+H,CS3312100000000,"Chester town, NH",0,T,4756
+H,CS3312260000000,"Chesterfield town, NH",0,T,4757
+H,CS3312420000000,"Chichester town, NH",0,T,4758
+H,CS3313220000000,"Clarksville town, NH",0,T,4760
+H,CS3313780000000,"Colebrook town, NH",0,T,4761
+H,CS3313940000000,"Columbia town, NH",0,T,4762
+H,CS3314660000000,"Conway town, NH",0,T,4764
+H,CS3315060000000,"Cornish town, NH",0,T,4765
+H,CS3316340000000,"Croydon town, NH",0,T,4766
+H,CS3316820000000,"Dalton town, NH",0,T,4767
+H,CS3316980000000,"Danbury town, NH",0,T,4768
+H,CS3317140000000,"Danville town, NH",0,T,4769
+H,CS3317460000000,"Deerfield town, NH",0,T,4770
+H,CS3317780000000,"Deering town, NH",0,T,4771
+H,CS3318420000000,"Dixville township, NH",0,T,4773
+H,CS3318740000000,"Dorchester town, NH",0,T,4774
+H,CS3319140000000,"Dublin town, NH",0,T,4776
+H,CS3319300000000,"Dummer town, NH",0,T,4777
+H,CS3319460000000,"Dunbarton town, NH",0,T,4778
+H,CS3319700000000,"Durham town, NH",0,T,4779
+H,CS3321380000000,"East Kingston town, NH",0,T,4780
+H,CS3322020000000,"Easton town, NH",0,T,4781
+H,CS3323380000000,"Eaton town, NH",0,T,4782
+H,CS3323620000000,"Effingham town, NH",0,T,4783
+H,CS3323860000000,"Ellsworth town, NH",0,T,4784
+H,CS3324340000000,"Enfield town, NH",0,T,4785
+H,CS3324660000000,"Epping town, NH",0,T,4786
+H,CS3324900000000,"Epsom town, NH",0,T,4787
+H,CS3325140000000,"Errol town, NH",0,T,4788
+H,CS3325380000000,"Exeter town, NH",0,T,4789
+H,CS3326020000000,"Farmington town, NH",0,T,4790
+H,CS3326500000000,"Fitzwilliam town, NH",0,T,4791
+H,CS3327140000000,"Francestown town, NH",0,T,4792
+H,CS3327300000000,"Franconia town, NH",0,T,4793
+H,CS3327700000000,"Freedom town, NH",0,T,4795
+H,CS3327940000000,"Fremont town, NH",0,T,4796
+H,CS3328740000000,"Gilford town, NH",0,T,4797
+H,CS3328980000000,"Gilmanton town, NH",0,T,4798
+H,CS3329220000000,"Gilsum town, NH",0,T,4799
+H,CS3329860000000,"Goffstown town, NH",0,T,4800
+H,CS3330260000000,"Gorham town, NH",0,T,4801
+H,CS3330500000000,"Goshen town, NH",0,T,4802
+H,CS3330820000000,"Grafton town, NH",0,T,4803
+H,CS3331220000000,"Grantham town, NH",0,T,4804
+H,CS3331540000000,"Greenfield town, NH",0,T,4805
+H,CS3331700000000,"Greenland town, NH",0,T,4806
+H,CS3331940000000,"Greenville town, NH",0,T,4807
+H,CS3332180000000,"Groton town, NH",0,T,4808
+H,CS3332500000000,"Hale's location, NH",0,T,4809
+H,CS3332900000000,"Hampstead town, NH",0,T,4810
+H,CS3333060000000,"Hampton town, NH",0,T,4811
+H,CS3333460000000,"Hampton Falls town, NH",0,T,4812
+H,CS3333700000000,"Hancock town, NH",0,T,4813
+H,CS3333860000000,"Hanover town, NH",0,T,4814
+H,CS3334420000000,"Harrisville town, NH",0,T,4815
+H,CS3334500000000,"Hart's Location town, NH",0,T,4816
+H,CS3334820000000,"Haverhill town, NH",0,T,4817
+H,CS3335220000000,"Hebron town, NH",0,T,4818
+H,CS3335540000000,"Henniker town, NH",0,T,4819
+H,CS3335860000000,"Hill town, NH",0,T,4820
+H,CS3336180000000,"Hillsborough town, NH",0,T,4821
+H,CS3336660000000,"Hinsdale town, NH",0,T,4822
+H,CS3336900000000,"Holderness town, NH",0,T,4823
+H,CS3337140000000,"Hollis town, NH",0,T,4824
+H,CS3337300000000,"Hooksett town, NH",0,T,4825
+H,CS3337540000000,"Hopkinton town, NH",0,T,4826
+H,CS3338260000000,"Jackson town, NH",0,T,4828
+H,CS3338500000000,"Jaffrey town, NH",0,T,4829
+H,CS3338820000000,"Jefferson town, NH",0,T,4830
+H,CS3339780000000,"Kensington town, NH",0,T,4832
+H,CS3340100000000,"Kingston town, NH",0,T,4833
+H,CS3340420000000,"Lancaster town, NH",0,T,4835
+H,CS3340660000000,"Landaff town, NH",0,T,4836
+H,CS3340900000000,"Langdon town, NH",0,T,4837
+H,CS3341460000000,"Lee town, NH",0,T,4839
+H,CS3341700000000,"Lempster town, NH",0,T,4840
+H,CS3341860000000,"Lincoln town, NH",0,T,4841
+H,CS3342020000000,"Lisbon town, NH",0,T,4842
+H,CS3342260000000,"Litchfield town, NH",0,T,4843
+H,CS3342580000000,"Littleton town, NH",0,T,4844
+H,CS3343380000000,"Loudon town, NH",0,T,4846
+H,CS3344100000000,"Lyman town, NH",0,T,4847
+H,CS3344260000000,"Lyme town, NH",0,T,4848
+H,CS3344580000000,"Lyndeborough town, NH",0,T,4849
+H,CS3344820000000,"Madbury town, NH",0,T,4850
+H,CS3345060000000,"Madison town, NH",0,T,4851
+H,CS3345460000000,"Marlborough town, NH",0,T,4853
+H,CS3345700000000,"Marlow town, NH",0,T,4854
+H,CS3346260000000,"Mason town, NH",0,T,4855
+H,CS3347140000000,"Meredith town, NH",0,T,4856
+H,CS3347700000000,"Middleton town, NH",0,T,4858
+H,CS3347860000000,"Milan town, NH",0,T,4859
+H,CS3348020000000,"Milford town, NH",0,T,4860
+H,CS3348260000000,"Millsfield township, NH",0,T,4861
+H,CS3348660000000,"Milton town, NH",0,T,4862
+H,CS3348980000000,"Monroe town, NH",0,T,4863
+H,CS3349140000000,"Mont Vernon town, NH",0,T,4864
+H,CS3349380000000,"Moultonborough town, NH",0,T,4865
+H,CS3350580000000,"Nelson town, NH",0,T,4867
+H,CS3350740000000,"New Boston town, NH",0,T,4868
+H,CS3350900000000,"Newbury town, NH",0,T,4869
+H,CS3350980000000,"New Castle town, NH",0,T,4870
+H,CS3351220000000,"New Durham town, NH",0,T,4871
+H,CS3351380000000,"Newfields town, NH",0,T,4872
+H,CS3351540000000,"New Hampton town, NH",0,T,4873
+H,CS3351620000000,"Newington town, NH",0,T,4874
+H,CS3351940000000,"New Ipswich town, NH",0,T,4875
+H,CS3352100000000,"New London town, NH",0,T,4876
+H,CS3352340000000,"Newmarket town, NH",0,T,4877
+H,CS3352580000000,"Newport town, NH",0,T,4878
+H,CS3352900000000,"Newton town, NH",0,T,4879
+H,CS3354260000000,"Northfield town, NH",0,T,4880
+H,CS3354580000000,"North Hampton town, NH",0,T,4881
+H,CS3356100000000,"Northumberland town, NH",0,T,4882
+H,CS3356820000000,"Northwood town, NH",0,T,4883
+H,CS3357460000000,"Nottingham town, NH",0,T,4884
+H,CS3358340000000,"Orange town, NH",0,T,4885
+H,CS3358500000000,"Orford town, NH",0,T,4886
+H,CS3358740000000,"Ossipee town, NH",0,T,4887
+H,CS3359940000000,"Pelham town, NH",0,T,4888
+H,CS3360020000000,"Pembroke town, NH",0,T,4889
+H,CS3360580000000,"Peterborough town, NH",0,T,4890
+H,CS3361060000000,"Piermont town, NH",0,T,4891
+H,CS3361620000000,"Pinkhams grant, NH",0,T,4892
+H,CS3361780000000,"Pittsburg town, NH",0,T,4893
+H,CS3361940000000,"Pittsfield town, NH",0,T,4894
+H,CS3362340000000,"Plainfield town, NH",0,T,4895
+H,CS3362500000000,"Plaistow town, NH",0,T,4896
+H,CS3362660000000,"Plymouth town, NH",0,T,4897
+H,CS3363860000000,"Randolph town, NH",0,T,4899
+H,CS3364020000000,"Raymond town, NH",0,T,4900
+H,CS3364420000000,"Richmond town, NH",0,T,4901
+H,CS3364580000000,"Rindge town, NH",0,T,4902
+H,CS3365540000000,"Rollinsford town, NH",0,T,4904
+H,CS3365700000000,"Roxbury town, NH",0,T,4905
+H,CS3365940000000,"Rumney town, NH",0,T,4906
+H,CS3366180000000,"Rye town, NH",0,T,4907
+H,CS3366980000000,"Salisbury town, NH",0,T,4909
+H,CS3367300000000,"Sanbornton town, NH",0,T,4910
+H,CS3367620000000,"Sandown town, NH",0,T,4911
+H,CS3367780000000,"Sandwich town, NH",0,T,4912
+H,CS3368260000000,"Seabrook town, NH",0,T,4913
+H,CS3368820000000,"Sharon town, NH",0,T,4914
+H,CS3368980000000,"Shelburne town, NH",0,T,4915
+H,CS3371140000000,"South Hampton town, NH",0,T,4917
+H,CS3372740000000,"Springfield town, NH",0,T,4918
+H,CS3373060000000,"Stark town, NH",0,T,4919
+H,CS3373380000000,"Stewartstown town, NH",0,T,4920
+H,CS3373700000000,"Stoddard town, NH",0,T,4921
+H,CS3373860000000,"Strafford town, NH",0,T,4922
+H,CS3374180000000,"Stratford town, NH",0,T,4923
+H,CS3374340000000,"Stratham town, NH",0,T,4924
+H,CS3374740000000,"Sugar Hill town, NH",0,T,4925
+H,CS3374900000000,"Sullivan town, NH",0,T,4926
+H,CS3375060000000,"Sunapee town, NH",0,T,4927
+H,CS3375300000000,"Surry town, NH",0,T,4928
+H,CS3375460000000,"Sutton town, NH",0,T,4929
+H,CS3375700000000,"Swanzey town, NH",0,T,4930
+H,CS3376100000000,"Tamworth town, NH",0,T,4931
+H,CS3376260000000,"Temple town, NH",0,T,4932
+H,CS3376740000000,"Thornton town, NH",0,T,4933
+H,CS3377060000000,"Tilton town, NH",0,T,4934
+H,CS3377380000000,"Troy town, NH",0,T,4935
+H,CS3377620000000,"Tuftonboro town, NH",0,T,4936
+H,CS3377940000000,"Unity town, NH",0,T,4937
+H,CS3378180000000,"Wakefield town, NH",0,T,4938
+H,CS3378420000000,"Walpole town, NH",0,T,4939
+H,CS3378580000000,"Warner town, NH",0,T,4940
+H,CS3378740000000,"Warren town, NH",0,T,4941
+H,CS3378980000000,"Washington town, NH",0,T,4942
+H,CS3379380000000,"Waterville Valley town, NH",0,T,4943
+H,CS3379780000000,"Weare town, NH",0,T,4944
+H,CS3380020000000,"Webster town, NH",0,T,4945
+H,CS3380500000000,"Wentworth town, NH",0,T,4946
+H,CS3380740000000,"Wentworth location, NH",0,T,4947
+H,CS3382660000000,"Westmoreland town, NH",0,T,4948
+H,CS3384420000000,"Whitefield town, NH",0,T,4949
+H,CS3384900000000,"Wilmot town, NH",0,T,4950
+H,CS3385220000000,"Wilton town, NH",0,T,4951
+H,CS3385540000000,"Winchester town, NH",0,T,4952
+H,CS3385780000000,"Windham town, NH",0,T,4953
+H,CS3385940000000,"Windsor town, NH",0,T,4954
+H,CS3386420000000,"Wolfeboro town, NH",0,T,4955
+H,CS3387060000000,"Woodstock town, NH",0,T,4956
+H,CS4405140000000,"Barrington town, RI",0,T,6357
+H,CS4409280000000,"Bristol town, RI",0,T,6358
+H,CS4411800000000,"Burrillville town, RI",0,T,6359
+H,CS4414500000000,"Charlestown town, RI",0,T,6361
+H,CS4422240000000,"East Greenwich town, RI",0,T,6365
+H,CS4425300000000,"Exeter town, RI",0,T,6367
+H,CS4427460000000,"Foster town, RI",0,T,6368
+H,CS4430340000000,"Glocester town, RI",0,T,6369
+H,CS4435380000000,"Hopkinton town, RI",0,T,6370
+H,CS4436820000000,"Jamestown town, RI",0,T,6371
+H,CS4441500000000,"Lincoln town, RI",0,T,6373
+H,CS4442400000000,"Little Compton town, RI",0,T,6374
+H,CS4445460000000,"Middletown town, RI",0,T,6375
+H,CS4448340000000,"Narragansett town, RI",0,T,6376
+H,CS4450500000000,"New Shoreham town, RI",0,T,6378
+H,CS4452480000000,"North Smithfield town, RI",0,T,6381
+H,CS4457880000000,"Portsmouth town, RI",0,T,6383
+H,CS4461160000000,"Richmond town, RI",0,T,6385
+H,CS4464220000000,"Scituate town, RI",0,T,6386
+H,CS4466200000000,"Smithfield town, RI",0,T,6387
+H,CS4470880000000,"Tiverton town, RI",0,T,6389
+H,CS4473760000000,"Warren town, RI",0,T,6390
+H,CS4477000000000,"Westerly town, RI",0,T,6392
+H,CS4477720000000,"West Greenwich town, RI",0,T,6393
+H,CS5000325000000,"Addison town, VT",0,T,7412
+H,CS5000475000000,"Albany town, VT",0,T,7413
+H,CS5000860000000,"Alburgh town, VT",0,T,7414
+H,CS5001300000000,"Andover town, VT",0,T,7415
+H,CS5001450000000,"Arlington town, VT",0,T,7416
+H,CS5001900000000,"Athens town, VT",0,T,7417
+H,CS5002125000000,"Averill town, VT",0,T,7418
+H,CS5002500000000,"Bakersfield town, VT",0,T,7419
+H,CS5002575000000,"Baltimore town, VT",0,T,7420
+H,CS5002725000000,"Barnard town, VT",0,T,7421
+H,CS5002875000000,"Barnet town, VT",0,T,7422
+H,CS5003250000000,"Barre town, VT",0,T,7424
+H,CS5003550000000,"Barton town, VT",0,T,7425
+H,CS5004375000000,"Belvidere town, VT",0,T,7426
+H,CS5004825000000,"Bennington town, VT",0,T,7427
+H,CS5005200000000,"Benson town, VT",0,T,7428
+H,CS5005425000000,"Berkshire town, VT",0,T,7429
+H,CS5005650000000,"Berlin town, VT",0,T,7430
+H,CS5005800000000,"Bethel town, VT",0,T,7431
+H,CS5006325000000,"Bloomfield town, VT",0,T,7432
+H,CS5006550000000,"Bolton town, VT",0,T,7433
+H,CS5007375000000,"Bradford town, VT",0,T,7434
+H,CS5007600000000,"Braintree town, VT",0,T,7435
+H,CS5007750000000,"Brandon town, VT",0,T,7436
+H,CS5007900000000,"Brattleboro town, VT",0,T,7437
+H,CS5008275000000,"Bridgewater town, VT",0,T,7438
+H,CS5008575000000,"Bridport town, VT",0,T,7439
+H,CS5008725000000,"Brighton town, VT",0,T,7440
+H,CS5009025000000,"Bristol town, VT",0,T,7441
+H,CS5009325000000,"Brookfield town, VT",0,T,7442
+H,CS5009475000000,"Brookline town, VT",0,T,7443
+H,CS5009850000000,"Brownington town, VT",0,T,7444
+H,CS5010075000000,"Brunswick town, VT",0,T,7445
+H,CS5010300000000,"Buels gore, VT",0,T,7446
+H,CS5010450000000,"Burke town, VT",0,T,7447
+H,CS5011125000000,"Cabot town, VT",0,T,7449
+H,CS5011350000000,"Calais town, VT",0,T,7450
+H,CS5011500000000,"Cambridge town, VT",0,T,7451
+H,CS5011800000000,"Canaan town, VT",0,T,7452
+H,CS5011950000000,"Castleton town, VT",0,T,7453
+H,CS5012250000000,"Cavendish town, VT",0,T,7454
+H,CS5013150000000,"Charleston town, VT",0,T,7455
+H,CS5013300000000,"Charlotte town, VT",0,T,7456
+H,CS5013525000000,"Chelsea town, VT",0,T,7457
+H,CS5013675000000,"Chester town, VT",0,T,7458
+H,CS5014350000000,"Chittenden town, VT",0,T,7459
+H,CS5014500000000,"Clarendon town, VT",0,T,7460
+H,CS5014875000000,"Colchester town, VT",0,T,7461
+H,CS5015250000000,"Concord town, VT",0,T,7462
+H,CS5015700000000,"Corinth town, VT",0,T,7463
+H,CS5016000000000,"Cornwall town, VT",0,T,7464
+H,CS5016150000000,"Coventry town, VT",0,T,7465
+H,CS5016300000000,"Craftsbury town, VT",0,T,7466
+H,CS5016825000000,"Danby town, VT",0,T,7467
+H,CS5017125000000,"Danville town, VT",0,T,7468
+H,CS5017350000000,"Derby town, VT",0,T,7469
+H,CS5017725000000,"Dorset town, VT",0,T,7470
+H,CS5017875000000,"Dover town, VT",0,T,7471
+H,CS5018325000000,"Dummerston town, VT",0,T,7472
+H,CS5018550000000,"Duxbury town, VT",0,T,7473
+H,CS5021250000000,"East Haven town, VT",0,T,7474
+H,CS5021925000000,"East Montpelier town, VT",0,T,7475
+H,CS5023500000000,"Eden town, VT",0,T,7476
+H,CS5023725000000,"Elmore town, VT",0,T,7477
+H,CS5024050000000,"Enosburgh town, VT",0,T,7478
+H,CS5024175000000,"Essex town, VT",0,T,7479
+H,CS5024925000000,"Fairfax town, VT",0,T,7480
+H,CS5025225000000,"Fairfield town, VT",0,T,7481
+H,CS5025375000000,"Fair Haven town, VT",0,T,7482
+H,CS5025675000000,"Fairlee town, VT",0,T,7483
+H,CS5025825000000,"Fayston town, VT",0,T,7484
+H,CS5025975000000,"Ferdinand town, VT",0,T,7485
+H,CS5026300000000,"Ferrisburgh town, VT",0,T,7486
+H,CS5026500000000,"Fletcher town, VT",0,T,7487
+H,CS5027100000000,"Franklin town, VT",0,T,7488
+H,CS5027700000000,"Georgia town, VT",0,T,7489
+H,CS5027962000000,"Glastenbury town, VT",0,T,7490
+H,CS5028075000000,"Glover town, VT",0,T,7491
+H,CS5028600000000,"Goshen town, VT",0,T,7492
+H,CS5028900000000,"Grafton town, VT",0,T,7493
+H,CS5029125000000,"Granby town, VT",0,T,7494
+H,CS5029275000000,"Grand Isle town, VT",0,T,7495
+H,CS5029575000000,"Granville town, VT",0,T,7496
+H,CS5030175000000,"Greensboro town, VT",0,T,7497
+H,CS5030550000000,"Groton town, VT",0,T,7498
+H,CS5030775000000,"Guildhall town, VT",0,T,7499
+H,CS5030925000000,"Guilford town, VT",0,T,7500
+H,CS5031150000000,"Halifax town, VT",0,T,7501
+H,CS5031525000000,"Hancock town, VT",0,T,7502
+H,CS5031825000000,"Hardwick town, VT",0,T,7503
+H,CS5032275000000,"Hartford town, VT",0,T,7504
+H,CS5032425000000,"Hartland town, VT",0,T,7505
+H,CS5033025000000,"Highgate town, VT",0,T,7506
+H,CS5033475000000,"Hinesburg town, VT",0,T,7507
+H,CS5033775000000,"Holland town, VT",0,T,7508
+H,CS5034450000000,"Hubbardton town, VT",0,T,7509
+H,CS5034600000000,"Huntington town, VT",0,T,7510
+H,CS5035050000000,"Hyde Park town, VT",0,T,7511
+H,CS5035425000000,"Ira town, VT",0,T,7512
+H,CS5035575000000,"Irasburg town, VT",0,T,7513
+H,CS5035875000000,"Isle La Motte town, VT",0,T,7514
+H,CS5036175000000,"Jamaica town, VT",0,T,7515
+H,CS5036325000000,"Jay town, VT",0,T,7516
+H,CS5036700000000,"Jericho town, VT",0,T,7517
+H,CS5037075000000,"Johnson town, VT",0,T,7518
+H,CS5037685000000,"Killington town, VT",0,T,7519
+H,CS5037900000000,"Kirby town, VT",0,T,7520
+H,CS5039025000000,"Landgrove town, VT",0,T,7521
+H,CS5039325000000,"Leicester town, VT",0,T,7522
+H,CS5039700000000,"Lemington town, VT",0,T,7523
+H,CS5040075000000,"Lincoln town, VT",0,T,7524
+H,CS5040225000000,"Londonderry town, VT",0,T,7525
+H,CS5040525000000,"Lowell town, VT",0,T,7526
+H,CS5041275000000,"Ludlow town, VT",0,T,7527
+H,CS5041425000000,"Lunenburg town, VT",0,T,7528
+H,CS5041725000000,"Lyndon town, VT",0,T,7529
+H,CS5042475000000,"Maidstone town, VT",0,T,7530
+H,CS5042850000000,"Manchester town, VT",0,T,7531
+H,CS5043375000000,"Marlboro town, VT",0,T,7532
+H,CS5043600000000,"Marshfield town, VT",0,T,7533
+H,CS5044125000000,"Mendon town, VT",0,T,7534
+H,CS5044350000000,"Middlebury town, VT",0,T,7535
+H,CS5044500000000,"Middlesex town, VT",0,T,7536
+H,CS5044800000000,"Middletown Springs town, VT",0,T,7537
+H,CS5045250000000,"Milton town, VT",0,T,7538
+H,CS5045550000000,"Monkton town, VT",0,T,7539
+H,CS5045850000000,"Montgomery town, VT",0,T,7540
+H,CS5046225000000,"Moretown town, VT",0,T,7542
+H,CS5046450000000,"Morgan town, VT",0,T,7543
+H,CS5046675000000,"Morristown town, VT",0,T,7544
+H,CS5047200000000,"Mount Holly town, VT",0,T,7545
+H,CS5047425000000,"Mount Tabor town, VT",0,T,7546
+H,CS5047725000000,"Newark town, VT",0,T,7547
+H,CS5048175000000,"Newbury town, VT",0,T,7548
+H,CS5048400000000,"Newfane town, VT",0,T,7549
+H,CS5048700000000,"New Haven town, VT",0,T,7550
+H,CS5048925000000,"Newport town, VT",0,T,7552
+H,CS5050275000000,"Northfield town, VT",0,T,7553
+H,CS5050650000000,"North Hero town, VT",0,T,7554
+H,CS5052750000000,"Norton town, VT",0,T,7555
+H,CS5052900000000,"Norwich town, VT",0,T,7556
+H,CS5053425000000,"Orange town, VT",0,T,7557
+H,CS5053725000000,"Orwell town, VT",0,T,7558
+H,CS5053950000000,"Panton town, VT",0,T,7559
+H,CS5054250000000,"Pawlet town, VT",0,T,7560
+H,CS5054400000000,"Peacham town, VT",0,T,7561
+H,CS5055000000000,"Peru town, VT",0,T,7562
+H,CS5055450000000,"Pittsfield town, VT",0,T,7563
+H,CS5055600000000,"Pittsford town, VT",0,T,7564
+H,CS5055825000000,"Plainfield town, VT",0,T,7565
+H,CS5056050000000,"Plymouth town, VT",0,T,7566
+H,CS5056350000000,"Pomfret town, VT",0,T,7567
+H,CS5056875000000,"Poultney town, VT",0,T,7568
+H,CS5057025000000,"Pownal town, VT",0,T,7569
+H,CS5057250000000,"Proctor town, VT",0,T,7570
+H,CS5057700000000,"Putney town, VT",0,T,7571
+H,CS5058075000000,"Randolph town, VT",0,T,7572
+H,CS5058375000000,"Reading town, VT",0,T,7573
+H,CS5058600000000,"Readsboro town, VT",0,T,7574
+H,CS5059125000000,"Richford town, VT",0,T,7575
+H,CS5059275000000,"Richmond town, VT",0,T,7576
+H,CS5059650000000,"Ripton town, VT",0,T,7577
+H,CS5060100000000,"Rochester town, VT",0,T,7578
+H,CS5060250000000,"Rockingham town, VT",0,T,7579
+H,CS5060625000000,"Roxbury town, VT",0,T,7580
+H,CS5060850000000,"Royalton town, VT",0,T,7581
+H,CS5061000000000,"Rupert town, VT",0,T,7582
+H,CS5061300000000,"Rutland town, VT",0,T,7584
+H,CS5061525000000,"Ryegate town, VT",0,T,7585
+H,CS5061750000000,"St. Albans town, VT",0,T,7587
+H,CS5062050000000,"St. George town, VT",0,T,7588
+H,CS5062200000000,"St. Johnsbury town, VT",0,T,7589
+H,CS5062575000000,"Salisbury town, VT",0,T,7590
+H,CS5062875000000,"Sandgate town, VT",0,T,7591
+H,CS5063175000000,"Searsburg town, VT",0,T,7592
+H,CS5063550000000,"Shaftsbury town, VT",0,T,7593
+H,CS5063775000000,"Sharon town, VT",0,T,7594
+H,CS5064075000000,"Sheffield town, VT",0,T,7595
+H,CS5064300000000,"Shelburne town, VT",0,T,7596
+H,CS5064600000000,"Sheldon town, VT",0,T,7597
+H,CS5065050000000,"Shoreham town, VT",0,T,7598
+H,CS5065275000000,"Shrewsbury town, VT",0,T,7599
+H,CS5067000000000,"South Hero town, VT",0,T,7601
+H,CS5069550000000,"Springfield town, VT",0,T,7602
+H,CS5069775000000,"Stamford town, VT",0,T,7603
+H,CS5069925000000,"Stannard town, VT",0,T,7604
+H,CS5070075000000,"Starksboro town, VT",0,T,7605
+H,CS5070375000000,"Stockbridge town, VT",0,T,7606
+H,CS5070525000000,"Stowe town, VT",0,T,7607
+H,CS5070675000000,"Strafford town, VT",0,T,7608
+H,CS5070750000000,"Stratton town, VT",0,T,7609
+H,CS5071050000000,"Sudbury town, VT",0,T,7610
+H,CS5071425000000,"Sunderland town, VT",0,T,7611
+H,CS5071575000000,"Sutton town, VT",0,T,7612
+H,CS5071725000000,"Swanton town, VT",0,T,7613
+H,CS5072400000000,"Thetford town, VT",0,T,7614
+H,CS5072925000000,"Tinmouth town, VT",0,T,7615
+H,CS5073075000000,"Topsham town, VT",0,T,7616
+H,CS5073300000000,"Townshend town, VT",0,T,7617
+H,CS5073525000000,"Troy town, VT",0,T,7618
+H,CS5073675000000,"Tunbridge town, VT",0,T,7619
+H,CS5073975000000,"Underhill town, VT",0,T,7620
+H,CS5074800000000,"Vernon town, VT",0,T,7622
+H,CS5074950000000,"Vershire town, VT",0,T,7623
+H,CS5075175000000,"Victory town, VT",0,T,7624
+H,CS5075325000000,"Waitsfield town, VT",0,T,7625
+H,CS5075700000000,"Walden town, VT",0,T,7626
+H,CS5075925000000,"Wallingford town, VT",0,T,7627
+H,CS5076075000000,"Waltham town, VT",0,T,7628
+H,CS5076225000000,"Wardsboro town, VT",0,T,7629
+H,CS5076525000000,"Warren town, VT",0,T,7630
+H,CS5076562000000,"Warren's gore, VT",0,T,7631
+H,CS5076750000000,"Washington town, VT",0,T,7632
+H,CS5076975000000,"Waterbury town, VT",0,T,7633
+H,CS5077125000000,"Waterford town, VT",0,T,7634
+H,CS5077425000000,"Waterville town, VT",0,T,7635
+H,CS5077500000000,"Weathersfield town, VT",0,T,7636
+H,CS5077950000000,"Wells town, VT",0,T,7637
+H,CS5079975000000,"West Fairlee town, VT",0,T,7638
+H,CS5080200000000,"Westfield town, VT",0,T,7639
+H,CS5080350000000,"Westford town, VT",0,T,7640
+H,CS5080875000000,"West Haven town, VT",0,T,7641
+H,CS5081400000000,"Westminster town, VT",0,T,7642
+H,CS5081700000000,"Westmore town, VT",0,T,7643
+H,CS5082000000000,"Weston town, VT",0,T,7644
+H,CS5082300000000,"West Rutland town, VT",0,T,7645
+H,CS5083050000000,"West Windsor town, VT",0,T,7646
+H,CS5083275000000,"Weybridge town, VT",0,T,7647
+H,CS5083500000000,"Wheelock town, VT",0,T,7648
+H,CS5083800000000,"Whiting town, VT",0,T,7649
+H,CS5083950000000,"Whitingham town, VT",0,T,7650
+H,CS5084175000000,"Williamstown town, VT",0,T,7651
+H,CS5084475000000,"Williston town, VT",0,T,7652
+H,CS5084700000000,"Wilmington town, VT",0,T,7653
+H,CS5084850000000,"Windham town, VT",0,T,7654
+H,CS5084925000000,"Windsor town, VT",0,T,7655
+H,CS5085075000000,"Winhall town, VT",0,T,7656
+H,CS5085375000000,"Wolcott town, VT",0,T,7658
+H,CS5085525000000,"Woodbury town, VT",0,T,7659
+H,CS5085675000000,"Woodford town, VT",0,T,7660
+H,CS5085975000000,"Woodstock town, VT",0,T,7661
+H,CS5086125000000,"Worcester town, VT",0,T,7662
+H,CT0901150000000,"Ansonia city/town, CT",0,T,927
+H,CT0919480000000,"Derby city/town, CT",0,T,962
+H,CT2302060000000,"Auburn city, ME",0,T,2776
+H,CT2302100000000,"Augusta city, ME",0,T,2777
+H,CT2303355000000,"Bath city, ME",0,T,2786
+H,CT2303950000000,"Belfast city, ME",0,T,2790
+H,CT2304860000000,"Biddeford city, ME",0,T,2796
+H,CT2306925000000,"Brewer city, ME",0,T,2809
+H,CT2309585000000,"Calais city, ME",0,T,2826
+H,CT2310565000000,"Caribou city, ME",0,T,2833
+H,CT2321730000000,"Eastport city, ME",0,T,2902
+H,CT2323200000000,"Ellsworth city, ME",0,T,2907
+H,CT2327085000000,"Gardiner city, ME",0,T,2929
+H,CT2330550000000,"Hallowell city, ME",0,T,2947
+H,CT2355225000000,"Old Town city, ME",0,T,3096
+H,CT2360825000000,"Presque Isle city, ME",0,T,3133
+H,CT2363590000000,"Rockland city, ME",0,T,3145
+H,CT2364675000000,"Saco city, ME",0,T,3152
+H,CT2365725000000,"Sanford city, ME",0,T,3159
+H,CT2380740000000,"Waterville city, ME",0,T,3242
+H,CT2382105000000,"Westbrook city, ME",0,T,3250
+H,CT2501260000000,"Amesbury Town city, MA",0,T,3392
+H,CT2519370000000,"Easthampton Town city, MA",0,T,3472
+H,CT2525485000000,"Gardner city, MA",0,T,3489
+H,CT2527060000000,"Greenfield city, MA",0,T,3499
+H,CT2545245000000,"Newburyport city, MA",0,T,3589
+H,CT2546225000000,"North Adams city, MA",0,T,3594
+H,CT2552144000000,"Palmer Town city, MA",0,T,3612
+H,CT2563345000000,"Southbridge Town city, MA",0,T,3662
+H,CT2581005000000,"Winthrop Town city, MA",0,T,3731
+H,CT3305140000000,"Berlin city, NH",0,T,4737
+H,CT3312900000000,"Claremont city, NH",0,T,4759
+H,CT3327380000000,"Franklin city, NH",0,T,4794
+H,CT3339300000000,"Keene city, NH",0,T,4831
+H,CT3340180000000,"Laconia city, NH",0,T,4834
+H,CT3341300000000,"Lebanon city, NH",0,T,4838
+H,CT3362900000000,"Portsmouth city, NH",0,T,4898
+H,CT3369940000000,"Somersworth city, NH",0,T,4916
+H,CT4414140000000,"Central Falls city, RI",0,T,6360
+H,CT5003175000000,"Barre city, VT",0,T,7423
+H,CT5046000000000,"Montpelier city, VT",0,T,7541
+H,CT5048850000000,"Newport city, VT",0,T,7551
+H,CT5061225000000,"Rutland city, VT",0,T,7583
+H,CT5061675000000,"St. Albans city, VT",0,T,7586
+H,CT5066175000000,"South Burlington city, VT",0,T,7600
+H,CT5074650000000,"Vergennes city, VT",0,T,7621
+H,CT5085150000000,"Winooski city, VT",0,T,7657
+I,PT0107000073000,"Birmingham city, Jefferson County part, AL",0,T,125
+I,PT0107000117000,"Birmingham city, Shelby County part, AL",0,T,126
+I,PT0120104083000,"Decatur city, Limestone County part, AL",0,T,127
+I,PT0120104103000,"Decatur city, Morgan County part, AL",0,T,128
+I,PT0121184045000,"Dothan city, Dale County part, AL",0,T,129
+I,PT0121184069000,"Dothan city, Houston County part, AL",0,T,130
+I,PT0124184031000,"Enterprise city, Coffee County part, AL",0,T,131
+I,PT0124184045000,"Enterprise city, Dale County part, AL",0,T,132
+I,PT0135896073000,"Hoover city, Jefferson County part, AL",0,T,133
+I,PT0135896117000,"Hoover city, Shelby County part, AL",0,T,134
+I,PT0137000083000,"Huntsville city, Limestone County part, AL",0,T,135
+I,PT0137000089000,"Huntsville city, Madison County part, AL",0,T,136
+I,PT0145784083000,"Madison city, Limestone County part, AL",0,T,137
+I,PT0145784089000,"Madison city, Madison County part, AL",0,T,138
+I,PT0159472081000,"Phenix City city, Lee County part, AL",0,T,139
+I,PT0159472113000,"Phenix City city, Russell County part, AL",0,T,140
+I,PT0162328001000,"Prattville city, Autauga County part, AL",0,T,141
+I,PT0162328051000,"Prattville city, Elmore County part, AL",0,T,142
+I,PT0176944073000,"Trussville city, Jefferson County part, AL",0,T,143
+I,PT0176944115000,"Trussville city, St. Clair County part, AL",0,T,144
+I,PT0178552073000,"Vestavia Hills city, Jefferson County part, AL",0,T,145
+I,PT0178552117000,"Vestavia Hills city, Shelby County part, AL",0,T,146
+I,PT0402830013000,"Apache Junction city, Maricopa County part, AZ",0,T,253
+I,PT0402830021000,"Apache Junction city, Pinal County part, AZ",0,T,254
+I,PT0458150013000,"Queen Creek town, Maricopa County part, AZ",0,T,255
+I,PT0458150021000,"Queen Creek town, Pinal County part, AZ",0,T,256
+I,PT0566080007000,"Springdale city, Benton County part, AR",0,T,377
+I,PT0566080143000,"Springdale city, Washington County part, AR",0,T,378
+I,PT0803455001000,"Arvada city, Adams County part, CO",0,T,886
+I,PT0803455059000,"Arvada city, Jefferson County part, CO",0,T,887
+I,PT0804000001000,"Aurora city, Adams County part, CO",0,T,888
+I,PT0804000005000,"Aurora city, Arapahoe County part, CO",0,T,889
+I,PT0804000035000,"Aurora city, Douglas County part, CO",0,T,890
+I,PT0808675001000,"Brighton city, Adams County part, CO",0,T,891
+I,PT0808675123000,"Brighton city, Weld County part, CO",0,T,892
+I,PT0824950013000,"Erie town, Boulder County part, CO",0,T,893
+I,PT0824950123000,"Erie town, Weld County part, CO",0,T,894
+I,PT0845255005000,"Littleton city, Arapahoe County part, CO",0,T,895
+I,PT0845255035000,"Littleton city, Douglas County part, CO",0,T,896
+I,PT0845255059000,"Littleton city, Jefferson County part, CO",0,T,897
+I,PT0845970013000,"Longmont city, Boulder County part, CO",0,T,898
+I,PT0845970123000,"Longmont city, Weld County part, CO",0,T,899
+I,PT0854330001000,"Northglenn city, Adams County part, CO",0,T,900
+I,PT0854330123000,"Northglenn city, Weld County part, CO",0,T,901
+I,PT0883835001000,"Westminster city, Adams County part, CO",0,T,902
+I,PT0883835059000,"Westminster city, Jefferson County part, CO",0,T,903
+I,PT0885485069000,"Windsor town, Larimer County part, CO",0,T,904
+I,PT0885485123000,"Windsor town, Weld County part, CO",0,T,905
+I,PT1304000089000,"Atlanta city, DeKalb County part, GA",0,T,1576
+I,PT1304000121000,"Atlanta city, Fulton County part, GA",0,T,1577
+I,PT1380508153000,"Warner Robins city, Houston County part, GA",0,T,1578
+I,PT1380508225000,"Warner Robins city, Peach County part, GA",0,T,1579
+I,PT1664090005000,"Pocatello city, Bannock County part, ID",0,T,1669
+I,PT1664090077000,"Pocatello city, Power County part, ID",0,T,1670
+I,PT1700685089000,"Algonquin village, Kane County part, IL",0,T,1920
+I,PT1700685111000,"Algonquin village, McHenry County part, IL",0,T,1921
+I,PT1703012043000,"Aurora city, DuPage County part, IL",0,T,1922
+I,PT1703012089000,"Aurora city, Kane County part, IL",0,T,1923
+I,PT1703012093000,"Aurora city, Kendall County part, IL",0,T,1924
+I,PT1703012197000,"Aurora city, Will County part, IL",0,T,1925
+I,PT1704013031000,"Bartlett village, Cook County part, IL",0,T,1926
+I,PT1704013043000,"Bartlett village, DuPage County part, IL",0,T,1927
+I,PT1707133043000,"Bolingbrook village, DuPage County part, IL",0,T,1928
+I,PT1707133197000,"Bolingbrook village, Will County part, IL",0,T,1929
+I,PT1709447031000,"Buffalo Grove village, Cook County part, IL",0,T,1930
+I,PT1709447097000,"Buffalo Grove village, Lake County part, IL",0,T,1931
+I,PT1715599119000,"Collinsville city, Madison County part, IL",0,T,1932
+I,PT1715599163000,"Collinsville city, St. Clair County part, IL",0,T,1933
+I,PT1723074031000,"Elgin city, Cook County part, IL",0,T,1934
+I,PT1723074089000,"Elgin city, Kane County part, IL",0,T,1935
+I,PT1732746031000,"Hanover Park village, Cook County part, IL",0,T,1936
+I,PT1732746043000,"Hanover Park village, DuPage County part, IL",0,T,1937
+I,PT1736750089000,"Huntley village, Kane County part, IL",0,T,1938
+I,PT1736750111000,"Huntley village, McHenry County part, IL",0,T,1939
+I,PT1738570093000,"Joliet city, Kendall County part, IL",0,T,1940
+I,PT1738570197000,"Joliet city, Will County part, IL",0,T,1941
+I,PT1751622043000,"Naperville city, DuPage County part, IL",0,T,1942
+I,PT1751622197000,"Naperville city, Will County part, IL",0,T,1943
+I,PT1757732031000,"Park Forest village, Cook County part, IL",0,T,1944
+I,PT1757732197000,"Park Forest village, Will County part, IL",0,T,1945
+I,PT1760287093000,"Plainfield village, Kendall County part, IL",0,T,1946
+I,PT1760287197000,"Plainfield village, Will County part, IL",0,T,1947
+I,PT1766703043000,"St. Charles city, DuPage County part, IL",0,T,1948
+I,PT1766703089000,"St. Charles city, Kane County part, IL",0,T,1949
+I,PT1775484031000,"Tinley Park village, Cook County part, IL",0,T,1950
+I,PT1775484197000,"Tinley Park village, Will County part, IL",0,T,1951
+I,PT1921000153000,"Des Moines city, Polk County part, IA",0,T,2293
+I,PT1921000181000,"Des Moines city, Warren County part, IA",0,T,2294
+I,PT1979950049000,"Urbandale city, Dallas County part, IA",0,T,2295
+I,PT1979950153000,"Urbandale city, Polk County part, IA",0,T,2296
+I,PT1983910049000,"West Des Moines city, Dallas County part, IA",0,T,2297
+I,PT1983910153000,"West Des Moines city, Polk County part, IA",0,T,2298
+I,PT2044250149000,"Manhattan city, Pottawatomie County part, KS",0,T,2450
+I,PT2044250161000,"Manhattan city, Riley County part, KS",0,T,2451
+I,PT2270000015000,"Shreveport city, Bossier Parish part, LA",0,T,2727
+I,PT2270000017000,"Shreveport city, Caddo Parish part, LA",0,T,2728
+I,PT2624120037000,"East Lansing city, Clinton County part, MI",0,T,3958
+I,PT2624120065000,"East Lansing city, Ingham County part, MI",0,T,3959
+I,PT2638640005000,"Holland city, Allegan County part, MI",0,T,3960
+I,PT2638640139000,"Holland city, Ottawa County part, MI",0,T,3961
+I,PT2646000045000,"Lansing city, Eaton County part, MI",0,T,3962
+I,PT2646000065000,"Lansing city, Ingham County part, MI",0,T,3963
+I,PT2653780017000,"Midland city, Bay County part, MI",0,T,3964
+I,PT2653780111000,"Midland city, Midland County part, MI",0,T,3965
+I,PT2739878013000,"Mankato city, Blue Earth County part, MN",0,T,4130
+I,PT2739878103000,"Mankato city, Nicollet County part, MN",0,T,4131
+I,PT2756896009000,"St. Cloud city, Benton County part, MN",0,T,4132
+I,PT2756896141000,"St. Cloud city, Sherburne County part, MN",0,T,4133
+I,PT2756896145000,"St. Cloud city, Stearns County part, MN",0,T,4134
+I,PT2769970123000,"White Bear Lake city, Ramsey County part, MN",0,T,4135
+I,PT2769970163000,"White Bear Lake city, Washington County part, MN",0,T,4136
+I,PT2831020035000,"Hattiesburg city, Forrest County part, MS",0,T,4271
+I,PT2831020073000,"Hattiesburg city, Lamar County part, MS",0,T,4272
+I,PT2836000049000,"Jackson city, Hinds County part, MS",0,T,4273
+I,PT2836000089000,"Jackson city, Madison County part, MS",0,T,4274
+I,PT2836000121000,"Jackson city, Rankin County part, MS",0,T,4275
+I,PT2937000027000,"Jefferson City city, Callaway County part, MO",0,T,4452
+I,PT2937000051000,"Jefferson City city, Cole County part, MO",0,T,4453
+I,PT2937592097000,"Joplin city, Jasper County part, MO",0,T,4454
+I,PT2937592145000,"Joplin city, Newton County part, MO",0,T,4455
+I,PT2938000037000,"Kansas City city, Cass County part, MO",0,T,4456
+I,PT2938000047000,"Kansas City city, Clay County part, MO",0,T,4457
+I,PT2938000095000,"Kansas City city, Jackson County part, MO",0,T,4458
+I,PT2938000165000,"Kansas City city, Platte County part, MO",0,T,4459
+I,PT2941348037000,"Lee's Summit city, Cass County part, MO",0,T,4460
+I,PT2941348095000,"Lee's Summit city, Jackson County part, MO",0,T,4461
+I,PT3709060001000,"Burlington city, Alamance County part, NC",0,T,5586
+I,PT3709060081000,"Burlington city, Guilford County part, NC",0,T,5587
+I,PT3710740037000,"Cary town, Chatham County part, NC",0,T,5588
+I,PT3710740183000,"Cary town, Wake County part, NC",0,T,5589
+I,PT3711800063000,"Chapel Hill town, Durham County part, NC",0,T,5590
+I,PT3711800135000,"Chapel Hill town, Orange County part, NC",0,T,5591
+I,PT3719000063000,"Durham city, Durham County part, NC",0,T,5592
+I,PT3719000135000,"Durham city, Orange County part, NC",0,T,5593
+I,PT3731060023000,"Hickory city, Burke County part, NC",0,T,5594
+I,PT3731060027000,"Hickory city, Caldwell County part, NC",0,T,5595
+I,PT3731060035000,"Hickory city, Catawba County part, NC",0,T,5596
+I,PT3731400057000,"High Point city, Davidson County part, NC",0,T,5597
+I,PT3731400081000,"High Point city, Guilford County part, NC",0,T,5598
+I,PT3731400151000,"High Point city, Randolph County part, NC",0,T,5599
+I,PT3735200025000,"Kannapolis city, Cabarrus County part, NC",0,T,5600
+I,PT3735200159000,"Kannapolis city, Rowan County part, NC",0,T,5601
+I,PT3735600067000,"Kernersville town, Forsyth County part, NC",0,T,5602
+I,PT3735600081000,"Kernersville town, Guilford County part, NC",0,T,5603
+I,PT3755000063000,"Raleigh city, Durham County part, NC",0,T,5604
+I,PT3755000183000,"Raleigh city, Wake County part, NC",0,T,5605
+I,PT3757500065000,"Rocky Mount city, Edgecombe County part, NC",0,T,5606
+I,PT3757500127000,"Rocky Mount city, Nash County part, NC",0,T,5607
+I,PT3767420057000,"Thomasville city, Davidson County part, NC",0,T,5608
+I,PT3767420151000,"Thomasville city, Randolph County part, NC",0,T,5609
+I,PT3770540069000,"Wake Forest town, Franklin County part, NC",0,T,5610
+I,PT3770540183000,"Wake Forest town, Wake County part, NC",0,T,5611
+I,PT3918000041000,"Columbus city, Delaware County part, OH",0,T,5900
+I,PT3918000045000,"Columbus city, Fairfield County part, OH",0,T,5901
+I,PT3918000049000,"Columbus city, Franklin County part, OH",0,T,5902
+I,PT3922694041000,"Dublin city, Delaware County part, OH",0,T,5903
+I,PT3922694049000,"Dublin city, Franklin County part, OH",0,T,5904
+I,PT3922694159000,"Dublin city, Union County part, OH",0,T,5905
+I,PT3936610109000,"Huber Heights city, Miami County part, OH",0,T,5906
+I,PT3936610113000,"Huber Heights city, Montgomery County part, OH",0,T,5907
+I,PT3940040057000,"Kettering city, Greene County part, OH",0,T,5908
+I,PT3940040113000,"Kettering city, Montgomery County part, OH",0,T,5909
+I,PT3949840017000,"Middletown city, Butler County part, OH",0,T,5910
+I,PT3949840165000,"Middletown city, Warren County part, OH",0,T,5911
+I,PT3966390045000,"Reynoldsburg city, Fairfield County part, OH",0,T,5912
+I,PT3966390049000,"Reynoldsburg city, Franklin County part, OH",0,T,5913
+I,PT3966390089000,"Reynoldsburg city, Licking County part, OH",0,T,5914
+I,PT3983342041000,"Westerville city, Delaware County part, OH",0,T,5915
+I,PT3983342049000,"Westerville city, Franklin County part, OH",0,T,5916
+I,PT4006400143000,"Bixby city, Tulsa County part, OK",0,T,6045
+I,PT4006400145000,"Bixby city, Wagoner County part, OK",0,T,6046
+I,PT4009050143000,"Broken Arrow city, Tulsa County part, OK",0,T,6047
+I,PT4009050145000,"Broken Arrow city, Wagoner County part, OK",0,T,6048
+I,PT4055000017000,"Oklahoma City city, Canadian County part, OK",0,T,6049
+I,PT4055000027000,"Oklahoma City city, Cleveland County part, OK",0,T,6050
+I,PT4055000109000,"Oklahoma City city, Oklahoma County part, OK",0,T,6051
+I,PT4055000125000,"Oklahoma City city, Pottawatomie County part, OK",0,T,6052
+I,PT4056650131000,"Owasso city, Rogers County part, OK",0,T,6053
+I,PT4056650143000,"Owasso city, Tulsa County part, OK",0,T,6054
+I,PT4075000113000,"Tulsa city, Osage County part, OK",0,T,6055
+I,PT4075000143000,"Tulsa city, Tulsa County part, OK",0,T,6056
+I,PT4075000145000,"Tulsa city, Wagoner County part, OK",0,T,6057
+I,PT4101000003000,"Albany city, Benton County part, OR",0,T,6144
+I,PT4101000043000,"Albany city, Linn County part, OR",0,T,6145
+I,PT4140550005000,"Lake Oswego city, Clackamas County part, OR",0,T,6146
+I,PT4140550051000,"Lake Oswego city, Multnomah County part, OR",0,T,6147
+I,PT4159000005000,"Portland city, Clackamas County part, OR",0,T,6148
+I,PT4159000051000,"Portland city, Multnomah County part, OR",0,T,6149
+I,PT4159000067000,"Portland city, Washington County part, OR",0,T,6150
+I,PT4164900047000,"Salem city, Marion County part, OR",0,T,6151
+I,PT4164900053000,"Salem city, Polk County part, OR",0,T,6152
+I,PT4174950005000,"Tualatin city, Clackamas County part, OR",0,T,6153
+I,PT4174950067000,"Tualatin city, Washington County part, OR",0,T,6154
+I,PT4182800005000,"Wilsonville city, Clackamas County part, OR",0,T,6155
+I,PT4182800067000,"Wilsonville city, Washington County part, OR",0,T,6156
+I,PT4206088077000,"Bethlehem city, Lehigh County part, PA",0,T,6345
+I,PT4206088095000,"Bethlehem city, Northampton County part, PA",0,T,6346
+I,PT4513330015000,"Charleston city, Berkeley County part, SC",0,T,6484
+I,PT4513330019000,"Charleston city, Charleston County part, SC",0,T,6485
+I,PT4516000063000,"Columbia city, Lexington County part, SC",0,T,6486
+I,PT4516000079000,"Columbia city, Richland County part, SC",0,T,6487
+I,PT4530985045000,"Greer city, Greenville County part, SC",0,T,6488
+I,PT4530985083000,"Greer city, Spartanburg County part, SC",0,T,6489
+I,PT4550875019000,"North Charleston city, Charleston County part, SC",0,T,6490
+I,PT4550875035000,"North Charleston city, Dorchester County part, SC",0,T,6491
+I,PT4570270015000,"Summerville town, Berkeley County part, SC",0,T,6492
+I,PT4570270019000,"Summerville town, Charleston County part, SC",0,T,6493
+I,PT4570270035000,"Summerville town, Dorchester County part, SC",0,T,6494
+I,PT4659020083000,"Sioux Falls city, Lincoln County part, SD",0,T,6580
+I,PT4659020099000,"Sioux Falls city, Minnehaha County part, SD",0,T,6581
+I,PT4738320019000,"Johnson City city, Carter County part, TN",0,T,6742
+I,PT4738320163000,"Johnson City city, Sullivan County part, TN",0,T,6743
+I,PT4738320179000,"Johnson City city, Washington County part, TN",0,T,6744
+I,PT4739560073000,"Kingsport city, Hawkins County part, TN",0,T,6745
+I,PT4739560163000,"Kingsport city, Sullivan County part, TN",0,T,6746
+I,PT4755120001000,"Oak Ridge city, Anderson County part, TN",0,T,6747
+I,PT4755120145000,"Oak Ridge city, Roane County part, TN",0,T,6748
+I,PT4770580119000,"Spring Hill city, Maury County part, TN",0,T,6749
+I,PT4770580187000,"Spring Hill city, Williamson County part, TN",0,T,6750
+I,PT4801000253000,"Abilene city, Jones County part, TX",0,T,7220
+I,PT4801000441000,"Abilene city, Taylor County part, TX",0,T,7221
+I,PT4803000375000,"Amarillo city, Potter County part, TX",0,T,7222
+I,PT4803000381000,"Amarillo city, Randall County part, TX",0,T,7223
+I,PT4805000453000,"Austin city, Travis County part, TX",0,T,7224
+I,PT4805000491000,"Austin city, Williamson County part, TX",0,T,7225
+I,PT4806128071000,"Baytown city, Chambers County part, TX",0,T,7226
+I,PT4806128201000,"Baytown city, Harris County part, TX",0,T,7227
+I,PT4811428251000,"Burleson city, Johnson County part, TX",0,T,7228
+I,PT4811428439000,"Burleson city, Tarrant County part, TX",0,T,7229
+I,PT4813024113000,"Carrollton city, Dallas County part, TX",0,T,7230
+I,PT4813024121000,"Carrollton city, Denton County part, TX",0,T,7231
+I,PT4813492113000,"Cedar Hill city, Dallas County part, TX",0,T,7232
+I,PT4813492139000,"Cedar Hill city, Ellis County part, TX",0,T,7233
+I,PT4813552453000,"Cedar Park city, Travis County part, TX",0,T,7234
+I,PT4813552491000,"Cedar Park city, Williamson County part, TX",0,T,7235
+I,PT4816612113000,"Coppell city, Dallas County part, TX",0,T,7236
+I,PT4816612121000,"Coppell city, Denton County part, TX",0,T,7237
+I,PT4816624099000,"Copperas Cove city, Coryell County part, TX",0,T,7238
+I,PT4816624281000,"Copperas Cove city, Lampasas County part, TX",0,T,7239
+I,PT4819000085000,"Dallas city, Collin County part, TX",0,T,7240
+I,PT4819000113000,"Dallas city, Dallas County part, TX",0,T,7241
+I,PT4819000121000,"Dallas city, Denton County part, TX",0,T,7242
+I,PT4819000397000,"Dallas city, Rockwall County part, TX",0,T,7243
+I,PT4826232121000,"Flower Mound town, Denton County part, TX",0,T,7244
+I,PT4826232439000,"Flower Mound town, Tarrant County part, TX",0,T,7245
+I,PT4827000121000,"Fort Worth city, Denton County part, TX",0,T,7246
+I,PT4827000439000,"Fort Worth city, Tarrant County part, TX",0,T,7247
+I,PT4827648167000,"Friendswood city, Galveston County part, TX",0,T,7248
+I,PT4827648201000,"Friendswood city, Harris County part, TX",0,T,7249
+I,PT4827684085000,"Frisco city, Collin County part, TX",0,T,7250
+I,PT4827684121000,"Frisco city, Denton County part, TX",0,T,7251
+I,PT4829000085000,"Garland city, Collin County part, TX",0,T,7252
+I,PT4829000113000,"Garland city, Dallas County part, TX",0,T,7253
+I,PT4830464113000,"Grand Prairie city, Dallas County part, TX",0,T,7254
+I,PT4830464439000,"Grand Prairie city, Tarrant County part, TX",0,T,7255
+I,PT4830644113000,"Grapevine city, Dallas County part, TX",0,T,7256
+I,PT4830644439000,"Grapevine city, Tarrant County part, TX",0,T,7257
+I,PT4835000157000,"Houston city, Fort Bend County part, TX",0,T,7258
+I,PT4835000201000,"Houston city, Harris County part, TX",0,T,7259
+I,PT4835000339000,"Houston city, Montgomery County part, TX",0,T,7260
+I,PT4841980167000,"League City city, Galveston County part, TX",0,T,7261
+I,PT4841980201000,"League City city, Harris County part, TX",0,T,7262
+I,PT4842016453000,"Leander city, Travis County part, TX",0,T,7263
+I,PT4842016491000,"Leander city, Williamson County part, TX",0,T,7264
+I,PT4842508113000,"Lewisville city, Dallas County part, TX",0,T,7265
+I,PT4842508121000,"Lewisville city, Denton County part, TX",0,T,7266
+I,PT4843888183000,"Longview city, Gregg County part, TX",0,T,7267
+I,PT4843888203000,"Longview city, Harrison County part, TX",0,T,7268
+I,PT4846452139000,"Mansfield city, Ellis County part, TX",0,T,7269
+I,PT4846452251000,"Mansfield city, Johnson County part, TX",0,T,7270
+I,PT4846452439000,"Mansfield city, Tarrant County part, TX",0,T,7271
+I,PT4847892113000,"Mesquite city, Dallas County part, TX",0,T,7272
+I,PT4847892257000,"Mesquite city, Kaufman County part, TX",0,T,7273
+I,PT4848804157000,"Missouri City city, Fort Bend County part, TX",0,T,7274
+I,PT4848804201000,"Missouri City city, Harris County part, TX",0,T,7275
+I,PT4850820091000,"New Braunfels city, Comal County part, TX",0,T,7276
+I,PT4850820187000,"New Braunfels city, Guadalupe County part, TX",0,T,7277
+I,PT4853388135000,"Odessa city, Ector County part, TX",0,T,7278
+I,PT4853388329000,"Odessa city, Midland County part, TX",0,T,7279
+I,PT4856348039000,"Pearland city, Brazoria County part, TX",0,T,7280
+I,PT4856348157000,"Pearland city, Fort Bend County part, TX",0,T,7281
+I,PT4856348201000,"Pearland city, Harris County part, TX",0,T,7282
+I,PT4857176453000,"Pflugerville city, Travis County part, TX",0,T,7283
+I,PT4857176491000,"Pflugerville city, Williamson County part, TX",0,T,7284
+I,PT4858016085000,"Plano city, Collin County part, TX",0,T,7285
+I,PT4858016121000,"Plano city, Denton County part, TX",0,T,7286
+I,PT4859696085000,"Prosper town, Collin County part, TX",0,T,7287
+I,PT4859696121000,"Prosper town, Denton County part, TX",0,T,7288
+I,PT4861796085000,"Richardson city, Collin County part, TX",0,T,7289
+I,PT4861796113000,"Richardson city, Dallas County part, TX",0,T,7290
+I,PT4863500453000,"Round Rock city, Travis County part, TX",0,T,7291
+I,PT4863500491000,"Round Rock city, Williamson County part, TX",0,T,7292
+I,PT4863572113000,"Rowlett city, Dallas County part, TX",0,T,7293
+I,PT4863572397000,"Rowlett city, Rockwall County part, TX",0,T,7294
+I,PT4864064085000,"Sachse city, Collin County part, TX",0,T,7295
+I,PT4864064113000,"Sachse city, Dallas County part, TX",0,T,7296
+I,PT4865000029000,"San Antonio city, Bexar County part, TX",0,T,7297
+I,PT4865000325000,"San Antonio city, Medina County part, TX",0,T,7298
+I,PT4866128029000,"Schertz city, Bexar County part, TX",0,T,7299
+I,PT4866128091000,"Schertz city, Comal County part, TX",0,T,7300
+I,PT4866128187000,"Schertz city, Guadalupe County part, TX",0,T,7301
+I,PT4869032121000,"Southlake city, Denton County part, TX",0,T,7302
+I,PT4869032439000,"Southlake city, Tarrant County part, TX",0,T,7303
+I,PT4880356085000,"Wylie city, Collin County part, TX",0,T,7304
+I,PT4880356113000,"Wylie city, Dallas County part, TX",0,T,7305
+I,PT4880356397000,"Wylie city, Rockwall County part, TX",0,T,7306
+I,PT4920120035000,"Draper city, Salt Lake County part, UT",0,T,7390
+I,PT4920120049000,"Draper city, Utah County part, UT",0,T,7391
+I,PT5303180033000,"Auburn city, King County part, WA",0,T,7991
+I,PT5303180053000,"Auburn city, Pierce County part, WA",0,T,7992
+I,PT5307380033000,"Bothell city, King County part, WA",0,T,7993
+I,PT5307380061000,"Bothell city, Snohomish County part, WA",0,T,7994
+I,PT5439460011000,"Huntington city, Cabell County part, WV",0,T,8073
+I,PT5439460099000,"Huntington city, Wayne County part, WV",0,T,8074
+I,PT5486452051000,"Wheeling city, Marshall County part, WV",0,T,8075
+I,PT5486452069000,"Wheeling city, Ohio County part, WV",0,T,8076
+I,PT5502375015000,"Appleton city, Calumet County part, WI",0,T,8224
+I,PT5502375087000,"Appleton city, Outagamie County part, WI",0,T,8225
+I,PT5502375139000,"Appleton city, Winnebago County part, WI",0,T,8226
+I,PT5522300017000,"Eau Claire city, Chippewa County part, WI",0,T,8227
+I,PT5522300035000,"Eau Claire city, Eau Claire County part, WI",0,T,8228
+J,SA0880140000000,"Alamosa-Conejos, CO LMA",0,T,906
+J,SA0882100000000,"Otero-Crowley, CO LMA",0,T,907
+J,SA0981220000000,"Hampton, CT LMA",0,T,1095
+J,SA0981580000000,"Litchfield, CT LMA",0,T,1096
+J,SA1381140000000,"Greene-Wilkes-Taliaferro, GA LMA",0,T,1580
+J,SA1681460000000,"Idaho-Lewis, ID LMA",0,T,1671
+J,SA2181500000000,"Lee-Owsley, KY LMA",0,T,2617
+J,SA2182180000000,"Perry-Knott-Leslie, KY LMA",0,T,2618
+J,SA2380100000000,"Acton, ME LMA",0,T,3279
+J,SA2380300000000,"Belfast, ME LMA",0,T,3280
+J,SA2380380000000,"Boothbay, ME LMA",0,T,3281
+J,SA2380460000000,"Bridgton-Paris, ME LMA",0,T,3282
+J,SA2380540000000,"Calais, ME LMA",0,T,3283
+J,SA2380900000000,"Dover-Foxcroft, ME LMA",0,T,3284
+J,SA2380940000000,"Ellsworth, ME LMA",0,T,3285
+J,SA2380980000000,"Farmington, ME LMA",0,T,3286
+J,SA2381420000000,"Houlton, ME LMA",0,T,3287
+J,SA2381540000000,"Lincoln, ME LMA",0,T,3288
+J,SA2381660000000,"Machias, ME LMA",0,T,3289
+J,SA2381700000000,"Madawaska, ME LMA",0,T,3290
+J,SA2381860000000,"Millinocket, ME LMA",0,T,3291
+J,SA2382260000000,"Pittsfield, ME LMA",0,T,3292
+J,SA2382340000000,"Presque Isle, ME LMA",0,T,3293
+J,SA2382580000000,"Rockland-Camden, ME LMA",0,T,3294
+J,SA2382620000000,"Rumford, ME LMA",0,T,3295
+J,SA2382700000000,"Skowhegan, ME LMA",0,T,3296
+J,SA2382820000000,"Waldoboro, ME LMA",0,T,3297
+J,SA2382860000000,"Wells, ME LMA",0,T,3298
+J,SA2580500000000,"Buckland, MA LMA",0,T,3737
+J,SA2581100000000,"Great Barrington, MA LMA",0,T,3738
+J,SA2681060000000,"Gogebic-Iron, MI-WI LMA",0,T,3966
+J,SA2782140000000,"Pennington-Red Lake, MN LMA",0,T,4137
+J,SA3081940000000,"Musselshell-Petroleum, MT LMA",0,T,4541
+J,SA3182500000000,"Red Willow-Hitchcock, NE LMA",0,T,4657
+J,SA3380340000000,"Belmont, NH LMA",0,T,4957
+J,SA3380620000000,"Charlestown, NH LMA",0,T,4958
+J,SA3380700000000,"Colebrook, NH-VT LMA",0,T,4959
+J,SA3380740000000,"Conway, NH-ME LMA",0,T,4960
+J,SA3381020000000,"Franklin, NH LMA",0,T,4961
+J,SA3381260000000,"Haverhill, NH LMA",0,T,4962
+J,SA3381380000000,"Hillsborough, NH LMA",0,T,4963
+J,SA3381620000000,"Littleton, NH-VT LMA",0,T,4964
+J,SA3381780000000,"Meredith, NH LMA",0,T,4965
+J,SA3381980000000,"New London, NH LMA",0,T,4966
+J,SA3382040000000,"Newport, NH LMA",0,T,4967
+J,SA3382220000000,"Peterborough, NH LMA",0,T,4968
+J,SA3382300000000,"Plymouth, NH LMA",0,T,4969
+J,SA3382460000000,"Raymond, NH LMA",0,T,4970
+J,SA3382940000000,"Wolfeboro, NH LMA",0,T,4971
+J,SA4680860000000,"Dewey-Ziebach, SD LMA",0,T,6582
+J,SA4880780000000,"Dallam-Hartley, TX LMA",0,T,7307
+J,SA4882900000000,"Winkler-Loving, TX LMA",0,T,7308
+J,SA5080420000000,"Brattleboro, VT-NH LMA",0,T,7663
+J,SA5080820000000,"Derby, VT LMA",0,T,7664
+J,SA5081340000000,"Highgate, VT LMA",0,T,7665
+J,SA5081740000000,"Manchester, VT LMA",0,T,7666
+J,SA5081820000000,"Middlebury, VT LMA",0,T,7667
+J,SA5081900000000,"Morristown-Waterbury, VT LMA",0,T,7668
+J,SA5082020000000,"Newbury, VT LMA",0,T,7669
+J,SA5082060000000,"Northfield-Waitsfield, VT LMA",0,T,7670
+J,SA5082420000000,"Randolph, VT LMA",0,T,7671
+J,SA5082660000000,"St. Johnsbury, VT LMA",0,T,7672
+J,SA5082780000000,"Springfield, VT LMA",0,T,7673
+J,SA5082980000000,"Woodstock, VT LMA",0,T,7674
+J,SA5180180000000,"Alleghany-Covington, VA LMA",0,T,7868
+J,SA5180580000000,"Carroll-Grayson-Galax, VA LMA",0,T,7869
+J,SA5181180000000,"Greensville-Emporia, VA LMA",0,T,7870
+J,SA5182380000000,"Prince Edward-Cumberland, VA LMA",0,T,7871
+J,SA5182540000000,"Rockbridge-Lexington-Buena Vista, VA LMA",0,T,7872
+J,SA5182740000000,"Southampton-Franklin, VA LMA",0,T,7873
+J,SA5580220000000,"Ashland-Bayfield, WI LMA",0,T,8229
+K,ID1048864000000,"Wilmington, DE-MD-NJ Metropolitan Division, DE part",0,T,1110
+K,ID1147894000000,"Washington-Arlington-Alexandria, DC-VA-MD-WV Metropolitan Division, DC part",0,T,1118
+K,ID1729404000000,"Lake County-Kenosha County, IL-WI Metropolitan Division, IL part",0,T,1952
+K,ID2447894000000,"Washington-Arlington-Alexandria, DC-VA-MD-WV Metropolitan Division, MD part",0,T,3344
+K,ID2448864000000,"Wilmington, DE-MD-NJ Metropolitan Division, MD part",0,T,3345
+K,ID2573604000000,"Haverhill-Newburyport-Amesbury Town, MA-NH NECTA Division, MA part",0,T,3739
+K,ID2574204000000,"Lawrence-Methuen Town-Salem, MA-NH NECTA Division, MA part",0,T,3740
+K,ID2574804000000,"Lowell-Billerica-Chelmsford, MA-NH NECTA Division, MA part",0,T,3741
+K,ID2575404000000,"Nashua, NH-MA NECTA Division, MA part",0,T,3742
+K,ID3373604000000,"Haverhill-Newburyport-Amesbury Town, MA-NH NECTA Division, NH part",0,T,4972
+K,ID3374204000000,"Lawrence-Methuen Town-Salem, MA-NH NECTA Division, NH part",0,T,4973
+K,ID3374804000000,"Lowell-Billerica-Chelmsford, MA-NH NECTA Division, NH part",0,T,4974
+K,ID3375404000000,"Nashua, NH-MA NECTA Division, NH part",0,T,4975
+K,ID3435084000000,"Newark, NJ-PA Metropolitan Division, NJ part",0,T,5117
+K,ID3435614000000,"New York-Jersey City-White Plains, NY-NJ Metropolitan Division, NJ part",0,T,5118
+K,ID3448864000000,"Wilmington, DE-MD-NJ Metropolitan Division, NJ part",0,T,5119
+K,ID3635614000000,"New York-Jersey City-White Plains, NY-NJ Metropolitan Division, NY part",0,T,5391
+K,ID4235084000000,"Newark, NJ-PA Metropolitan Division, PA part",0,T,6347
+K,ID5147894000000,"Washington-Arlington-Alexandria, DC-VA-MD-WV Metropolitan Division, VA part",0,T,7874
+K,ID5447894000000,"Washington-Arlington-Alexandria, DC-VA-MD-WV Metropolitan Division, WV part",0,T,8077
+K,ID5529404000000,"Lake County-Kenosha County, IL-WI Metropolitan Division, WI part",0,T,8230
+K,IM0117980000000,"Columbus, GA-AL Metropolitan Statistical Area, AL part",0,T,147
+K,IM0121640000000,"Eufaula, AL-GA Micropolitan Statistical Area, AL part",0,T,148
+K,IM0522220000000,"Fayetteville-Springdale-Rogers, AR-MO Metropolitan Statistical Area, AR part",0,T,379
+K,IM0522900000000,"Fort Smith, AR-OK Metropolitan Statistical Area, AR part",0,T,380
+K,IM0532820000000,"Memphis, TN-MS-AR Metropolitan Statistical Area, AR part",0,T,381
+K,IM0545500000000,"Texarkana, TX-AR Metropolitan Statistical Area, AR part",0,T,382
+K,IM0976450000000,"Norwich-New London-Westerly, CT-RI Metropolitan NECTA, CT part",0,T,1097
+K,IM0978100000000,"Springfield, MA-CT Metropolitan NECTA, CT part",0,T,1098
+K,IM0979600000000,"Worcester, MA-CT Metropolitan NECTA, CT part",0,T,1099
+K,IM1041540000000,"Salisbury, MD-DE Metropolitan Statistical Area, DE part",0,T,1111
+K,IM1312260000000,"Augusta-Richmond County, GA-SC Metropolitan Statistical Area, GA part",0,T,1581
+K,IM1316860000000,"Chattanooga, TN-GA Metropolitan Statistical Area, GA part",0,T,1582
+K,IM1317980000000,"Columbus, GA-AL Metropolitan Statistical Area, GA part",0,T,1583
+K,IM1321640000000,"Eufaula, AL-GA Micropolitan Statistical Area, GA part",0,T,1584
+K,IM1627220000000,"Jackson, WY-ID Micropolitan Statistical Area, ID part",0,T,1672
+K,IM1630300000000,"Lewiston, ID-WA Metropolitan Statistical Area, ID part",0,T,1673
+K,IM1630860000000,"Logan, UT-ID Metropolitan Statistical Area, ID part",0,T,1674
+K,IM1636620000000,"Ontario, OR-ID Micropolitan Statistical Area, ID part",0,T,1675
+K,IM1715460000000,"Burlington, IA-IL Micropolitan Statistical Area, IL part",0,T,1953
+K,IM1716020000000,"Cape Girardeau, MO-IL Metropolitan Statistical Area, IL part",0,T,1954
+K,IM1719340000000,"Davenport-Moline-Rock Island, IA-IL Metropolitan Statistical Area, IL part",0,T,1955
+K,IM1722800000000,"Fort Madison-Keokuk, IA-IL-MO Micropolitan Statistical Area, IL part",0,T,1956
+K,IM1737140000000,"Paducah, KY-IL Micropolitan Statistical Area, IL part",0,T,1957
+K,IM1739500000000,"Quincy, IL-MO Micropolitan Statistical Area, IL part",0,T,1958
+K,IM1741180000000,"St. Louis, MO-IL Metropolitan Statistical Area, IL part",0,T,1959
+K,IM1817140000000,"Cincinnati, OH-KY-IN Metropolitan Statistical Area, IN part",0,T,2138
+K,IM1821780000000,"Evansville, IN-KY Metropolitan Statistical Area, IN part",0,T,2139
+K,IM1831140000000,"Louisville/Jefferson County, KY-IN Metropolitan Statistical Area, IN part",0,T,2140
+K,IM1843780000000,"South Bend-Mishawaka, IN-MI Metropolitan Statistical Area, IN part",0,T,2141
+K,IM1915460000000,"Burlington, IA-IL Micropolitan Statistical Area, IA part",0,T,2299
+K,IM1919340000000,"Davenport-Moline-Rock Island, IA-IL Metropolitan Statistical Area, IA part",0,T,2300
+K,IM1922800000000,"Fort Madison-Keokuk, IA-IL-MO Micropolitan Statistical Area, IA part",0,T,2301
+K,IM1936540000000,"Omaha-Council Bluffs, NE-IA Metropolitan Statistical Area, IA part",0,T,2302
+K,IM1943580000000,"Sioux City, IA-NE-SD Metropolitan Statistical Area, IA part",0,T,2303
+K,IM2028140000000,"Kansas City, MO-KS Metropolitan Statistical Area, KS part",0,T,2452
+K,IM2041140000000,"St. Joseph, MO-KS Metropolitan Statistical Area, KS part",0,T,2453
+K,IM2117140000000,"Cincinnati, OH-KY-IN Metropolitan Statistical Area, KY part",0,T,2619
+K,IM2117300000000,"Clarksville, TN-KY Metropolitan Statistical Area, KY part",0,T,2620
+K,IM2121780000000,"Evansville, IN-KY Metropolitan Statistical Area, KY part",0,T,2621
+K,IM2126580000000,"Huntington-Ashland, WV-KY-OH Metropolitan Statistical Area, KY part",0,T,2622
+K,IM2131140000000,"Louisville/Jefferson County, KY-IN Metropolitan Statistical Area, KY part",0,T,2623
+K,IM2137140000000,"Paducah, KY-IL Micropolitan Statistical Area, KY part",0,T,2624
+K,IM2146460000000,"Union City, TN-KY Micropolitan Statistical Area, KY part",0,T,2625
+K,IM2235020000000,"Natchez, MS-LA Micropolitan Statistical Area, LA part",0,T,2729
+K,IM2373050000000,"Dover-Durham, NH-ME Metropolitan NECTA, ME part",0,T,3299
+K,IM2376900000000,"Portsmouth, NH-ME Metropolitan NECTA, ME part",0,T,3300
+K,IM2419060000000,"Cumberland, MD-WV Metropolitan Statistical Area, MD part",0,T,3346
+K,IM2425180000000,"Hagerstown-Martinsburg, MD-WV Metropolitan Statistical Area, MD part",0,T,3347
+K,IM2441540000000,"Salisbury, MD-DE Metropolitan Statistical Area, MD part",0,T,3348
+K,IM2576150000000,"North Adams, MA-VT Micropolitan NECTA, MA part",0,T,3743
+K,IM2577200000000,"Providence-Warwick, RI-MA Metropolitan NECTA, MA part",0,T,3744
+K,IM2578100000000,"Springfield, MA-CT Metropolitan NECTA, MA part",0,T,3745
+K,IM2579600000000,"Worcester, MA-CT Metropolitan NECTA, MA part",0,T,3746
+K,IM2627020000000,"Iron Mountain, MI-WI Micropolitan Statistical Area, MI part",0,T,3967
+K,IM2631940000000,"Marinette, WI-MI Micropolitan Statistical Area, MI part",0,T,3968
+K,IM2643780000000,"South Bend-Mishawaka, IN-MI Metropolitan Statistical Area, MI part",0,T,3969
+K,IM2720260000000,"Duluth, MN-WI Metropolitan Statistical Area, MN part",0,T,4138
+K,IM2722020000000,"Fargo, ND-MN Metropolitan Statistical Area, MN part",0,T,4139
+K,IM2724220000000,"Grand Forks, ND-MN Metropolitan Statistical Area, MN part",0,T,4140
+K,IM2729100000000,"La Crosse-Onalaska, WI-MN Metropolitan Statistical Area, MN part",0,T,4141
+K,IM2733460000000,"Minneapolis-St. Paul-Bloomington, MN-WI Metropolitan Statistical Area, MN part",0,T,4142
+K,IM2747420000000,"Wahpeton, ND-MN Micropolitan Statistical Area, MN part",0,T,4143
+K,IM2832820000000,"Memphis, TN-MS-AR Metropolitan Statistical Area, MS part",0,T,4276
+K,IM2835020000000,"Natchez, MS-LA Micropolitan Statistical Area, MS part",0,T,4277
+K,IM2916020000000,"Cape Girardeau, MO-IL Metropolitan Statistical Area, MO part",0,T,4462
+K,IM2922220000000,"Fayetteville-Springdale-Rogers, AR-MO Metropolitan Statistical Area, MO part",0,T,4463
+K,IM2922800000000,"Fort Madison-Keokuk, IA-IL-MO Micropolitan Statistical Area, MO part",0,T,4464
+K,IM2928140000000,"Kansas City, MO-KS Metropolitan Statistical Area, MO part",0,T,4465
+K,IM2939500000000,"Quincy, IL-MO Micropolitan Statistical Area, MO part",0,T,4466
+K,IM2941140000000,"St. Joseph, MO-KS Metropolitan Statistical Area, MO part",0,T,4467
+K,IM2941180000000,"St. Louis, MO-IL Metropolitan Statistical Area, MO part",0,T,4468
+K,IM3136540000000,"Omaha-Council Bluffs, NE-IA Metropolitan Statistical Area, NE part",0,T,4658
+K,IM3143580000000,"Sioux City, IA-NE-SD Metropolitan Statistical Area, NE part",0,T,4659
+K,IM3373050000000,"Dover-Durham, NH-ME Metropolitan NECTA, NH part",0,T,4976
+K,IM3374350000000,"Lebanon, NH-VT Micropolitan NECTA, NH part",0,T,4977
+K,IM3376900000000,"Portsmouth, NH-ME Metropolitan NECTA, NH part",0,T,4978
+K,IM3410900000000,"Allentown-Bethlehem-Easton, PA-NJ Metropolitan Statistical Area, NJ part",0,T,5120
+K,IM3716740000000,"Charlotte-Concord-Gastonia, NC-SC Metropolitan Statistical Area, NC part",0,T,5612
+K,IM3734820000000,"Myrtle Beach-Conway-North Myrtle Beach, SC-NC Metropolitan Statistical Area, NC part",0,T,5613
+K,IM3747260000000,"Virginia Beach-Norfolk-Newport News, VA-NC Metropolitan Statistical Area, NC part",0,T,5614
+K,IM3822020000000,"Fargo, ND-MN Metropolitan Statistical Area, ND part",0,T,5685
+K,IM3824220000000,"Grand Forks, ND-MN Metropolitan Statistical Area, ND part",0,T,5686
+K,IM3847420000000,"Wahpeton, ND-MN Micropolitan Statistical Area, ND part",0,T,5687
+K,IM3917140000000,"Cincinnati, OH-KY-IN Metropolitan Statistical Area, OH part",0,T,5917
+K,IM3926580000000,"Huntington-Ashland, WV-KY-OH Metropolitan Statistical Area, OH part",0,T,5918
+K,IM3938580000000,"Point Pleasant, WV-OH Micropolitan Statistical Area, OH part",0,T,5919
+K,IM3948260000000,"Weirton-Steubenville, WV-OH Metropolitan Statistical Area, OH part",0,T,5920
+K,IM3948540000000,"Wheeling, WV-OH Metropolitan Statistical Area, OH part",0,T,5921
+K,IM3949660000000,"Youngstown-Warren-Boardman, OH-PA Metropolitan Statistical Area, OH part",0,T,5922
+K,IM4022900000000,"Fort Smith, AR-OK Metropolitan Statistical Area, OK part",0,T,6058
+K,IM4136620000000,"Ontario, OR-ID Micropolitan Statistical Area, OR part",0,T,6157
+K,IM4138900000000,"Portland-Vancouver-Hillsboro, OR-WA Metropolitan Statistical Area, OR part",0,T,6158
+K,IM4210900000000,"Allentown-Bethlehem-Easton, PA-NJ Metropolitan Statistical Area, PA part",0,T,6348
+K,IM4249660000000,"Youngstown-Warren-Boardman, OH-PA Metropolitan Statistical Area, PA part",0,T,6349
+K,IM4476450000000,"Norwich-New London-Westerly, CT-RI Metropolitan NECTA, RI part",0,T,6396
+K,IM4477200000000,"Providence-Warwick, RI-MA Metropolitan NECTA, RI part",0,T,6397
+K,IM4512260000000,"Augusta-Richmond County, GA-SC Metropolitan Statistical Area, SC part",0,T,6495
+K,IM4516740000000,"Charlotte-Concord-Gastonia, NC-SC Metropolitan Statistical Area, SC part",0,T,6496
+K,IM4534820000000,"Myrtle Beach-Conway-North Myrtle Beach, SC-NC Metropolitan Statistical Area, SC part",0,T,6497
+K,IM4643580000000,"Sioux City, IA-NE-SD Metropolitan Statistical Area, SD part",0,T,6583
+K,IM4716860000000,"Chattanooga, TN-GA Metropolitan Statistical Area, TN part",0,T,6751
+K,IM4717300000000,"Clarksville, TN-KY Metropolitan Statistical Area, TN part",0,T,6752
+K,IM4728700000000,"Kingsport-Bristol-Bristol, TN-VA Metropolitan Statistical Area, TN part",0,T,6753
+K,IM4732820000000,"Memphis, TN-MS-AR Metropolitan Statistical Area, TN part",0,T,6754
+K,IM4746460000000,"Union City, TN-KY Micropolitan Statistical Area, TN part",0,T,6755
+K,IM4845500000000,"Texarkana, TX-AR Metropolitan Statistical Area, TX part",0,T,7309
+K,IM4930860000000,"Logan, UT-ID Metropolitan Statistical Area, UT part",0,T,7392
+K,IM5074350000000,"Lebanon, NH-VT Micropolitan NECTA, VT part",0,T,7675
+K,IM5076150000000,"North Adams, MA-VT Micropolitan NECTA, VT part",0,T,7676
+K,IM5114140000000,"Bluefield, WV-VA Micropolitan Statistical Area, VA part",0,T,7875
+K,IM5128700000000,"Kingsport-Bristol-Bristol, TN-VA Metropolitan Statistical Area, VA part",0,T,7876
+K,IM5147260000000,"Virginia Beach-Norfolk-Newport News, VA-NC Metropolitan Statistical Area, VA part",0,T,7877
+K,IM5149020000000,"Winchester, VA-WV Metropolitan Statistical Area, VA part",0,T,7878
+K,IM5330300000000,"Lewiston, ID-WA Metropolitan Statistical Area, WA part",0,T,7995
+K,IM5338900000000,"Portland-Vancouver-Hillsboro, OR-WA Metropolitan Statistical Area, WA part",0,T,7996
+K,IM5414140000000,"Bluefield, WV-VA Micropolitan Statistical Area, WV part",0,T,8078
+K,IM5419060000000,"Cumberland, MD-WV Metropolitan Statistical Area, WV part",0,T,8079
+K,IM5425180000000,"Hagerstown-Martinsburg, MD-WV Metropolitan Statistical Area, WV part",0,T,8080
+K,IM5426580000000,"Huntington-Ashland, WV-KY-OH Metropolitan Statistical Area, WV part",0,T,8081
+K,IM5438580000000,"Point Pleasant, WV-OH Micropolitan Statistical Area, WV part",0,T,8082
+K,IM5448260000000,"Weirton-Steubenville, WV-OH Metropolitan Statistical Area, WV part",0,T,8083
+K,IM5448540000000,"Wheeling, WV-OH Metropolitan Statistical Area, WV part",0,T,8084
+K,IM5449020000000,"Winchester, VA-WV Metropolitan Statistical Area, WV part",0,T,8085
+K,IM5520260000000,"Duluth, MN-WI Metropolitan Statistical Area, WI part",0,T,8231
+K,IM5527020000000,"Iron Mountain, MI-WI Micropolitan Statistical Area, WI part",0,T,8232
+K,IM5529100000000,"La Crosse-Onalaska, WI-MN Metropolitan Statistical Area, WI part",0,T,8233
+K,IM5531940000000,"Marinette, WI-MI Micropolitan Statistical Area, WI part",0,T,8234
+K,IM5533460000000,"Minneapolis-St. Paul-Bloomington, MN-WI Metropolitan Statistical Area, WI part",0,T,8235
+K,IM5627220000000,"Jackson, WY-ID Micropolitan Statistical Area, WY part",0,T,8274
+K,IS2380740000000,"Conway, NH-ME LMA, ME part",0,T,3301
+K,IS2681060000000,"Gogebic-Iron, MI-WI LMA, MI part",0,T,3970
+K,IS3380420000000,"Brattleboro, VT-NH LMA, NH part",0,T,4979
+K,IS3380700000000,"Colebrook, NH-VT LMA, NH part",0,T,4980
+K,IS3380740000000,"Conway, NH-ME LMA, NH part",0,T,4981
+K,IS3381620000000,"Littleton, NH-VT LMA, NH part",0,T,4982
+K,IS5080420000000,"Brattleboro, VT-NH LMA, VT part",0,T,7677
+K,IS5080700000000,"Colebrook, NH-VT LMA, VT part",0,T,7678
+K,IS5081620000000,"Littleton, NH-VT LMA, VT part",0,T,7679
+K,IS5581060000000,"Gogebic-Iron, MI-WI LMA, WI part",0,T,8236
+L,BS0600000000000,"Balance of California, state less Los Angeles-Long Beach-Glendale MD",0,T,771
+L,BS1200000000000,"Balance of Florida, state less Miami-Miami Beach-Kendall MD",0,T,1330
+L,BS1700000000000,"Balance of Illinois, state less Chicago-Naperville-Arlington Heights MD",0,T,1960
+L,BS2600000000000,"Balance of Michigan, state less Detroit-Warren-Dearborn MSA",0,T,3971
+L,BS3600000000000,"Balance of New York, state less New York city",0,T,5392
+L,BS3900000000000,"Balance of Ohio, state less Cleveland-Elyria MSA",0,T,5923
+L,BS5300000000000,"Balance of Washington, state less Seattle-Bellevue-Everett MD",0,T,7997
+M,RD9100000000000,Northeast region,0,T,8369
+M,RD9200000000000,Midwest region,0,T,8370
+M,RD9300000000000,South region,0,T,8371
+M,RD9400000000000,West region,0,T,8372
+N,RD8100000000000,New England division,0,T,8373
+N,RD8200000000000,Middle Atlantic division,0,T,8374
+N,RD8300000000000,East North Central division,0,T,8375
+N,RD8400000000000,West North Central division,0,T,8376
+N,RD8500000000000,South Atlantic division,0,T,8377
+N,RD8600000000000,East South Central division,0,T,8378
+N,RD8700000000000,West South Central division,0,T,8379
+N,RD8800000000000,Mountain division,0,T,8380
+N,RD8900000000000,Pacific division,0,T,8381


### PR DESCRIPTION
The file contains Series ID (derived from geoid) for City, States and Counties available on the [U.S. Bureau of Labor Statistics](https://www.bls.gov/) website used to fetch Unemployment data 